### PR TITLE
Fix scan packages

### DIFF
--- a/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/config/InterceptorApplicationConfig.java
+++ b/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/config/InterceptorApplicationConfig.java
@@ -11,9 +11,9 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
-@EnableJpaRepositories(basePackages = {"de.terrestris.shogun.interceptor", "${scan.package}"})
-@ComponentScan(basePackages = {"de.terrestris.shogun.interceptor", "${scan.package}"})
-@EntityScan(basePackages = {"de.terrestris.shogun.interceptor", "${scan.package}"})
+@EnableJpaRepositories(basePackages = {"de.terrestris.shogun", "${scan.package}"})
+@ComponentScan(basePackages = {"de.terrestris.shogun", "${scan.package}"})
+@EntityScan(basePackages = {"de.terrestris.shogun", "${scan.package}"})
 @EnableConfigurationProperties({
     InterceptorProperties.class,
     NamespaceProperties.class,


### PR DESCRIPTION
Fixes the Spring scan packages to include all of SHOGun in order to get access to e.g. the `SecurityContextUtil` in derived applications.

@terrestris/devs Please review.