### PR TITLE
Removes ComponentScan from BootWebSecurityConfig

### DIFF
--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootWebSecurityConfig.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootWebSecurityConfig.java
@@ -9,7 +9,6 @@ import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
 @Configuration
 @EnableWebSecurity
-@ComponentScan(basePackages = { "de.terrestris.shogun.boot", "de.terrestris.shogun.lib" })
 public class BootWebSecurityConfig extends WebSecurityConfig {
 
 //    @Autowired


### PR DESCRIPTION
This removes the `ComponetScan` from the `BootWebSecurityConfig.java` as the scanned pathes are already covered by the `ComponentScan` from the `ApplicationConfig.java`.