### PR TITLE
Migration to Hibernate 4 and corresponding Hibernate spatial version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,8 @@
 
 		<!-- Hibernate -->
 		<hibernate.version>3.6.10.Final</hibernate.version>
+		<hibernate-spatial.version>1.0</hibernate-spatial.version>
+		<c3p0.version>0.9.2.1</c3p0.version>
 
 	</properties>
 
@@ -121,14 +123,14 @@
 		<dependency>
 			<groupId>org.hibernatespatial</groupId>
 			<artifactId>hibernate-spatial-postgis</artifactId>
-			<version>1.0</version>
+			<version>${hibernate-spatial.version}</version>
 		</dependency>
 
 		<!-- c3p0 JDBC Connection Pooling -->
 		<dependency>
 			<groupId>com.mchange</groupId>
 			<artifactId>c3p0</artifactId>
-			<version>0.9.2.1</version>
+			<version>${c3p0.version}</version>
 		</dependency>
 
 		<!-- H2 database -->

--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,9 @@
 		<spring.version>4.2.3.RELEASE</spring.version>
 		<spring-security.version>4.0.3.RELEASE</spring-security.version>
 
-		<!-- Hibernate -->
-		<hibernate.version>3.6.10.Final</hibernate.version>
-		<hibernate-spatial.version>1.0</hibernate-spatial.version>
+		<!-- Hibernate / Persistance -->
+		<hibernate.version>4.3.11.Final</hibernate.version>
+		<hibernate-spatial.version>4.3</hibernate-spatial.version>
 		<c3p0.version>0.9.2.1</c3p0.version>
 
 	</properties>
@@ -121,8 +121,8 @@
 
 		<!-- Hibernate Spatial -->
 		<dependency>
-			<groupId>org.hibernatespatial</groupId>
-			<artifactId>hibernate-spatial-postgis</artifactId>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-spatial</artifactId>
 			<version>${hibernate-spatial.version}</version>
 		</dependency>
 

--- a/src/main/java/de/terrestris/shogun/dao/DatabaseDao.java
+++ b/src/main/java/de/terrestris/shogun/dao/DatabaseDao.java
@@ -60,12 +60,6 @@ import org.hibernate.criterion.Disjunction;
 import org.hibernate.criterion.ProjectionList;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
-import org.hibernate.engine.SessionFactoryImplementor;
-import org.hibernate.impl.CriteriaImpl;
-import org.hibernate.impl.SessionImpl;
-import org.hibernate.loader.OuterJoinLoader;
-import org.hibernate.loader.criteria.CriteriaLoader;
-import org.hibernate.persister.entity.OuterJoinLoadable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -1689,31 +1683,6 @@ public class DatabaseDao {
 		// get the logged-in user and check if he has the SuperAdmin role
 		User sessionUser = this.getUserObjectFromSession();
 		return sessionUser.hasSuperAdminRole();
-	}
-
-	/**
-	 * Helper function to print out the SQL from a criteria object
-	 *
-	 * @param criteria
-	 * @return
-	 */
-	private String toSql(Criteria criteria) {
-		try {
-			CriteriaImpl c = (CriteriaImpl) criteria;
-			SessionImpl s = (SessionImpl) c.getSession();
-			SessionFactoryImplementor factory = (SessionFactoryImplementor) s.getSessionFactory();
-			String[] implementors = factory.getImplementors(c.getEntityOrClassName());
-
-			CriteriaLoader loader = new CriteriaLoader(
-					(OuterJoinLoadable) factory
-							.getEntityPersister(implementors[0]),
-					factory, c, implementors[0], s.getLoadQueryInfluencers());
-			Field f = OuterJoinLoader.class.getDeclaredField("sql");
-			f.setAccessible(true);
-			return (String) f.get(loader);
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
 	}
 
 	/**

--- a/src/main/java/de/terrestris/shogun/hibernatecriteria/filter/HibernateFilterItem.java
+++ b/src/main/java/de/terrestris/shogun/hibernatecriteria/filter/HibernateFilterItem.java
@@ -45,7 +45,7 @@ import org.hibernate.criterion.Conjunction;
 import org.hibernate.criterion.Criterion;
 import org.hibernate.criterion.Disjunction;
 import org.hibernate.criterion.Restrictions;
-import org.hibernatespatial.criterion.SpatialRestrictions;
+import org.hibernate.spatial.criterion.SpatialRestrictions;
 
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.io.WKTReader;

--- a/src/main/java/de/terrestris/shogun/service/ShogunService.java
+++ b/src/main/java/de/terrestris/shogun/service/ShogunService.java
@@ -53,7 +53,7 @@ import java.util.Set;
 import javax.persistence.ManyToMany;
 
 import org.apache.log4j.Logger;
-import org.hibernate.collection.PersistentSet;
+import org.hibernate.collection.internal.PersistentSet;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -226,7 +226,7 @@ public class ShogunService extends AbstractShogunService {
 				// dynamic invoking of the getter
 				// receive all left objects that are associated to the current right object
 				// e.g. all MapLayers of a User
-				PersistentSet currentAssocedUsersMapLayers = (PersistentSet)rightGetter.invoke(currentAssocedUser);
+				PersistentSet currentAssocedUsersMapLayers = (PersistentSet) rightGetter.invoke(currentAssocedUser);
 
 				/*
 				 * http://www.java-forums.org/new-java/20849-how-can-i-avoid-java-util-concurrentmodificationexception-exception.html

--- a/src/main/webapp/WEB-INF/spring/db-config.xml
+++ b/src/main/webapp/WEB-INF/spring/db-config.xml
@@ -76,7 +76,7 @@
 
 	<!-- Hibernate SessionFactory -->
 	<bean id="sessionFactory"
-		class="org.springframework.orm.hibernate3.annotation.AnnotationSessionFactoryBean">
+		class="org.springframework.orm.hibernate4.LocalSessionFactoryBean">
 		<property name="dataSource" ref="dataSource" />
 		<property name="packagesToScan" ref="dbEntitiesPackages" />
 
@@ -97,7 +97,7 @@
 	<tx:annotation-driven transaction-manager="transactionManager" />
 
 	<bean id="transactionManager"
-		class="org.springframework.orm.hibernate3.HibernateTransactionManager">
+		class="org.springframework.orm.hibernate4.HibernateTransactionManager">
 		<property name="sessionFactory" ref="sessionFactory" />
 	</bean>
 


### PR DESCRIPTION
In this PR, SHOGun will be migrated from Hibernate `3.6.10.Final` to the lastest stable of Hibernate 4 (`4.3.11.Final`).
Beside the changes described in [migration guide](https://access.redhat.com/documentation/en-US/JBoss_Enterprise_Application_Platform/6/html/Migration_Guide/Migrate_Your_Hibernate_3.5.x_Application_to_Hibernate_4.x.html), unused methods have been removed.

Following scenarios with different db types were tested:
* **H2 database**:
  * create new DB (`hibernate.hbm2ddl=create`, `databaseInitializationEnabled=true`)
  * use SHOGun-DB created before (`hibernate.hbm2ddl=none`, `databaseInitializationEnabled=false`)
  * update models in SHOGun-DB (`hibernate.hbm2ddl=update`, `databaseInitializationEnabled=false`)
  * use SHOGun-DB, created with Hibernate 3 (`hibernate.hbm2ddl=none`, `databaseInitializationEnabled=false`)
* **PostgreSQL database**:
  * create new DB (`hibernate.hbm2ddl=create`, `databaseInitializationEnabled=true`)
  * use SHOGun-DB created before (`hibernate.hbm2ddl=none`, `databaseInitializationEnabled=false`)
  * update models in SHOGun-DB (`hibernate.hbm2ddl=update`, `databaseInitializationEnabled=false`)
  * use SHOGun-DB,  created with Hibernate 3 (`hibernate.hbm2ddl=none`, `databaseInitializationEnabled=false`)
* **Oracle 11g database** (used in project of terrestris):
  * use SHOGun-DB,  created with Hibernate 3 (`hibernate.hbm2ddl=none`, `databaseInitializationEnabled=false`)

Please review.