### PR TITLE
Removes duplicated componentscan

### DIFF
--- a/shogun-boot/src/main/java/de/terrestris/shogunboot/config/WebSecurityConfig.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogunboot/config/WebSecurityConfig.java
@@ -13,7 +13,6 @@ import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
 @Configuration
 @EnableWebSecurity
-@ComponentScan(basePackages = { "de.terrestris.shogunboot", "de.terrestris.shoguncore" })
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Autowired


### PR DESCRIPTION
This removes the doubled componete scan for SHOGun v3. Compare #23 .