### PR TITLE
Removes allowing of bean overriding

### DIFF
--- a/shogun-config/src/main/resources/application-base.yml
+++ b/shogun-config/src/main/resources/application-base.yml
@@ -12,7 +12,6 @@ server:
 spring:
   main:
     banner-mode: off
-    allow-bean-definition-overriding: true
   jpa:
     database-platform: org.hibernate.spatial.dialect.postgis.PostgisPG95Dialect
     hibernate:


### PR DESCRIPTION
This removes the `allow-bean-definition-overriding` flag from the application-base.yml. This is more or less a followup of #23 .