### PR TITLE
Fix error in initialize-beans.xml

### DIFF
--- a/src/main/webapp/WEB-INF/spring/initialize-beans.xml
+++ b/src/main/webapp/WEB-INF/spring/initialize-beans.xml
@@ -140,7 +140,7 @@
 
 		<property name="mapConfigs">
 			<list>
-				<ref local="stdMapConfig" />
+				<ref bean="stdMapConfig" />
 			</list>
 		</property>
 


### PR DESCRIPTION
This PR fixes an error in the `initialize-beans.xml`.

The attribute of `ref` element must be `bean` (see [Spring reference](http://docs.spring.io/spring/docs/4.0.x/spring-framework-reference/html/xsd-config.html)), not `local`.