### PR TITLE
Make precision model and SRID of GeometryFactory configurable

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/config/JacksonConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/config/JacksonConfig.java
@@ -3,16 +3,22 @@ package de.terrestris.shogun.lib.config;
 import com.bedatadriven.jackson.datatype.jts.JtsModule;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class JacksonConfig {
 
+    @Value("${shogun.srid:4326}")
+    protected int srid;
+
+    @Value("${shogun.coordinatePrecisionScale:10}")
+    protected int coordinatePrecisionScale;
+
     @Bean
     public JtsModule jtsModule() {
-        GeometryFactory geomFactory = new GeometryFactory(new PrecisionModel(10), 4326);
-
+        GeometryFactory geomFactory = new GeometryFactory(new PrecisionModel(coordinatePrecisionScale), srid);
         return new JtsModule(geomFactory);
     }
 


### PR DESCRIPTION
In particular, this is needed if geometries sent to SHOGun have a coordinate system that is not WGS84. By default, `EPSG:4326` and a scale of 10 is used as before. To overwrite this, simply add (f.e.)
```
shogun:
  srid: 25832
  coordinatePrecisionScale: 6
```
to the `application.yml` of your project.

Plz review @terrestris/devs 