### PR TITLE
Introduces Geometry scalar for GraphQL

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/graphql/GraphQLProvider.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/graphql/GraphQLProvider.java
@@ -1,6 +1,7 @@
 package de.terrestris.shoguncore.graphql;
 
 import com.google.common.io.Resources;
+import de.terrestris.shoguncore.graphql.scalar.GeometryScalar;
 import graphql.GraphQL;
 import graphql.scalars.ExtendedScalars;
 import graphql.schema.GraphQLScalarType;
@@ -76,6 +77,7 @@ public class GraphQLProvider {
     protected List<GraphQLScalarType> gatherScalars() {
         List<GraphQLScalarType> scalars = new ArrayList<>();
         scalars.add(ExtendedScalars.Json);
+        scalars.add(GeometryScalar.GEOMETRY);
         return scalars;
     }
 

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/graphql/scalar/GeometryScalar.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/graphql/scalar/GeometryScalar.java
@@ -26,7 +26,7 @@ public class GeometryScalar {
 
         @Override
         public Object parseValue(Object input) {
-            return parseGeoemtryFromVariable(input);
+            return parseGeometryFromVariable(input);
         }
 
         @Override
@@ -47,14 +47,14 @@ public class GeometryScalar {
             } catch (JsonProcessingException e) {
                 LOG.error("JSON Processing error while writing geometry for GraphQL");
                 LOG.trace("Full stack trace: ", e);
+                throw new CoercingSerializeException(e.getMessage());
             }
         } else {
             throw new CoercingSerializeException("Unable to serialize " + dataFetcherResult + " as a geometry");
         }
-        return null;
     }
 
-    private static Object parseGeoemtryFromVariable(Object input) {
+    private static Object parseGeometryFromVariable(Object input) {
         if (input instanceof String) {
             String geometryString = (String)input;
             try {

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/graphql/scalar/GeometryScalar.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/graphql/scalar/GeometryScalar.java
@@ -1,0 +1,80 @@
+package de.terrestris.shoguncore.graphql.scalar;
+
+import com.bedatadriven.jackson.datatype.jts.JtsModule;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import graphql.language.StringValue;
+import graphql.schema.*;
+import org.locationtech.jts.geom.Geometry;
+
+import java.util.HashMap;
+
+public class GeometryScalar {
+
+    public static final GraphQLScalarType GEOMETRY = new GraphQLScalarType("Geometry", "A custom scalar that handles geometries", new Coercing() {
+        @Override
+        public Object serialize(Object dataFetcherResult) {
+            return serializeGeometry(dataFetcherResult);
+        }
+
+        @Override
+        public Object parseValue(Object input) {
+            return parseGeoemtryFromVariable(input);
+        }
+
+        @Override
+        public Object parseLiteral(Object input) {
+            return parseGeometryFromAstLiteral(input);
+        }
+    });
+
+    private static boolean isAGeometry(Object possibleGeometryValue) {
+        return possibleGeometryValue instanceof Geometry;
+    }
+
+    private static Object serializeGeometry(Object dataFetcherResult) {
+        if (isAGeometry(dataFetcherResult)) {
+            Geometry geometry = (Geometry) dataFetcherResult;
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.registerModule(new JtsModule());
+            try {
+                return mapper.readValue(mapper.writeValueAsString(geometry), HashMap.class);
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+            }
+        } else {
+            throw new CoercingSerializeException("Unable to serialize " + dataFetcherResult + " as a geometry");
+        }
+        return null;
+    }
+
+    private static Object parseGeoemtryFromVariable(Object input) {
+        if (input instanceof String) {
+            String geometryString = (String)input;
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.registerModule(new JtsModule());
+            try {
+                return mapper.readValue(geometryString, HashMap.class);
+            } catch (JsonProcessingException e) {
+                throw new CoercingParseValueException("Unable to parse variable value " + input + " as a geometry");
+            }
+        }
+        throw new CoercingParseValueException("Unable to parse variable value " + input + " as a geometry");
+    }
+
+    private static Object parseGeometryFromAstLiteral(Object input) {
+        if (input instanceof StringValue) {
+            String geometryString = ((StringValue) input).getValue();;
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.registerModule(new JtsModule());
+            try {
+                return mapper.readValue(geometryString, HashMap.class);
+            } catch (JsonProcessingException e) {
+                throw new CoercingParseValueException("Unable to parse value " + input + " as a geometry");
+            }
+        }
+        throw new CoercingParseLiteralException(
+            "Value is not an geometry"
+        );
+    }
+}

--- a/shogun-lib/src/main/resources/graphql/shogun.graphqls
+++ b/shogun-lib/src/main/resources/graphql/shogun.graphqls
@@ -1,4 +1,5 @@
 scalar JSON
+scalar Geometry
 
 type Query {
     applicationById(id: ID): Application


### PR DESCRIPTION
This introduces the [custom scalar type](https://www.graphql-java.com/documentation/v12/scalars/) `Geometry`. This way we can use `Geometry` in the GraphQL schema instead of `String`.
So geometries can now be fetched as GeoJSON instead of WKT.