### PR TITLE
Publish artifacts on nexus

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,39 @@
+name: Build and publish SHOGun
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2.0.0
+
+    - name: Set up Java 11
+      uses: actions/setup-java@v1.3.0
+      with:
+        java-version: 11.0.6
+        java-package: jdk
+        architecture: x64
+
+    - name: Handle caching of maven repository
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
+    - name: Create maven settings.xml with credentials
+      uses: whelk-io/maven-settings-xml-action@v2
+      with:
+        servers: '[{ "id": "terrestris-nexus", "username": "${{ secrets.NEXUS_USER }}", "password": "${{ secrets.NEXUS_PASSWORD }}" },
+                   { "id": "terrestris-nexus-snapshots", "username": "${{ secrets.NEXUS_USER }}", "password": "${{ secrets.NEXUS_PASSWORD }}" }]'
+
+    - name: Build SHOGun with Maven and publish artifacts to nexus
+      run: mvn -B deploy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test SHOGun
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2.0.0
+
+    - name: Set up Java 11
+      uses: actions/setup-java@v1.3.0
+      with:
+        java-version: 11.0.6
+        java-package: jdk
+        architecture: x64
+
+    - name: Handle caching of maven repository
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
+    - name: Test SHOGun with Maven
+      run: mvn -B test

--- a/pom.xml
+++ b/pom.xml
@@ -35,12 +35,12 @@
   <!-- TODO pluginRepository -->
   <distributionManagement>
     <repository>
-      <id>nexus.terrestris.de-releases-shogun</id>
+      <id>terrestris-nexus</id>
       <name>Nexus Release Repository</name>
       <url>https://nexus.terrestris.de/repository/SHOGun/</url>
     </repository>
     <snapshotRepository>
-      <id>nexus.terrestris.de-snapshots-shogun</id>
+      <id>terrestris-nexus-snapshots</id>
       <name>Nexus Snapshot Repository</name>
       <url>https://nexus.terrestris.de/repository/SHOGun/</url>
     </snapshotRepository>
@@ -62,6 +62,7 @@
     <surefire-plugin.version>3.0.0-M4</surefire-plugin.version>
     <jacoco-plugin.version>0.8.5</jacoco-plugin.version>
     <project-info-reports-plugin.version>3.0.0</project-info-reports-plugin.version>
+    <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
 
     <!-- Javax -->
     <javax.servlet.api.version>4.0.1</javax.servlet.api.version>
@@ -168,8 +169,20 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>${maven-deploy-plugin.version}</version>
+        </plugin>
       </plugins>
     </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+      </plugin>
+    </plugins>
   </build>
 
   <profiles>


### PR DESCRIPTION
Introduced github actions for two scenarios:

1. Test the project in the context of a pull request
2. Publish artifacts on terrestris nexus when something has been merged/commited on the master branch

Maven artifacts are cached, so building and testing is really quick now!

Publishing on nexus seems to work fine when using the classic way with `mvn deploy`. The for the hint @hwbllmnn 

Please review @terrestris/devs 