### PR TITLE
Adds JsonIdentityInfo to BaseEntity

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/BaseEntity.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/BaseEntity.java
@@ -1,5 +1,7 @@
 package de.terrestris.shogun.lib.model;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -19,6 +21,7 @@ import java.util.Date;
 @AllArgsConstructor
 @ToString
 @EqualsAndHashCode
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 public abstract class BaseEntity implements Serializable {
 
     // TODO Replace with @GeneratedValue(strategy = GenerationType.IDENTITY) and remove hibernate_sequence from flyway migrations


### PR DESCRIPTION
This adds `@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")` to the BaseEntity to allow (de)serialization of circular references.
Compare: https://www.logicbig.com/tutorials/misc/jackson/json-identity-info-annotation.html