### PR TITLE
Fix a bug in the auth filter

### DIFF
--- a/src/main/java/de/terrestris/shogun/security/ShogunAuthProcessingFilter.java
+++ b/src/main/java/de/terrestris/shogun/security/ShogunAuthProcessingFilter.java
@@ -109,8 +109,8 @@ public class ShogunAuthProcessingFilter extends UsernamePasswordAuthenticationFi
         } catch (IOException e) {
             throw e;
         } finally {
-            IOUtils.closeQuietly(out);
             IOUtils.closeQuietly(jsonGenerator);
+            IOUtils.closeQuietly(out);
         }
     }
 

--- a/src/main/java/de/terrestris/shogun/security/ShogunAuthProcessingFilter.java
+++ b/src/main/java/de/terrestris/shogun/security/ShogunAuthProcessingFilter.java
@@ -89,6 +89,9 @@ public class ShogunAuthProcessingFilter extends UsernamePasswordAuthenticationFi
         });
         super.successfulAuthentication(request, response, authResult);
 
+        // set content type
+        response.setContentType("application/json;charset=UTF-8");
+
         // build a comma separated string of the ROLES
         String authorityText = StringUtils.join(authResult.getAuthorities(), ",");
 


### PR DESCRIPTION
The jsonGenerator has to be closed before the writer object. Otherwise no JSON will be returned when logging in.

The change will also set the content type of the login response to avoid a console error in Internet Explorer.