### PR TITLE
Introduce GeoServer importer module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,8 +95,11 @@
     <okhttp.version>4.3.1</okhttp.version>
     <commons.io.version>2.6</commons.io.version>
     <commons.lang3.version>3.9</commons.lang3.version>
+    <commons.fileupload.version>1.4</commons.fileupload.version>
     <threetenbp.version>1.4.1</threetenbp.version>
     <com.sun.mail.version>1.6.2</com.sun.mail.version>
+    <zip4j.version>2.5.1</zip4j.version>
+    <opencsv.version>4.6</opencsv.version>
 
     <!-- Testing -->
     <junit.version>4.13</junit.version>
@@ -125,6 +128,7 @@
 
     <!-- GeoServer/Geodata -->
     <geoserver-manager.version>1.7.0</geoserver-manager.version>
+    <geotools.version>22.3</geotools.version>
     <jts.version>1.16.1</jts.version>
 
   </properties>
@@ -434,6 +438,11 @@
         <artifactId>commons-lang3</artifactId>
         <version>${commons.lang3.version}</version>
       </dependency>
+      <dependency>
+        <groupId>commons-fileupload</groupId>
+        <artifactId>commons-fileupload</artifactId>
+        <version>${commons.fileupload.version}</version>
+      </dependency>
 
       <!-- Testing -->
       <dependency>
@@ -552,6 +561,11 @@
         <artifactId>threetenbp</artifactId>
         <version>${threetenbp.version}</version>
       </dependency>
+      <dependency>
+        <groupId>net.lingala.zip4j</groupId>
+        <artifactId>zip4j</artifactId>
+        <version>${zip4j.version}</version>
+      </dependency>
 
       <dependency>
         <groupId>javax.annotation</groupId>
@@ -592,6 +606,34 @@
         <groupId>it.geosolutions</groupId>
         <artifactId>geoserver-manager</artifactId>
         <version>${geoserver-manager.version}</version>
+      </dependency>
+
+      <!-- GeoTools -->
+      <dependency>
+        <groupId>org.geotools</groupId>
+        <artifactId>gt-main</artifactId>
+        <version>${geotools.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geotools</groupId>
+        <artifactId>gt-shapefile</artifactId>
+        <version>${geotools.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geotools</groupId>
+        <artifactId>gt-wfs-ng</artifactId>
+        <version>${geotools.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.geotools</groupId>
+        <artifactId>gt-jdbc</artifactId>
+        <version>${geotools.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.opencsv</groupId>
+        <artifactId>opencsv</artifactId>
+        <version>${opencsv.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <module>shogun-lib</module>
     <module>shogun-boot</module>
     <module>shogun-gs-interceptor</module>
+    <module>shogun-gs-importer</module>
     <module>shogun-config</module>
   </modules>
 

--- a/shogun-gs-importer/pom.xml
+++ b/shogun-gs-importer/pom.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>de.terrestris</groupId>
+    <artifactId>shogun</artifactId>
+    <version>4.0.1-SNAPSHOT</version>
+  </parent>
+
+  <groupId>de.terrestris</groupId>
+  <artifactId>shogun-gs-importer</artifactId>
+  <name>SHOGun GeoServer Importer</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <!-- https://stackoverflow.com/questions/53609881/maven-multi-module-project-packaging-error -->
+    <spring-boot.repackage.skip>true</spring-boot.repackage.skip>
+  </properties>
+
+  <dependencies>
+    <!-- Spring Boot -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-log4j2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-thymeleaf</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-redis</artifactId>
+    </dependency>
+
+    <!-- Spring -->
+    <dependency>
+      <groupId>org.springframework.session</groupId>
+      <artifactId>spring-session-data-redis</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-redis</artifactId>
+    </dependency>
+
+    <!-- Lombok -->
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+    </dependency>
+
+    <!-- Swagger -->
+    <dependency>
+      <groupId>io.springfox</groupId>
+      <artifactId>springfox-swagger2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.springfox</groupId>
+      <artifactId>springfox-swagger-ui</artifactId>
+    </dependency>
+
+    <!-- GeoServer Manager-->
+    <dependency>
+      <groupId>it.geosolutions</groupId>
+      <artifactId>geoserver-manager</artifactId>
+    </dependency>
+
+    <!-- GeoTools -->
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-main</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-shapefile</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-wfs-ng</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-jdbc</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>net.lingala.zip4j</groupId>
+      <artifactId>zip4j</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.opencsv</groupId>
+      <artifactId>opencsv</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-spring-boot-starter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-fileupload</groupId>
+      <artifactId>commons-fileupload</artifactId>
+    </dependency>
+
+    <!-- SHOGun Lib -->
+    <dependency>
+      <groupId>de.terrestris</groupId>
+      <artifactId>shogun-lib</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- SHOGun Config -->
+    <dependency>
+      <groupId>de.terrestris</groupId>
+      <artifactId>shogun-config</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.8.2</version>
+        <extensions>true</extensions>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.hibernate.orm.tooling</groupId>
+        <artifactId>hibernate-enhance-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <configuration>
+              <failOnError>true</failOnError>
+              <enableLazyInitialization>true</enableLazyInitialization>
+            </configuration>
+            <goals>
+              <goal>enhance</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/GeoServerRESTImporter.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/GeoServerRESTImporter.java
@@ -1,0 +1,609 @@
+package de.terrestris.shogun.importer;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import de.terrestris.shogun.importer.dto.*;
+import de.terrestris.shogun.importer.exception.GeoServerRESTImporterException;
+import de.terrestris.shogun.lib.dto.HttpResponse;
+import de.terrestris.shogun.lib.util.HttpUtil;
+import lombok.extern.log4j.Log4j2;
+import net.lingala.zip4j.ZipFile;
+import net.lingala.zip4j.exception.ZipException;
+import net.lingala.zip4j.model.FileHeader;
+import net.lingala.zip4j.model.ZipParameters;
+import net.lingala.zip4j.model.enums.CompressionLevel;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpException;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ContentType;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.wkt.Formattable;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.springframework.http.HttpStatus;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+@Log4j2
+public class GeoServerRESTImporter {
+
+    private String username;
+
+    private String password;
+
+    private ObjectMapper mapper;
+
+    private URI baseUri;
+
+    public GeoServerRESTImporter() { }
+
+    /***
+     * Constructs a new importer with values set.
+     */
+    public GeoServerRESTImporter(URI importerBaseURL, String username,
+                                 String password) {
+        if (importerBaseURL == null || StringUtils.isEmpty(username) ||
+            StringUtils.isEmpty(password)) {
+            log.error("Missing Constructor arguments. Could not create " +
+                "the GeoServerRESTImporter.");
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.UNWRAP_ROOT_VALUE, true);
+        mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, true);
+        mapper.setSerializationInclusion(Include.NON_NULL);
+
+        this.username = username;
+        this.password = password;
+
+        this.mapper = mapper;
+        this.baseUri = importerBaseURL;
+    }
+
+    /**
+     * Add a projection file to a shapefile zip archive.
+     */
+    public static File addPrjFileToArchive(File file, String targetCrs)
+        throws ZipException, IOException, FactoryException {
+
+        ZipFile zipFile = new ZipFile(file);
+
+        CoordinateReferenceSystem decodedTargetCrs = CRS.decode(targetCrs);
+        String targetCrsWkt = toSingleLineWKT(decodedTargetCrs);
+
+        ArrayList<String> zipFileNames = new ArrayList<>();
+        List<FileHeader> zipFileHeaders = zipFile.getFileHeaders();
+
+        for (FileHeader zipFileHeader : zipFileHeaders) {
+            if (FilenameUtils.getExtension(zipFileHeader.getFileName()).equalsIgnoreCase("prj")) {
+                continue;
+            }
+            zipFileNames.add(FilenameUtils.getBaseName(zipFileHeader.getFileName()));
+        }
+
+        log.debug("Following files will be created and added to ZIP file: " + zipFileNames);
+
+        for (String prefix : zipFileNames) {
+            File targetPrj = null;
+            try {
+                targetPrj = File.createTempFile("TMP_" + prefix, ".prj");
+                FileUtils.write(targetPrj, targetCrsWkt, "UTF-8");
+                ZipParameters params = new ZipParameters();
+//                params.setSourceExternalStream(true);
+                params.setCompressionLevel(CompressionLevel.NORMAL);
+                params.setFileNameInZip(prefix + ".prj");
+                zipFile.addFile(targetPrj, params);
+            } finally {
+                if (targetPrj != null) {
+                    boolean deleted = targetPrj.delete();
+                    if (!deleted) {
+                        log.warn("Temporary target prj file could not be deleted.");
+                    }
+                }
+            }
+        }
+
+        return zipFile.getFile();
+    }
+
+    /**
+     * Turns the CRS into a single line WKT
+     *
+     * @param crs CoordinateReferenceSystem which should be formatted
+     * @return Single line String which can be written to PRJ file
+     */
+    public static String toSingleLineWKT(CoordinateReferenceSystem crs) {
+        String wkt = null;
+        try {
+            // this is a lenient transformation, works with polar stereographics too
+            Formattable formattable = (Formattable) crs;
+            wkt = formattable.toWKT(0, false);
+        } catch (ClassCastException e) {
+            wkt = crs.toWKT();
+        }
+
+        wkt = wkt.replaceAll("\n", "").replaceAll("  ", "");
+        return wkt;
+    }
+
+    /**
+     * Create a new import job.
+     */
+    public RESTImport createImportJob(String workSpaceName, String dataStoreName)
+        throws Exception {
+
+        if (StringUtils.isEmpty(workSpaceName)) {
+            throw new GeoServerRESTImporterException("No workspace given. Please provide a "
+                + "workspace to import the data in.");
+        }
+
+        RESTImport importJob = new RESTImport();
+
+        log.debug("Creating a new import job to import into workspace " + workSpaceName);
+
+        RESTTargetWorkspace targetWorkspace = new RESTTargetWorkspace(workSpaceName);
+        importJob.setTargetWorkspace(targetWorkspace);
+
+        if (!StringUtils.isEmpty(dataStoreName)) {
+            log.debug("The data will be imported into datastore " + dataStoreName);
+            RESTTargetDataStore targetDataStore = new RESTTargetDataStore(dataStoreName, null);
+            importJob.setTargetStore(targetDataStore);
+        } else {
+            log.debug("No datastore given. A new datastore will be created in relation to the"
+                + "input data.");
+        }
+
+        HttpResponse httpResponse = HttpUtil.post(
+            this.addEndPoint(""),
+            this.asJSON(importJob),
+            ContentType.APPLICATION_JSON,
+            this.username,
+            this.password,
+            false
+        );
+
+        HttpStatus responseStatus = httpResponse.getStatusCode();
+        if (responseStatus == null || !responseStatus.is2xxSuccessful()) {
+            throw new GeoServerRESTImporterException("Import job cannot be "
+                + "created. Error message from GeoServer is: " + new String(httpResponse.getBody()));
+        }
+
+        RESTImport restImport = (RESTImport) this.asEntity(httpResponse.getBody(), RESTImport.class);
+
+        log.debug("Successfully created the import job with ID " + restImport.getId());
+
+        return restImport;
+    }
+
+    /**
+     * Create a reprojection task.
+     */
+    public boolean createReprojectTransformTask(Integer importJobId, Integer taskId,
+                                                String sourceSrs, String targetSrs) throws URISyntaxException, HttpException {
+        RESTReprojectTransform transformTask = new RESTReprojectTransform();
+        if (StringUtils.isNotEmpty(sourceSrs)) {
+            transformTask.setSource(sourceSrs);
+        }
+        transformTask.setTarget(targetSrs);
+
+        return createTransformTask(importJobId, taskId, transformTask);
+    }
+
+    /**
+     * Create and append importer task for <code>gdaladdo</code>
+     */
+    public boolean createGdalAddOverviewTask(Integer importJobId, Integer importTaskId,
+                                             List<String> opts, List<Integer> levels) throws URISyntaxException, HttpException {
+        RESTGdalAddoTransform transformTask = new RESTGdalAddoTransform();
+        if (!opts.isEmpty()) {
+            transformTask.setOptions(opts);
+        }
+        if (!levels.isEmpty()) {
+            transformTask.setLevels(levels);
+        }
+        return this.createTransformTask(importJobId, importTaskId, transformTask);
+    }
+
+    /**
+     * Create and append importer task for <code>gdalwarp</code>
+     */
+    public boolean createGdalWarpTask(Integer importJobId, Integer importTaskId,
+                                      List<String> optsGdalWarp) throws URISyntaxException, HttpException {
+        RESTGdalWarpTransform transformTask = new RESTGdalWarpTransform();
+        if (!optsGdalWarp.isEmpty()) {
+            transformTask.setOptions(optsGdalWarp);
+        }
+        return this.createTransformTask(importJobId, importTaskId, transformTask);
+    }
+
+    /**
+     * Create and append importer task for <code>gdal_translate</code>
+     */
+    public boolean createGdalTranslateTask(Integer importJobId, Integer importTaskId,
+                                           List<String> optsGdalTranslate) throws URISyntaxException, HttpException {
+        RESTGdalTranslateTransform transformTask = new RESTGdalTranslateTransform();
+        if (!optsGdalTranslate.isEmpty()) {
+            transformTask.setOptions(optsGdalTranslate);
+        }
+        return this.createTransformTask(importJobId, importTaskId, transformTask);
+    }
+
+    /**
+     * Upload an import file.
+     */
+    public RESTImportTaskList uploadFile(Integer importJobId, File file, String sourceSrs) throws Exception {
+
+        log.debug("Uploading file " + file.getName() + " to import job " + importJobId);
+
+        HttpResponse httpResponse = HttpUtil.post(
+            this.addEndPoint(importJobId + "/tasks"),
+            file,
+            this.username,
+            this.password
+        );
+
+        HttpStatus responseStatus = httpResponse.getStatusCode();
+        if (responseStatus == null || !responseStatus.is2xxSuccessful()) {
+            throw new GeoServerRESTImporterException("Error while uploading the file.");
+        }
+
+        log.debug("Successfully uploaded the file to import job " + importJobId);
+
+        RESTImportTaskList importTaskList = null;
+        // check, if it is a list of import tasks (for multiple layers)
+        try {
+            importTaskList = mapper.readValue(httpResponse.getBody(), RESTImportTaskList.class);
+            log.debug("Imported file " + file.getName() + " contains data for multiple layers.");
+            return importTaskList;
+        } catch (IOException e) {
+            log.debug("Imported file " + file.getName() + " likely contains data for single " +
+                "layer. Will check this now.");
+            try {
+                RESTImportTask importTask = mapper.readValue(httpResponse.getBody(), RESTImportTask.class);
+                if (importTask != null) {
+                    importTaskList = new RESTImportTaskList();
+                    importTaskList.add(importTask);
+                    log.debug("Imported file " + file.getName() + " contains data for a single layer.");
+                }
+                return importTaskList;
+            } catch (IOException ex) {
+                log.info("It seems that the SRS definition source file can not be interpreted by " +
+                    "GeoServer / GeoTools. Try to set SRS definition to " + sourceSrs + ".");
+
+                File updatedGeoTiff = null;
+                try {
+                    if (!StringUtils.isEmpty(sourceSrs)) {
+                        // "First" recursion: try to add prj file to ZIP.
+                        updatedGeoTiff = addPrjFileToArchive(file, sourceSrs);
+                    } else {
+                        // At least second recursion: throw exception since SRS definition
+                        // could not be set.
+                        throw new GeoServerRESTImporterException("Could not set SRS definition "
+                            + "of GeoTIFF.");
+                    }
+                } catch (ZipException ze) {
+                    throw new GeoServerRESTImporterException("No valid ZIP file given containing "
+                        + "GeoTiff datasets.");
+                }
+
+                if (updatedGeoTiff != null) {
+                    importTaskList = uploadFile(importJobId, updatedGeoTiff, null);
+                    return importTaskList;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Updates the given import task.
+     */
+    public boolean updateImportTask(int importJobId, int importTaskId,
+                                    AbstractRESTEntity updateTaskEntity) throws Exception {
+        log.debug("Updating the import task " + importTaskId + " in job " + importJobId +
+            " with " + updateTaskEntity);
+
+        HttpResponse httpResponse = HttpUtil.put(
+            this.addEndPoint(importJobId + "/tasks/" + importTaskId),
+            this.asJSON(updateTaskEntity),
+            ContentType.APPLICATION_JSON,
+            this.username,
+            this.password,
+            false
+        );
+
+        boolean success = httpResponse.getStatusCode().equals(HttpStatus.NO_CONTENT);
+
+        if (success) {
+            log.debug("Successfully updated the task " + importTaskId);
+        } else {
+            log.error("Unknown error occured while updating the task " + importTaskId);
+        }
+
+        return success;
+    }
+
+    /**
+     * Update layer object for a given task of an import job (via PUT)
+     *
+     * @param importJobId      The import job ID
+     * @param importTaskId     The import task ID
+     * @param updateTaskEntity The entity to use for update
+     * @return true if successful, false otherwise
+     * @throws URISyntaxException
+     * @throws HttpException
+     */
+    public boolean updateLayerForImportTask(int importJobId, int importTaskId, AbstractRESTEntity updateTaskEntity) throws URISyntaxException, HttpException {
+        if (importJobId < 0 || importTaskId < 0) {
+            log.debug("Invalid importJobId or importTaskId passed.");
+            return false;
+        }
+        if (updateTaskEntity == null) {
+            log.debug("Entity to update is null.");
+            return false;
+        }
+
+        log.debug("Updating layer for the import task " + importTaskId + " in job " + importJobId + " with " + updateTaskEntity);
+        HttpResponse httpResponse = HttpUtil.put(
+            this.addEndPoint(importJobId + "/tasks/" + importTaskId + "/layer"),
+            this.asJSON(updateTaskEntity),
+            ContentType.APPLICATION_JSON,
+            this.username,
+            this.password,
+            false
+        );
+
+        boolean success = httpResponse.getStatusCode().equals(HttpStatus.NO_CONTENT);
+
+        if (success) {
+            log.debug("Successfully updated layer for task " + importTaskId);
+        } else {
+            log.error("An unknown error occurred while updating the task " + importTaskId);
+        }
+
+        return success;
+    }
+
+    /**
+     * Deletes an importJob.
+     */
+    public boolean deleteImportJob(Integer importJobId) throws URISyntaxException, HttpException {
+
+        log.debug("Deleting the import job " + importJobId);
+
+        HttpResponse httpResponse = HttpUtil.delete(
+            this.addEndPoint(importJobId.toString()),
+            this.username,
+            this.password);
+
+        boolean success = httpResponse.getStatusCode().equals(HttpStatus.NO_CONTENT);
+
+        if (success) {
+            log.debug("Successfully deleted the import job " + importJobId);
+        } else {
+            log.error("Unknown error occured while deleting the import job " + importJobId);
+        }
+
+        return success;
+    }
+
+    /**
+     * Run a previously configured import job.
+     */
+    public boolean runImportJob(Integer importJobId) throws
+        UnsupportedEncodingException, URISyntaxException, HttpException {
+
+        log.debug("Starting the import for job " + importJobId);
+
+        HttpResponse httpResponse = HttpUtil.post(
+            this.addEndPoint(Integer.toString(importJobId)),
+            this.username,
+            this.password
+        );
+
+        boolean success = httpResponse.getStatusCode().equals(HttpStatus.NO_CONTENT);
+
+        if (success) {
+            log.debug("Successfully started the import job " + importJobId);
+        } else {
+            log.error("Unknown error occured while running the import job " + importJobId);
+        }
+
+        return success;
+    }
+
+    /**
+     * Get a layer.
+     */
+    public RESTLayer getLayer(Integer importJobId, Integer taskId) throws Exception {
+        HttpResponse httpResponse = HttpUtil.get(
+            this.addEndPoint(importJobId + "/tasks/" + taskId + "/layer"),
+            this.username,
+            this.password
+        );
+
+        return (RESTLayer) this.asEntity(httpResponse.getBody(), RESTLayer.class);
+    }
+
+    /**
+     * fetch all created Layers of import job
+     */
+    public List<RESTLayer> getAllImportedLayers(Integer importJobId, List<RESTImportTask> tasks) throws Exception {
+        ArrayList<RESTLayer> layers = new ArrayList<RESTLayer>();
+        for (RESTImportTask task : tasks) {
+
+            RESTImportTask refreshedTask = this.getRESTImportTask(importJobId, task.getId());
+            if (refreshedTask.getState().equalsIgnoreCase("COMPLETE")) {
+                HttpResponse httpResponse = HttpUtil.get(
+                    this.addEndPoint(importJobId + "/tasks/" + task.getId() + "/layer"),
+                    this.username,
+                    this.password
+                );
+                RESTLayer layer = (RESTLayer) this.asEntity(httpResponse.getBody(), RESTLayer.class);
+
+                if (layer != null) {
+                    layers.add(layer);
+                }
+            } else if ((tasks.size() == 1) && refreshedTask.getState().equalsIgnoreCase("ERROR")) {
+                throw new GeoServerRESTImporterException(refreshedTask.getErrorMessage());
+            }
+        }
+        return layers;
+    }
+
+    /**
+     * Get the data of an import task.
+     */
+    public RESTData getDataOfImportTask(Integer importJobId, Integer taskId)
+        throws Exception {
+        final DeserializationFeature unwrapRootValueFeature = DeserializationFeature.UNWRAP_ROOT_VALUE;
+        boolean unwrapRootValueFeatureIsEnabled = mapper.isEnabled(unwrapRootValueFeature);
+
+        HttpResponse httpResponse = HttpUtil.get(
+            this.addEndPoint(importJobId + "/tasks/" + taskId + "/data"),
+            this.username,
+            this.password
+        );
+
+        // we have to disable the feature. otherwise deserialize would not work here
+        mapper.disable(unwrapRootValueFeature);
+
+        final RESTData resultEntity = (RESTData) this.asEntity(httpResponse.getBody(), RESTData.class);
+
+        if (unwrapRootValueFeatureIsEnabled) {
+            mapper.enable(unwrapRootValueFeature);
+        }
+
+        return resultEntity;
+    }
+
+    /**
+     * Get an import task.
+     */
+    public RESTImportTask getRESTImportTask(Integer importJobId, Integer taskId) throws
+        Exception {
+        HttpResponse httpResponse = HttpUtil.get(
+            this.addEndPoint(importJobId + "/tasks/" + taskId),
+            this.username,
+            this.password
+        );
+
+        return (RESTImportTask) this.asEntity(httpResponse.getBody(), RESTImportTask.class);
+    }
+
+    /**
+     * @param importJobId
+     * @throws Exception
+     */
+    public RESTImportTaskList getRESTImportTasks(Integer importJobId) throws Exception {
+        HttpResponse httpResponse = HttpUtil.get(
+            this.addEndPoint(importJobId + "/tasks"),
+            this.username,
+            this.password
+        );
+        return mapper.readValue(httpResponse.getBody(), RESTImportTaskList.class);
+    }
+
+    /**
+     * Helper method to create an importer transformTask
+     */
+    private boolean createTransformTask(Integer importJobId, Integer taskId, RESTTransform transformTask)
+        throws URISyntaxException, HttpException {
+
+        log.debug("Creating a new transform task for import job" + importJobId + " and task " + taskId);
+
+        mapper.disable(SerializationFeature.WRAP_ROOT_VALUE);
+
+        HttpResponse httpResponse = HttpUtil.post(
+            this.addEndPoint(importJobId + "/tasks/" + taskId + "/transforms"),
+            this.asJSON(transformTask),
+            ContentType.APPLICATION_JSON,
+            this.username,
+            this.password,
+            false
+        );
+
+        mapper.enable(SerializationFeature.WRAP_ROOT_VALUE);
+
+        if (httpResponse.getStatusCode().equals(HttpStatus.CREATED)) {
+            log.debug("Successfully created the transform task");
+            return true;
+        } else {
+            log.error("Error while creating the transform task");
+            return false;
+        }
+    }
+
+    /**
+     * Convert a byte array to an importer REST entity.
+     */
+    private AbstractRESTEntity asEntity(byte[] responseBody, Class<?> clazz)
+        throws Exception {
+
+        AbstractRESTEntity entity = null;
+
+        entity = (AbstractRESTEntity) mapper.readValue(responseBody, clazz);
+
+        return entity;
+    }
+
+    /**
+     * Convert an object to json.
+     */
+    protected String asJSON(Object entity) {
+
+        String entityJson = null;
+
+        try {
+            entityJson = this.mapper.writeValueAsString(entity);
+        } catch (Exception e) {
+            log.error("Could not parse as JSON: " + e.getMessage());
+        }
+
+        return entityJson;
+    }
+
+    /**
+     * Add an endpoint.
+     */
+    protected URI addEndPoint(String endPoint) throws URISyntaxException {
+
+        if (StringUtils.isEmpty(endPoint) || endPoint.equals("/")) {
+            return this.baseUri;
+        }
+
+        if (this.baseUri.getPath().endsWith("/") || endPoint.startsWith("/")) {
+            endPoint = this.baseUri.getPath() + endPoint;
+        } else {
+            endPoint = this.baseUri.getPath() + "/" + endPoint;
+        }
+
+        URI uri = null;
+
+        URIBuilder builder = new URIBuilder();
+
+        builder.setScheme(this.baseUri.getScheme());
+        builder.setHost(this.baseUri.getHost());
+        builder.setPort(this.baseUri.getPort());
+        builder.setPath(endPoint);
+
+        uri = builder.build();
+        return uri;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/config/ImporterApplicationConfig.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/config/ImporterApplicationConfig.java
@@ -1,0 +1,57 @@
+package de.terrestris.shogun.importer.config;
+
+import de.terrestris.shogun.importer.GeoServerRESTImporter;
+import de.terrestris.shogun.importer.config.properties.GeoServerProperties;
+import de.terrestris.shogun.importer.config.properties.ImporterProperties;
+import de.terrestris.shogun.importer.config.properties.RasterImportProperties;
+import de.terrestris.shogun.importer.config.properties.VectorImportProperties;
+import de.terrestris.shogun.properties.KeycloakAuthProperties;
+import it.geosolutions.geoserver.rest.GeoServerRESTManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"de.terrestris.shogun.importer", "de.terrestris.shogun.lib.util"})
+@EnableConfigurationProperties({
+    ImporterProperties.class,
+    GeoServerProperties.class,
+    RasterImportProperties.class,
+    VectorImportProperties.class,
+    KeycloakAuthProperties.class
+})
+public class ImporterApplicationConfig {
+
+    @Autowired
+    protected ImporterProperties importerProperties;
+
+    @Bean
+    public GeoServerRESTManager geoServerManager() throws URISyntaxException, MalformedURLException {
+        return new GeoServerRESTManager(
+            new URI(importerProperties.getGeoserver().getBaseUrl()).toURL(),
+            importerProperties.getGeoserver().getUsername(),
+            importerProperties.getGeoserver().getPassword()
+        );
+    }
+
+    @Bean
+    public GeoServerRESTImporter geoServerImporter() throws URISyntaxException {
+        return new GeoServerRESTImporter(
+            new URI(String.format("%s/rest/imports", importerProperties.getGeoserver().getBaseUrl())),
+            importerProperties.getGeoserver().getUsername(),
+            importerProperties.getGeoserver().getPassword()
+        );
+    }
+
+    public static void main(String[] args) {
+        SpringApplication.run(ImporterApplicationConfig.class, args);
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/config/ImporterKeycloakConfig.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/config/ImporterKeycloakConfig.java
@@ -1,0 +1,8 @@
+package de.terrestris.shogun.importer.config;
+
+import de.terrestris.shogun.config.KeycloakConfig;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ImporterKeycloakConfig extends KeycloakConfig {
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/config/ImporterSwaggerConfig.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/config/ImporterSwaggerConfig.java
@@ -1,0 +1,29 @@
+package de.terrestris.shogun.importer.config;
+
+import de.terrestris.shogun.config.SwaggerConfig;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.service.ApiInfo;
+
+import java.util.Collections;
+
+@Configuration
+@EnableAutoConfiguration
+public class ImporterSwaggerConfig extends SwaggerConfig {
+
+    @Override
+    protected ApiInfo apiInfo() {
+        ApiInfo apiInfo = new ApiInfo(
+            "SHOGun GeoServer Importer REST-API",
+            description,
+            version,
+            termsOfServiceUrl,
+            contact,
+            license,
+            licenseUrl,
+            Collections.emptyList()
+        );
+
+        return apiInfo;
+    }
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/config/ImporterSwaggerConfig.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/config/ImporterSwaggerConfig.java
@@ -1,8 +1,10 @@
 package de.terrestris.shogun.importer.config;
 
+import com.google.common.base.Predicate;
 import de.terrestris.shogun.config.SwaggerConfig;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.service.ApiInfo;
 
 import java.util.Collections;
@@ -25,5 +27,10 @@ public class ImporterSwaggerConfig extends SwaggerConfig {
         );
 
         return apiInfo;
+    }
+
+    @Override
+    protected Predicate<String> setSecurityContextPaths() {
+        return PathSelectors.any();
     }
 }

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/config/ImporterWebSecurityConfig.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/config/ImporterWebSecurityConfig.java
@@ -1,0 +1,46 @@
+package de.terrestris.shogun.importer.config;
+
+import de.terrestris.shogun.config.WebSecurityConfig;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Configuration
+public class ImporterWebSecurityConfig extends WebSecurityConfig {
+
+    RequestMatcher csrfRequestMatcher = new RequestMatcher() {
+        public boolean matches(HttpServletRequest httpServletRequest) {
+            if (httpServletRequest.getHeader("Referer").endsWith("swagger-ui.html")) {
+                return false;
+            }
+            return true;
+        }
+    };
+
+    @Override
+    protected void customHttpConfiguration(HttpSecurity http) throws Exception {
+        http
+            .authorizeRequests()
+            .antMatchers(
+                // Allow access to swagger interface
+                "/swagger-ui.html",
+                "/swagger-resources/**",
+                "/webjars/**",
+                "/v2/**",
+                "/csrf/**"
+            )
+                .permitAll()
+            .antMatchers(
+                "/graphiql/**",
+                "/import/**"
+            )
+                .authenticated()
+            .and()
+                .csrf()
+                    .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                    .ignoringRequestMatchers(csrfRequestMatcher);
+    }
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/config/properties/GeoServerProperties.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/config/properties/GeoServerProperties.java
@@ -1,0 +1,18 @@
+package de.terrestris.shogun.importer.config.properties;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "geoserver")
+@Data
+public class GeoServerProperties {
+
+    private String baseUrl;
+
+    private String username;
+
+    private String password;
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/config/properties/ImporterProperties.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/config/properties/ImporterProperties.java
@@ -1,0 +1,33 @@
+package de.terrestris.shogun.importer.config.properties;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "importer")
+@Data
+public class ImporterProperties {
+
+    @NestedConfigurationProperty
+    private GeoServerProperties geoserver;
+
+    @NestedConfigurationProperty
+    private SHOGunProperties shogun;
+
+    @NestedConfigurationProperty
+    private RasterImportProperties raster;
+
+    @NestedConfigurationProperty
+    private VectorImportProperties vector;
+
+    private String targetWorkspace;
+
+    private String targetEPSG;
+
+    private String interceptorEndpoint;
+
+    private Integer httpTimeout;
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/config/properties/RasterImportProperties.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/config/properties/RasterImportProperties.java
@@ -1,0 +1,20 @@
+package de.terrestris.shogun.importer.config.properties;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+@ConfigurationProperties(prefix = "raster")
+@Data
+public class RasterImportProperties {
+
+    private Boolean performGdalAddo;
+
+    private List<Integer> gdalAddoLevels;
+
+    private Boolean performGdalWarp;
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/config/properties/SHOGunProperties.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/config/properties/SHOGunProperties.java
@@ -1,0 +1,18 @@
+package de.terrestris.shogun.importer.config.properties;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "shogun")
+@Data
+public class SHOGunProperties {
+
+    private String baseUrl;
+
+    private String username;
+
+    private String password;
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/config/properties/VectorImportProperties.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/config/properties/VectorImportProperties.java
@@ -1,0 +1,18 @@
+package de.terrestris.shogun.importer.config.properties;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+
+@Configuration
+@ConfigurationProperties(prefix = "vector")
+@Data
+public class VectorImportProperties {
+
+    private String targetDatastore;
+
+    private Map<String, String> targetDatastoreConnectionParams;
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/controller/ImporterController.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/controller/ImporterController.java
@@ -1,0 +1,154 @@
+package de.terrestris.shogun.importer.controller;
+
+import de.terrestris.shogun.importer.exception.GeoServerRESTImporterException;
+import de.terrestris.shogun.importer.service.ImporterService;
+import lombok.extern.log4j.Log4j2;
+import org.apache.http.HttpException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URISyntaxException;
+import java.util.Map;
+
+@Controller
+@RequestMapping("/import")
+@Log4j2
+public class ImporterController {
+
+    @Autowired
+    private ImporterService service;
+
+    /**
+     * <p>createLayer.</p>
+     *
+     * @param file
+     * @param fileProjection a {@link java.lang.String} object.
+     * @param dataType       a {@link java.lang.String} object.
+     * @return a {@link org.springframework.http.ResponseEntity} object.
+     */
+    @RequestMapping(value = "/create-layer.action", method = {RequestMethod.POST})
+    public ResponseEntity<?> createLayer(
+        @RequestParam("file") MultipartFile file,
+        @RequestParam(value = "fileProjection", required = false) String fileProjection,
+        @RequestParam("dataType") String dataType) {
+
+        log.debug("Requested to create a layer from geo-file(s).");
+
+        try {
+            if (file.isEmpty()) {
+                log.error("Upload failed. File " + file + " is empty.");
+                throw new GeoServerRESTImporterException("File " +
+                    file.getOriginalFilename() + " is empty.");
+            }
+
+            Map<String, Object> responseMap = this.service.importGeodataAndCreateLayer(
+                file,
+                fileProjection,
+                dataType
+            );
+
+            return ResponseEntity.ok(responseMap);
+        } catch (Exception e) {
+            log.error("Could not create layer: " + e.getMessage());
+            log.trace("Full stack trace ", e);
+
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * <p>importWfs.</p>
+     *
+     * @param wfsUrl      The base URL of the WFS server to fetch the features from,
+     *                    e.g. "http://geoserver:8080/geoserver/ows". Required.
+     * @param wfsVersion  The WFS version to use, possible values are usually one of
+     *                    1.0.0, 1.1.0 or 2.0.0. Optional.
+     * @param featureType The name of the featureType to fetch and import, e.g.
+     *                    "GDA_Wasser:OG_MESSSTELLEN_NETZ_BESCHRIFTUNG". Required.
+     * @param targetEpsg  The EPSG to be used for the imported features, e.g. "EPSG:3857".
+     *                    Optional.
+     * @return a {@link org.springframework.http.ResponseEntity} object.
+     */
+    @RequestMapping(value = "/wfs.action", method = {RequestMethod.POST})
+    public ResponseEntity<?> importWfs(
+        @RequestParam(value = "wfsUrl", required = true) String wfsUrl,
+        @RequestParam(value = "wfsVersion", required = false) String wfsVersion,
+        @RequestParam(value = "featureType", required = true) String featureType,
+        @RequestParam(value = "targetEpsg", required = false) String targetEpsg) {
+
+        log.debug("Requested to import featureType " + featureType + " from WFS server " + wfsUrl +
+            " (in version " + wfsVersion + " and projection " + targetEpsg + ") as new layer.");
+
+        try {
+            // TODO
+//            ProjectLayer createdLayer = this.service.importWfsAndCreateLayer(
+//                wfsUrl, wfsVersion, featureType, targetEpsg);
+            String createdLayer = null;
+
+            return ResponseEntity.ok(createdLayer);
+        } catch (Exception e) {
+            String errMsg = "Error while creating a layer from WFS GetCapabilities";
+            log.error(errMsg + ": ", e);
+
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * <p>updateCrsForImport.</p>
+     *
+     * @param layerName      a {@link java.lang.String} object.
+     * @param dataType       a {@link java.lang.String} object.
+     * @param importJobId    a {@link java.lang.Integer} object.
+     * @param taskId         a {@link java.lang.Integer} object.
+     * @param fileProjection a {@link java.lang.String} object.
+     * @return a {@link org.springframework.http.ResponseEntity} object.
+     */
+    @RequestMapping(value = "/update-crs-for-import.action", method = {RequestMethod.POST})
+    public ResponseEntity<?> updateCrsForImport(
+        @RequestParam("layerName") String layerName,
+        @RequestParam("dataType") String dataType,
+        @RequestParam("importJobId") Integer importJobId,
+        @RequestParam("taskId") Integer taskId,
+        @RequestParam(value = "fileProjection") String fileProjection) {
+
+        try {
+            Map<String, Object> responseMap = this.service.updateCrsForImport(
+                layerName,
+                dataType,
+                importJobId, taskId, fileProjection);
+
+            return ResponseEntity.ok(responseMap);
+        } catch (Exception e) {
+            log.error("updateCrsForImport has thrown an exception. Error was: " + e.getMessage());
+
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    /**
+     * <p>deleteImportJob.</p>
+     *
+     * @param importJobId a {@link java.lang.Integer} object.
+     * @return a {@link org.springframework.http.ResponseEntity} object.
+     */
+    @RequestMapping(value = "/delete-import-job.action", method = {RequestMethod.POST})
+    public ResponseEntity<?> deleteImportJob(@RequestParam("importJobId") Integer importJobId) {
+
+        try {
+            Map<String, Object> responseMap = this.service.deleteImportJob(importJobId);
+
+            return ResponseEntity.ok(responseMap);
+        } catch (URISyntaxException | HttpException e) {
+            log.error("deleteImportJob has thrown an exception. Error was: " + e.getMessage());
+
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/AbstractRESTEntity.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/AbstractRESTEntity.java
@@ -1,0 +1,19 @@
+package de.terrestris.shogun.importer.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class AbstractRESTEntity {
+
+    /**
+     * Default constructor.
+     */
+    public AbstractRESTEntity() {
+
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTAttribute.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTAttribute.java
@@ -1,0 +1,63 @@
+package de.terrestris.shogun.importer.dto;
+
+/**
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+public class RESTAttribute extends AbstractRESTEntity {
+
+    /**
+     *
+     */
+    private String name;
+
+    /**
+     *
+     */
+    private String binding;
+
+    /**
+     * Default constructor.
+     */
+    public RESTAttribute() {
+
+    }
+
+    /**
+     * @param name
+     * @param binding
+     */
+    public RESTAttribute(String name, String binding) {
+        this.name = name;
+        this.binding = binding;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the binding
+     */
+    public String getBinding() {
+        return binding;
+    }
+
+    /**
+     * @param binding the binding to set
+     */
+    public void setBinding(String binding) {
+        this.binding = binding;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTBoundingBox.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTBoundingBox.java
@@ -1,0 +1,126 @@
+package de.terrestris.shogun.importer.dto;
+
+/**
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+public class RESTBoundingBox extends AbstractRESTEntity {
+
+    /**
+     *
+     */
+    private String minx;
+
+    /**
+     *
+     */
+    private String miny;
+
+    /**
+     *
+     */
+    private String maxx;
+
+    /**
+     *
+     */
+    private String maxy;
+
+    /**
+     *
+     */
+    private String crs;
+
+    /**
+     * Default constructor.
+     */
+    public RESTBoundingBox() {
+
+    }
+
+    /**
+     * @param minx
+     * @param miny
+     * @param maxx
+     * @param maxy
+     * @param crs
+     */
+    public RESTBoundingBox(String minx, String miny, String maxx, String maxy,
+                           String crs) {
+        this.minx = minx;
+        this.miny = miny;
+        this.maxx = maxx;
+        this.maxy = maxy;
+        this.crs = crs;
+    }
+
+    /**
+     * @return the minx
+     */
+    public String getMinx() {
+        return minx;
+    }
+
+    /**
+     * @param minx the minx to set
+     */
+    public void setMinx(String minx) {
+        this.minx = minx;
+    }
+
+    /**
+     * @return the miny
+     */
+    public String getMiny() {
+        return miny;
+    }
+
+    /**
+     * @param miny the miny to set
+     */
+    public void setMiny(String miny) {
+        this.miny = miny;
+    }
+
+    /**
+     * @return the maxx
+     */
+    public String getMaxx() {
+        return maxx;
+    }
+
+    /**
+     * @param maxx the maxx to set
+     */
+    public void setMaxx(String maxx) {
+        this.maxx = maxx;
+    }
+
+    /**
+     * @return the maxy
+     */
+    public String getMaxy() {
+        return maxy;
+    }
+
+    /**
+     * @param maxy the maxy to set
+     */
+    public void setMaxy(String maxy) {
+        this.maxy = maxy;
+    }
+
+    /**
+     * @return the crs
+     */
+    public String getCrs() {
+        return crs;
+    }
+
+    /**
+     * @param crs the crs to set
+     */
+    public void setCrs(String crs) {
+        this.crs = crs;
+    }
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTCoverageStore.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTCoverageStore.java
@@ -1,0 +1,15 @@
+package de.terrestris.shogun.importer.dto;
+
+/**
+ * terrestris GmbH & Co. KG
+ *
+ * @author ahenn
+ * @date 01.04.2016
+ */
+public class RESTCoverageStore extends RESTDataStore {
+
+    public RESTCoverageStore() {
+        super();
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTData.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTData.java
@@ -1,0 +1,104 @@
+package de.terrestris.shogun.importer.dto;
+
+/**
+ * A data is the description of the source data of a import (overall) or a
+ * task. In case the import has a global data definition, this normally refers
+ * to an aggregate store such as a directory or a database, and the data
+ * associated to the tasks refers to a single element inside such aggregation,
+ * such as a single file or table.
+ * <p>
+ * A import can have a "data" representing the source of the data to be
+ * imported. The data can be of different types, in particular: "file",
+ * "directory", "mosaic", "database" and "remote". During the import
+ * initialization the importer will scan the contents of said resource, and
+ * generate import tasks for each data found in it.
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+public class RESTData extends AbstractRESTEntity {
+
+    /**
+     *
+     */
+    private String type;
+
+    /**
+     *
+     */
+    private String format;
+
+    /**
+     *
+     */
+    private String file;
+
+    /**
+     *
+     */
+    private String location;
+
+    /**
+     * Default constructor.
+     */
+    public RESTData() {
+
+    }
+
+    /**
+     * @return the type
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @param type the type to set
+     */
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    /**
+     * @return the format
+     */
+    public String getFormat() {
+        return format;
+    }
+
+    /**
+     * @param format the format to set
+     */
+    public void setFormat(String format) {
+        this.format = format;
+    }
+
+    /**
+     * @return the file
+     */
+    public String getFile() {
+        return file;
+    }
+
+    /**
+     * @param file the file to set
+     */
+    public void setFile(String file) {
+        this.file = file;
+    }
+
+    /**
+     * @return
+     */
+    public String getLocation() {
+        return location;
+    }
+
+    /**
+     * @param location
+     */
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTDataDirectory.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTDataDirectory.java
@@ -1,0 +1,9 @@
+package de.terrestris.shogun.importer.dto;
+
+/**
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+public class RESTDataDirectory extends RESTData {
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTDataFile.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTDataFile.java
@@ -1,0 +1,125 @@
+package de.terrestris.shogun.importer.dto;
+
+import java.util.List;
+
+/**
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+public class RESTDataFile extends RESTData {
+
+    /**
+     *
+     */
+    private String format;
+
+    /**
+     *
+     */
+    private String location;
+
+    /**
+     *
+     */
+    private String file;
+
+    /**
+     *
+     */
+    private String href;
+
+    /**
+     *
+     */
+    private String prj;
+
+    /**
+     *
+     */
+    private List<String> other;
+
+    /**
+     * @return the format
+     */
+    public String getFormat() {
+        return format;
+    }
+
+    /**
+     * @param format the format to set
+     */
+    public void setFormat(String format) {
+        this.format = format;
+    }
+
+    /**
+     * @return the location
+     */
+    public String getLocation() {
+        return location;
+    }
+
+    /**
+     * @param location the location to set
+     */
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    /**
+     * @return the file
+     */
+    public String getFile() {
+        return file;
+    }
+
+    /**
+     * @param file the file to set
+     */
+    public void setFile(String file) {
+        this.file = file;
+    }
+
+    /**
+     * @return the href
+     */
+    public String getHref() {
+        return href;
+    }
+
+    /**
+     * @param href the href to set
+     */
+    public void setHref(String href) {
+        this.href = href;
+    }
+
+    /**
+     * @return the prj
+     */
+    public String getPrj() {
+        return prj;
+    }
+
+    /**
+     * @param prj the prj to set
+     */
+    public void setPrj(String prj) {
+        this.prj = prj;
+    }
+
+    /**
+     * @return the other
+     */
+    public List<String> getOther() {
+        return other;
+    }
+
+    /**
+     * @param other the other to set
+     */
+    public void setOther(List<String> other) {
+        this.other = other;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTDataRemote.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTDataRemote.java
@@ -1,0 +1,85 @@
+package de.terrestris.shogun.importer.dto;
+
+/**
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+public class RESTDataRemote extends RESTData {
+
+    /**
+     *
+     */
+    private String location;
+
+    /**
+     *
+     */
+    private String username;
+
+    /**
+     *
+     */
+    private String password;
+
+    /**
+     *
+     */
+    private String domain;
+
+    /**
+     * @return the location
+     */
+    public String getLocation() {
+        return location;
+    }
+
+    /**
+     * @param location the location to set
+     */
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    /**
+     * @return the username
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * @param username the username to set
+     */
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    /**
+     * @return the password
+     */
+    public String getPassword() {
+        return password;
+    }
+
+    /**
+     * @param password the password to set
+     */
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    /**
+     * @return the domain
+     */
+    public String getDomain() {
+        return domain;
+    }
+
+    /**
+     * @param domain the domain to set
+     */
+    public void setDomain(String domain) {
+        this.domain = domain;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTDataStore.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTDataStore.java
@@ -1,0 +1,62 @@
+package de.terrestris.shogun.importer.dto;
+
+/**
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+public class RESTDataStore extends AbstractRESTEntity {
+
+    /**
+     *
+     */
+    private String name;
+
+    /**
+     *
+     */
+    private String type;
+
+    /**
+     * Default constructor.
+     */
+    public RESTDataStore() {
+
+    }
+
+    /**
+     * @param name
+     * @param type
+     */
+    public RESTDataStore(String name, String type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the type
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @param type the type to set
+     */
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTDateFormatTransform.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTDateFormatTransform.java
@@ -1,0 +1,66 @@
+package de.terrestris.shogun.importer.dto;
+
+/**
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+public class RESTDateFormatTransform extends RESTTransform {
+
+    /**
+     *
+     */
+    private String href;
+
+    /**
+     *
+     */
+    private String field;
+
+    /**
+     *
+     */
+    private String format;
+
+    /**
+     * @return the href
+     */
+    public String getHref() {
+        return href;
+    }
+
+    /**
+     * @param href the href to set
+     */
+    public void setHref(String href) {
+        this.href = href;
+    }
+
+    /**
+     * @return the field
+     */
+    public String getField() {
+        return field;
+    }
+
+    /**
+     * @param field the field to set
+     */
+    public void setField(String field) {
+        this.field = field;
+    }
+
+    /**
+     * @return the format
+     */
+    public String getFormat() {
+        return format;
+    }
+
+    /**
+     * @param format the format to set
+     */
+    public void setFormat(String format) {
+        this.format = format;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTGdalAddoTransform.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTGdalAddoTransform.java
@@ -1,0 +1,58 @@
+package de.terrestris.shogun.importer.dto;
+
+import java.util.List;
+
+/**
+ * terrestris GmbH & Co. KG
+ *
+ * @author ahenn
+ * @date 01.04.2016
+ * <p>
+ * Task performing gdaladdo which builds or rebuilds overview images.
+ * @see <a href="http://www.gdal.org/gdaladdo.html">GDAL (gdaladdo) documentation</a>
+ * Requires <code>gdaladdo</code> to be inside the PATH used by the web container running GeoServer.
+ */
+public class RESTGdalAddoTransform extends RESTTransform {
+
+    public static final String TYPE_NAME = "GdalAddoTransform";
+
+    private List<String> options;
+    private List<Integer> levels;
+
+    /**
+     * Default constructor; sets <code>type</code> of
+     * {@link RESTTransform} to "GdalAddoTransform"
+     */
+    public RESTGdalAddoTransform() {
+        super(TYPE_NAME);
+    }
+
+    /**
+     * @return the options
+     */
+    public List<String> getOptions() {
+        return options;
+    }
+
+    /**
+     * @param options the options to set
+     */
+    public void setOptions(List<String> options) {
+        this.options = options;
+    }
+
+    /**
+     * @return the levels
+     */
+    public List<Integer> getLevels() {
+        return levels;
+    }
+
+    /**
+     * @param levels the levels to set
+     */
+    public void setLevels(List<Integer> levels) {
+        this.levels = levels;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTGdalTranslateTransform.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTGdalTranslateTransform.java
@@ -1,0 +1,50 @@
+/**
+ *
+ */
+package de.terrestris.shogun.importer.dto;
+
+import java.util.List;
+
+/**
+ * terrestris GmbH & Co. KG
+ *
+ * @author ahenn
+ * @date 01.04.2016
+ * <p>
+ * Importer transform task representing gdal_translate, a tool which converts
+ * raster data between different formats
+ * @see <a href="http://www.gdal.org/gdal_translate.html">GDAL (gdal_translate) documentation</a>
+ * Requires <code>gdal_translate</code> to be inside the PATH used by the web container running GeoServer.
+ */
+public class RESTGdalTranslateTransform extends RESTTransform {
+
+    /**
+     *
+     */
+    public static final String TYPE_NAME = "GdalTranslateTransform";
+
+    private List<String> options;
+
+    /**
+     * Default constructor; sets <code>type</code> of
+     * {@link RESTTransform} to "GdalTranslateTransform"
+     */
+    public RESTGdalTranslateTransform() {
+        super(TYPE_NAME);
+    }
+
+    /**
+     * @return the options
+     */
+    public List<String> getOptions() {
+        return options;
+    }
+
+    /**
+     * @param options the options to set
+     */
+    public void setOptions(List<String> options) {
+        this.options = options;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTGdalWarpTransform.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTGdalWarpTransform.java
@@ -1,0 +1,46 @@
+package de.terrestris.shogun.importer.dto;
+
+import java.util.List;
+
+/**
+ * terrestris GmbH & Co. KG
+ *
+ * @author ahenn
+ * @date 01.04.2016
+ * <p>
+ * Importer transform task representing gdalwarp, an image reprojection and warping utility,
+ * @see <a href="http://www.gdal.org/gdalwarp.html">GDAL (gdalwarp) documentation</a>
+ * Requires <code>gdalwarp</code> to be inside the PATH used by the web container running GeoServer.
+ */
+public class RESTGdalWarpTransform extends RESTTransform {
+
+    /**
+     *
+     */
+    public static final String TYPE_NAME = "GdalWarpTransform";
+
+    private List<String> options;
+
+    /**
+     * Default constructor; sets <code>type</code> of
+     * {@link RESTTransform} to "GdalWarpTransform"
+     */
+    public RESTGdalWarpTransform() {
+        super(TYPE_NAME);
+    }
+
+    /**
+     * @return the options
+     */
+    public List<String> getOptions() {
+        return options;
+    }
+
+    /**
+     * @param options the options to set
+     */
+    public void setOptions(List<String> options) {
+        this.options = options;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTImport.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTImport.java
@@ -1,0 +1,133 @@
+package de.terrestris.shogun.importer.dto;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+import java.util.List;
+
+/**
+ * An import refers to the top level object and is a "session" like entity the
+ * state of the entire import. It maintains information relevant to the import
+ * as a whole such as user information, timestamps along with optional
+ * information that is uniform along all tasks, such as a target workspace, the
+ * shared input data (e.g. a directory, a database). An import is made of any
+ * number of task objects.
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+@JsonRootName(value = "import")
+public class RESTImport extends AbstractRESTEntity {
+
+    /**
+     *
+     */
+    private Integer id;
+
+    /**
+     *
+     */
+    private String href;
+
+    /**
+     *
+     */
+    private String state;
+
+    /**
+     *
+     */
+    private RESTTargetWorkspace targetWorkspace;
+
+    /**
+     *
+     */
+    private RESTTargetDataStore targetStore;
+
+    /**
+     *
+     */
+    private RESTData data;
+
+    /**
+     *
+     */
+    private List<RESTImportTask> importTasks;
+
+    /**
+     * Default constructor.
+     */
+    public RESTImport() {
+
+    }
+
+    /**
+     * @return the targetWorkspace
+     */
+    public RESTTargetWorkspace getTargetWorkspace() {
+        return targetWorkspace;
+    }
+
+    /**
+     * @param targetWorkspace the targetWorkspace to set
+     */
+    public void setTargetWorkspace(RESTTargetWorkspace targetWorkspace) {
+        this.targetWorkspace = targetWorkspace;
+    }
+
+    /**
+     * @return the targetStore
+     */
+    public RESTTargetDataStore getTargetStore() {
+        return targetStore;
+    }
+
+    /**
+     * @param targetStore the targetStore to set
+     */
+    public void setTargetStore(RESTTargetDataStore targetStore) {
+        this.targetStore = targetStore;
+    }
+
+    /**
+     * @return the data
+     */
+    public RESTData getData() {
+        return data;
+    }
+
+    /**
+     * @param data the data to set
+     */
+    public void setData(RESTData data) {
+        this.data = data;
+    }
+
+    /**
+     * @return the id
+     */
+    public Integer getId() {
+        return id;
+    }
+
+    /**
+     * @return the href
+     */
+    public String getHref() {
+        return href;
+    }
+
+    /**
+     * @return the state
+     */
+    public String getState() {
+        return state;
+    }
+
+    /**
+     * @return the importTasks
+     */
+    public List<RESTImportTask> getImportTasks() {
+        return importTasks;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTImportTask.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTImportTask.java
@@ -1,0 +1,237 @@
+package de.terrestris.shogun.importer.dto;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+/**
+ * A task represents a unit of work to the importer needed to register one
+ * new layer, or alter an existing one, and contains the following information:
+ * <p>
+ * * The data being imported
+ * * The target store that is the destination of the import
+ * * The target layer
+ * * The data of a task, referred to as its source, is the data to be
+ * processed as part of the task.
+ * * The transformations that we need to apply to the data before it gets
+ * imported
+ * <p>
+ * This data comes in a variety of forms including:
+ * <p>
+ * * A spatial file (Shapefile, GeoTiff, KML, etc...)
+ * * A directory of spatial files
+ * * A table in a spatial database
+ * * A remote location that the server will download data from
+ * <p>
+ * A task is classified as either “direct” or “indirect”. A direct task is one
+ * in which the data being imported requires no transformation to be imported.
+ * It is imported directly. An example of such a task is one that involves
+ * simply importing an existing Shapefile as is. An indirect task is one that
+ * does require a transformation to the original import data. An example of an
+ * indirect task is one that involves importing a Shapefile into an existing
+ * PostGIS database. Another example of indirect task might involve taking a
+ * CSV file as an input, turning a x and y column into a Point, remapping a
+ * string column into a timestamp, and finally import the result into a PostGIS.
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+@JsonRootName(value = "task")
+public class RESTImportTask extends AbstractRESTEntity {
+
+    /**
+     *
+     */
+    private Integer id;
+
+    /**
+     *
+     */
+    private String href;
+
+    /**
+     *
+     */
+    private String state;
+
+    /**
+     *
+     */
+    private String updateMode;
+
+    /**
+     *
+     */
+    private RESTData data;
+
+    /**
+     *
+     */
+    private RESTTarget target;
+
+    /**
+     *
+     */
+    private String progress;
+
+    /**
+     *
+     */
+    private RESTLayer layer;
+
+    /**
+     *
+     */
+    private String errorMessage;
+
+    /**
+     *
+     */
+    private RESTTransformChain transformChain;
+
+    /**
+     * Default constructor.
+     */
+    public RESTImportTask() {
+
+    }
+
+    /**
+     * @return the id
+     */
+    public Integer getId() {
+        return id;
+    }
+
+    /**
+     * @param id the id to set
+     */
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    /**
+     * @return the href
+     */
+    public String getHref() {
+        return href;
+    }
+
+    /**
+     * @param href the href to set
+     */
+    public void setHref(String href) {
+        this.href = href;
+    }
+
+    /**
+     * @return the state
+     */
+    public String getState() {
+        return state;
+    }
+
+    /**
+     * @param state the state to set
+     */
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    /**
+     * @return the updateMode
+     */
+    public String getUpdateMode() {
+        return updateMode;
+    }
+
+    /**
+     * @param updateMode the updateMode to set
+     */
+    public void setUpdateMode(String updateMode) {
+        this.updateMode = updateMode;
+    }
+
+    /**
+     * @return the data
+     */
+    public RESTData getData() {
+        return data;
+    }
+
+    /**
+     * @param data the data to set
+     */
+    public void setData(RESTData data) {
+        this.data = data;
+    }
+
+    /**
+     * @return the target
+     */
+    public RESTTarget getTarget() {
+        return target;
+    }
+
+    /**
+     * @param target the target to set
+     */
+    public void setTarget(RESTTarget target) {
+        this.target = target;
+    }
+
+    /**
+     * @return the progress
+     */
+    public String getProgress() {
+        return progress;
+    }
+
+    /**
+     * @param progress the progress to set
+     */
+    public void setProgress(String progress) {
+        this.progress = progress;
+    }
+
+    /**
+     * @return the layer
+     */
+    public RESTLayer getLayer() {
+        return layer;
+    }
+
+    /**
+     * @param layer the layer to set
+     */
+    public void setLayer(RESTLayer layer) {
+        this.layer = layer;
+    }
+
+    /**
+     * @return the errorMessage
+     */
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    /**
+     * @param errorMessage the errorMessage to set
+     */
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    /**
+     * @return the transformChain
+     */
+    public RESTTransformChain getTransformChain() {
+        return transformChain;
+    }
+
+    /**
+     * @param transformChain the transformChain to set
+     */
+    public void setTransformChain(RESTTransformChain transformChain) {
+        this.transformChain = transformChain;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTImportTaskList.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTImportTaskList.java
@@ -1,0 +1,25 @@
+package de.terrestris.shogun.importer.dto;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+import java.util.ArrayList;
+
+/**
+ * terrestris GmbH & Co. KG
+ *
+ * @author ahenn
+ * @date 15.04.2016
+ */
+@JsonRootName("tasks")
+public class RESTImportTaskList extends ArrayList<RESTImportTask> {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 1L;
+
+    public RESTImportTaskList() {
+
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTLayer.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTLayer.java
@@ -1,0 +1,238 @@
+package de.terrestris.shogun.importer.dto;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+import java.util.List;
+
+/**
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+@JsonRootName(value = "layer")
+public class RESTLayer extends AbstractRESTEntity {
+
+    /**
+     *
+     */
+    private String name;
+
+    /**
+     *
+     */
+    private String href;
+
+    /**
+     *
+     */
+    private String title;
+
+    /**
+     *
+     */
+    private String description;
+
+    /**
+     *
+     */
+    private String originalName;
+
+    /**
+     *
+     */
+    private String nativeName;
+
+    /**
+     *
+     */
+    private String srs;
+
+    /**
+     *
+     */
+    private RESTBoundingBox bbox;
+
+    /**
+     *
+     */
+    private List<RESTAttribute> attributes;
+
+    /**
+     *
+     */
+    private RESTStyle style;
+
+    /**
+     * Default constructor.
+     */
+    public RESTLayer() {
+
+    }
+
+    /**
+     * @param name
+     * @param href
+     * @param title
+     * @param originalName
+     * @param nativeName
+     * @param srs
+     * @param bbox
+     * @param attributes
+     * @param style
+     */
+    public RESTLayer(String name, String href, String title, String description,
+                     String originalName, String nativeName, String srs,
+                     RESTBoundingBox bbox, List<RESTAttribute> attributes,
+                     RESTStyle style) {
+        this.name = name;
+        this.href = href;
+        this.title = title;
+        this.description = description;
+        this.originalName = originalName;
+        this.nativeName = nativeName;
+        this.srs = srs;
+        this.bbox = bbox;
+        this.attributes = attributes;
+        this.style = style;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the href
+     */
+    public String getHref() {
+        return href;
+    }
+
+    /**
+     * @param href the href to set
+     */
+    public void setHref(String href) {
+        this.href = href;
+    }
+
+    /**
+     * @return the title
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * @param title the title to set
+     */
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    /**
+     * @return the description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * @param description the description to set
+     */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     * @return the originalName
+     */
+    public String getOriginalName() {
+        return originalName;
+    }
+
+    /**
+     * @param originalName the originalName to set
+     */
+    public void setOriginalName(String originalName) {
+        this.originalName = originalName;
+    }
+
+    /**
+     * @return the nativeName
+     */
+    public String getNativeName() {
+        return nativeName;
+    }
+
+    /**
+     * @param nativeName the nativeName to set
+     */
+    public void setNativeName(String nativeName) {
+        this.nativeName = nativeName;
+    }
+
+    /**
+     * @return the srs
+     */
+    public String getSrs() {
+        return srs;
+    }
+
+    /**
+     * @param srs the srs to set
+     */
+    public void setSrs(String srs) {
+        this.srs = srs;
+    }
+
+    /**
+     * @return the bbox
+     */
+    public RESTBoundingBox getBbox() {
+        return bbox;
+    }
+
+    /**
+     * @param bbox the bbox to set
+     */
+    public void setBbox(RESTBoundingBox bbox) {
+        this.bbox = bbox;
+    }
+
+    /**
+     * @return the attributes
+     */
+    public List<RESTAttribute> getAttributes() {
+        return attributes;
+    }
+
+    /**
+     * @param attributes the attributes to set
+     */
+    public void setAttributes(List<RESTAttribute> attributes) {
+        this.attributes = attributes;
+    }
+
+    /**
+     * @return the style
+     */
+    public RESTStyle getStyle() {
+        return style;
+    }
+
+    /**
+     * @param style the style to set
+     */
+    public void setStyle(RESTStyle style) {
+        this.style = style;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTReprojectTransform.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTReprojectTransform.java
@@ -1,0 +1,80 @@
+package de.terrestris.shogun.importer.dto;
+
+/**
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+//@JsonRootName
+public class RESTReprojectTransform extends RESTTransform {
+
+    /**
+     * constant field for transform type name
+     */
+    public static final String TYPE_NAME = "ReprojectTransform";
+
+    /**
+     *
+     */
+    private String href;
+
+    /**
+     *
+     */
+    private String source;
+
+    /**
+     *
+     */
+    private String target;
+
+    /**
+     * Default constructor; sets <code>type</code> of
+     * {@link RESTTransform} to "ReprojectTransform"
+     */
+    public RESTReprojectTransform() {
+        super(TYPE_NAME);
+    }
+
+    /**
+     * @return the source
+     */
+    public String getSource() {
+        return source;
+    }
+
+    /**
+     * @param source the source to set
+     */
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    /**
+     * @return the target
+     */
+    public String getTarget() {
+        return target;
+    }
+
+    /**
+     * @param target the target to set
+     */
+    public void setTarget(String target) {
+        this.target = target;
+    }
+
+    /**
+     * @return the href
+     */
+    public String getHref() {
+        return href;
+    }
+
+    /**
+     * @param href the href to set
+     */
+    public void setHref(String href) {
+        this.href = href;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTStore.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTStore.java
@@ -1,0 +1,67 @@
+package de.terrestris.shogun.importer.dto;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+/***
+ *
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ *
+ */
+@JsonRootName(value = "dataStore")
+public class RESTStore extends AbstractRESTEntity {
+
+    /**
+     *
+     */
+    private String name;
+
+    /**
+     *
+     */
+    private String type;
+
+    /**
+     * Default constructor.
+     */
+    public RESTStore() {
+
+    }
+
+    /**
+     * @param name
+     */
+    public RESTStore(String name) {
+        super();
+        this.name = name;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the type
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @param type the type to set
+     */
+    public void setType(String type) {
+        this.type = type;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTStyle.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTStyle.java
@@ -1,0 +1,63 @@
+package de.terrestris.shogun.importer.dto;
+
+/**
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+public class RESTStyle extends AbstractRESTEntity {
+
+    /**
+     *
+     */
+    private String name;
+
+    /**
+     *
+     */
+    private String href;
+
+    /**
+     * Default constructor.
+     */
+    public RESTStyle() {
+
+    }
+
+    /**
+     * @param name
+     * @param href
+     */
+    public RESTStyle(String name, String href) {
+        this.name = name;
+        this.href = href;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the href
+     */
+    public String getHref() {
+        return href;
+    }
+
+    /**
+     * @param href the href to set
+     */
+    public void setHref(String href) {
+        this.href = href;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTTarget.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTTarget.java
@@ -1,0 +1,47 @@
+package de.terrestris.shogun.importer.dto;
+
+/**
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+public class RESTTarget extends AbstractRESTEntity {
+
+    /**
+     *
+     */
+    private String href;
+
+    /**
+     *
+     */
+    private RESTDataStore dataStore;
+
+    /**
+     * @return the href
+     */
+    public String getHref() {
+        return href;
+    }
+
+    /**
+     * @param href the href to set
+     */
+    public void setHref(String href) {
+        this.href = href;
+    }
+
+    /**
+     * @return the dataStore
+     */
+    public RESTDataStore getDataStore() {
+        return dataStore;
+    }
+
+    /**
+     * @param dataStore the dataStore to set
+     */
+    public void setDataStore(RESTDataStore dataStore) {
+        this.dataStore = dataStore;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTTargetDataStore.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTTargetDataStore.java
@@ -1,0 +1,43 @@
+package de.terrestris.shogun.importer.dto;
+
+/**
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+public class RESTTargetDataStore extends AbstractRESTEntity {
+
+    /**
+     *
+     */
+    private RESTDataStore dataStore;
+
+    /**
+     * Default constructor.
+     */
+    public RESTTargetDataStore() {
+
+    }
+
+    /**
+     * @param name
+     * @param type
+     */
+    public RESTTargetDataStore(String name, String type) {
+        this.dataStore = new RESTDataStore(name, type);
+    }
+
+    /**
+     * @return the dataStore
+     */
+    public RESTDataStore getDataStore() {
+        return dataStore;
+    }
+
+    /**
+     * @param dataStore the dataStore to set
+     */
+    public void setDataStore(RESTDataStore dataStore) {
+        this.dataStore = dataStore;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTTargetWorkspace.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTTargetWorkspace.java
@@ -1,0 +1,42 @@
+package de.terrestris.shogun.importer.dto;
+
+/**
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+public class RESTTargetWorkspace extends AbstractRESTEntity {
+
+    /**
+     *
+     */
+    private RESTWorkspace workspace;
+
+    /**
+     * Default constructor.
+     */
+    public RESTTargetWorkspace() {
+
+    }
+
+    /**
+     * @param name
+     */
+    public RESTTargetWorkspace(String name) {
+        this.workspace = new RESTWorkspace(name);
+    }
+
+    /**
+     * @return the workspace
+     */
+    public RESTWorkspace getWorkspace() {
+        return workspace;
+    }
+
+    /**
+     * @param workspace the workspace to set
+     */
+    public void setWorkspace(RESTWorkspace workspace) {
+        this.workspace = workspace;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTTransform.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTTransform.java
@@ -1,0 +1,42 @@
+package de.terrestris.shogun.importer.dto;
+
+/**
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+public class RESTTransform extends AbstractRESTEntity {
+
+    /**
+     *
+     */
+    private String type;
+
+    /**
+     * Default constructor
+     */
+    public RESTTransform() {
+
+    }
+
+    /**
+     * @param type
+     */
+    public RESTTransform(String type) {
+        this.type = type;
+    }
+
+    /**
+     * @return the type
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @param type the type to set
+     */
+    public void setType(String type) {
+        this.type = type;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTTransformChain.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTTransformChain.java
@@ -1,0 +1,56 @@
+package de.terrestris.shogun.importer.dto;
+
+import java.util.List;
+
+/**
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+public class RESTTransformChain extends AbstractRESTEntity {
+
+    /**
+     *
+     */
+    private String type;
+
+    /**
+     *
+     */
+    private List<RESTTransform> transforms;
+
+    /**
+     * Default constructor.
+     */
+    public RESTTransformChain() {
+
+    }
+
+    /**
+     * @return the type
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @param type the type to set
+     */
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    /**
+     * @return the transforms
+     */
+    public List<RESTTransform> getTransforms() {
+        return transforms;
+    }
+
+    /**
+     * @param transforms the transforms to set
+     */
+    public void setTransforms(List<RESTTransform> transforms) {
+        this.transforms = transforms;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTWorkspace.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/dto/RESTWorkspace.java
@@ -1,0 +1,45 @@
+package de.terrestris.shogun.importer.dto;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+
+/**
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+@JsonRootName(value = "workspace")
+public class RESTWorkspace extends AbstractRESTEntity {
+
+    /**
+     *
+     */
+    private String name;
+
+    /**
+     * Default constructor.
+     */
+    public RESTWorkspace() {
+
+    }
+
+    /**
+     * @param name
+     */
+    public RESTWorkspace(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name the name to set
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/exception/GeoServerRESTImporterException.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/exception/GeoServerRESTImporterException.java
@@ -1,0 +1,42 @@
+package de.terrestris.shogun.importer.exception;
+
+/**
+ * @author Daniel Koch
+ * @author terrestris GmbH & Co. KG
+ */
+public class GeoServerRESTImporterException extends Exception {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     *
+     */
+    public GeoServerRESTImporterException() {
+    }
+
+    /**
+     * @param message
+     */
+    public GeoServerRESTImporterException(String message) {
+        super(message);
+    }
+
+    /**
+     * @param cause
+     */
+    public GeoServerRESTImporterException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * @param message
+     * @param cause
+     */
+    public GeoServerRESTImporterException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/service/ImporterService.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/service/ImporterService.java
@@ -1,0 +1,1233 @@
+package de.terrestris.shogun.importer.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.opencsv.CSVReader;
+import de.terrestris.shogun.importer.GeoServerRESTImporter;
+import de.terrestris.shogun.importer.config.properties.ImporterProperties;
+import de.terrestris.shogun.importer.dto.*;
+import de.terrestris.shogun.importer.exception.GeoServerRESTImporterException;
+import de.terrestris.shogun.importer.transformer.VectorFeatureTypeTransformer;
+import de.terrestris.shogun.importer.validator.TableNameValidator;
+import de.terrestris.shogun.lib.dto.HttpResponse;
+import de.terrestris.shogun.lib.enumeration.LayerType;
+import de.terrestris.shogun.lib.model.Layer;
+import de.terrestris.shogun.lib.model.User;
+import de.terrestris.shogun.lib.util.HttpUtil;
+import de.terrestris.shogun.lib.util.KeycloakUtil;
+import it.geosolutions.geoserver.rest.GeoServerRESTManager;
+import it.geosolutions.geoserver.rest.GeoServerRESTReader;
+import it.geosolutions.geoserver.rest.decoder.RESTCoverage;
+import it.geosolutions.geoserver.rest.decoder.RESTFeatureType;
+import it.geosolutions.geoserver.rest.encoder.GSLayerEncoder;
+import it.geosolutions.geoserver.rest.encoder.GSResourceEncoder;
+import it.geosolutions.geoserver.rest.encoder.coverage.GSCoverageEncoder;
+import it.geosolutions.geoserver.rest.encoder.feature.GSFeatureTypeEncoder;
+import lombok.extern.log4j.Log4j2;
+import net.lingala.zip4j.ZipFile;
+import org.apache.commons.fileupload.disk.DiskFileItem;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpException;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.entity.ContentType;
+import org.apache.http.message.BasicNameValuePair;
+import org.geotools.data.*;
+import org.geotools.data.crs.ReprojectFeatureResults;
+import org.geotools.data.shapefile.ShapefileDataStore;
+import org.geotools.data.shapefile.ShapefileDataStoreFactory;
+import org.geotools.data.shapefile.shp.JTSUtilities;
+import org.geotools.data.shapefile.shp.ShapeType;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureSource;
+import org.geotools.data.simple.SimpleFeatureStore;
+import org.geotools.data.store.ContentFeatureSource;
+import org.geotools.data.wfs.WFSDataStore;
+import org.geotools.data.wfs.WFSDataStoreFactory;
+import org.geotools.feature.FeatureCollection;
+import org.geotools.feature.SchemaException;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.jdbc.JDBCDataStore;
+import org.geotools.referencing.CRS;
+import org.geotools.util.factory.Hints;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.AttributeDescriptor;
+import org.opengis.feature.type.GeometryDescriptor;
+import org.opengis.feature.type.Name;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.TransformException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.commons.CommonsMultipartFile;
+
+import java.io.*;
+import java.net.URISyntaxException;
+import java.util.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+@Service
+@Log4j2
+public class ImporterService {
+
+    private static final String EXPECTED_CSV_ENCODING = "UTF-8";
+    private static final String NAME_OF_ABSCISSA = "X";
+    private static final String NAME_OF_ORDINATE = "Y";
+    private static final String NAME_OF_GEOMETRY = "the_geom";
+    private static final String GEOTOOLS_PT_HEADER = NAME_OF_GEOMETRY + ":Point";
+    private static final String DEFAULT_WFS_VERSION = "1.1.0";
+    private static final String WFS_MAX_FEATURES = "0"; // 0 = no limit
+    private static final String WFS_IMPORT_TABLE_PREFIX = "WFS_IMP";
+    private static char CSVFIELDDIVIDERCHAR = ';';
+    private static char CSVQUOTECHAR = '\'';
+
+    @Autowired
+    private GeoServerRESTImporter geoServerImporter;
+
+    @Autowired
+    private GeoServerRESTManager geoServerManager;
+
+    @Autowired
+    private ImporterProperties importerProperties;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private KeycloakUtil keycloakUtil;
+
+    /**
+     * @param file
+     * @param fileProjection
+     * @param layerType
+     * @return
+     * @throws Exception
+     */
+    public Map<String, Object> importGeodataAndCreateLayer(
+        MultipartFile file,
+        String fileProjection,
+        String layerType
+    ) throws Exception {
+        Map<String, Object> responseMap = new HashMap<>();
+
+        // 1. Check if a CSV file has been uploaded. If true => transform to shapefile.
+        if (StringUtils.containsIgnoreCase(file.getContentType(), "text/csv") ||
+            StringUtils.containsIgnoreCase(file.getContentType(), "text/plain")) {
+            file = this.createShapeFileForCsv(file);
+        } else if (layerType.equalsIgnoreCase("vector")) {
+            // 2. Transform to geometry to 2D if 3D data is contained
+            file = reduceTo2d(file);
+        }
+
+        // 3. Create the import job.
+        RESTImport restImport = null;
+        if (layerType.equalsIgnoreCase("vector")) {
+            restImport = this.geoServerImporter.createImportJob(
+                this.importerProperties.getTargetWorkspace(),
+                this.importerProperties.getVector().getTargetDatastore()
+            );
+        } else if (layerType.equalsIgnoreCase("raster")) {
+            restImport = this.geoServerImporter.createImportJob(
+                this.importerProperties.getTargetWorkspace(), null);
+        } else {
+            throw new GeoServerRESTImporterException("Invalid layerType given. " +
+                "Valid options are: vector, raster");
+        }
+
+        // 4. Upload the import file.
+        Integer importJobId = restImport.getId();
+        RESTImportTaskList importTasks = null;
+        importTasks = this.uploadZipFile(importJobId, file, fileProjection);
+
+        if (importTasks == null) {
+            throw new GeoServerRESTImporterException("Import task could not be created.");
+        }
+
+        // 5. Check if we need to set the SRS of the import layer manually.
+        RESTImportTaskList tasksWithoutProjection = new RESTImportTaskList(); //this.checkSrsOfImportTasks(importTasks);
+
+        // 6. Add transform tasks.
+        try {
+            createTransformTasks(fileProjection, layerType, importJobId, importTasks);
+        } catch (GeoServerRESTImporterException gsrie) {
+            // TODO what happens if more than one importTasks are contained here?
+            tasksWithoutProjection.addAll(importTasks);
+        }
+
+        // Redefine broken tasks
+        if (tasksWithoutProjection.size() > 0 && StringUtils.isEmpty(fileProjection)) {
+            responseMap.put("success", false);
+            responseMap.put("message", "NO_CRS or invalid CRS (EPSG:404000) detected and "
+                + "no fileProjection is given.");
+            responseMap.put("importJobId", importJobId);
+            responseMap.put("tasksWithoutProjection", tasksWithoutProjection);
+            responseMap.put("error", "NO_CRS");
+
+            return responseMap;
+        }
+
+        // 7. Run the import and create the SHOGun layer.
+        responseMap = runJobAndCreateLayer(file.getOriginalFilename(), layerType, importJobId, false);
+
+        return responseMap;
+    }
+
+    /**
+     * Content of the shapefile within the ZIP will be transformed to 2D
+     *
+     * @param shapeFile
+     * @return
+     * @throws Exception
+     */
+    private MultipartFile reduceTo2d(MultipartFile shapeFile) throws Exception {
+        final String outputFolderPath = FileUtils.getTempDirectoryPath() + File.separator + System.currentTimeMillis();
+        final File outputFolder = new File(outputFolderPath);
+        if (!outputFolder.exists()) {
+            outputFolder.mkdir();
+        }
+        final String originalFileName = shapeFile.getOriginalFilename();
+        File file = new File(outputFolder + File.separator + originalFileName);
+        shapeFile.transferTo(file);
+        ZipFile zipFile = new ZipFile(file);
+        zipFile.extractAll(outputFolderPath);
+
+        Collection<File> containedShapes = FileUtils.listFiles(outputFolder, new String[]{"shp"}, false);
+        File firstMatchingFile = containedShapes.stream().findFirst().get();
+        FileDataStore store = FileDataStoreFinder.getDataStore(firstMatchingFile);
+        SimpleFeatureSource featureSource = store.getFeatureSource();
+
+        // check if 2D
+        final SimpleFeatureType featureType = store.getSchema();
+        GeometryDescriptor geomDescr = featureType.getGeometryDescriptor();
+        ShapeType shapeType = JTSUtilities.getShapeType(geomDescr);
+        log.debug("Shapefile has following shape type: " + shapeType);
+
+        log.info("Shapefile contains 3D data. Will map data to 2D.");
+        // read in the 2D geometries only
+        Query query = new Query("features");
+        query.setHints(new Hints(Hints.FEATURE_2D, true));
+        SimpleFeatureCollection featureCollection = featureSource.getFeatures(query);
+        return createShapeZipForFeatureCollection(featureType.getTypeName(), featureType, featureCollection);
+    }
+
+    /**
+     * Generate Shapefile (ZIP) containing points (ONLY!) based on CSV
+     *
+     * @param uploadedCsv {@link MultipartFile} which contains CSV
+     * @return {@link MultipartFile} containing ZIP file which shape (POINT)
+     * @throws Exception
+     */
+    private MultipartFile createShapeFileForCsv(MultipartFile uploadedCsv) throws Exception {
+        MultipartFile createdShapeZip;
+
+        long csvFileSize = uploadedCsv.getSize();
+        String csvFileName = uploadedCsv.getOriginalFilename();
+        String csvFileContentType = uploadedCsv.getContentType();
+        log.info("Trying to transform features of " + csvFileName);
+        log.debug("The Content-Type of the file is " + csvFileContentType + ". The file-size is " + csvFileSize + " bytes.");
+        String csvFileNameWithoutExtension = csvFileName;
+        if (csvFileNameWithoutExtension.contains(".")) {
+            csvFileNameWithoutExtension = csvFileNameWithoutExtension.substring(0, csvFileNameWithoutExtension.lastIndexOf("."));
+        }
+
+        Transaction transaction = null;
+
+        try (
+            InputStream is = uploadedCsv.getInputStream();
+            // TODO get rid of deprecated constructor
+            CSVReader reader = new CSVReader(new InputStreamReader(is, EXPECTED_CSV_ENCODING), CSVFIELDDIVIDERCHAR, CSVQUOTECHAR);
+        ) {
+            // HashMap to store the entries of the CSV file in
+            // Each line results in an entry of the HashMap
+            HashMap<String, HashMap<String, String>> retVals = new HashMap<>();
+
+            String[] nextLine;
+            int lineCounter = 0;
+            String[] header = null;
+
+            while ((nextLine = reader.readNext()) != null) {
+                if (lineCounter == 0) {
+                    header = nextLine;
+                    lineCounter++;
+                    continue;
+                }
+                HashMap<String, String> inlineObject = new HashMap<String, String>();
+
+                if (header.length != nextLine.length) {
+                    // this line will be ignored from import
+                    continue;
+                }
+
+                for (int i = 0; i < nextLine.length; i++) {
+                    inlineObject.put(header[i].trim().replace("'", "").toLowerCase(),
+                        nextLine[i].trim().replace("'", ""));
+                }
+                retVals.put("Object_" + lineCounter, inlineObject);
+                lineCounter++;
+            }
+
+            String schemaName = "IMP_" + System.currentTimeMillis() + "_" + csvFileNameWithoutExtension;
+            if (!TableNameValidator.isValidName(schemaName)) {
+                schemaName = TableNameValidator.createValidTableName(schemaName);
+            }
+
+            // create feature type and feature collection
+            SimpleFeatureType featureTypeDefinition = createFeatureType(header, schemaName);
+            SimpleFeatureCollection featureCollection = createFeatureCollectionFromCsv(featureTypeDefinition, retVals);
+
+            createdShapeZip = createShapeZipForFeatureCollection(schemaName, featureTypeDefinition, featureCollection);
+        } finally {
+            // TODO this log is probably wrong because because we can also come to the finally
+            // block when an exception has been catched
+            log.debug("Created ZIP file containing shapefile based on CSV successfully.");
+            IOUtils.closeQuietly(transaction);
+        }
+
+        return createdShapeZip;
+    }
+
+    /**
+     * @param schemaName
+     * @param featureTypeDefinition
+     * @param featureCollection
+     * @return
+     * @throws IOException
+     */
+    private MultipartFile createShapeZipForFeatureCollection(String schemaName, SimpleFeatureType featureTypeDefinition, FeatureCollection featureCollection) throws IOException {
+        // Define temporary directories to put the shapefile in
+        File tmpDirBase = FileUtils.getTempDirectory();
+        String tmpDirBasePath = tmpDirBase.getAbsolutePath();
+        File newFile = new File(tmpDirBasePath + "/" + schemaName + ".shp");
+        Map<String, Serializable> params = new HashMap<>();
+        params.put("url", newFile.toURI().toURL());
+        params.put("create spatial index", Boolean.TRUE);
+
+        // create shapefile using datastore factory
+        ShapefileDataStoreFactory dataStoreFactory = new ShapefileDataStoreFactory();
+        ShapefileDataStore shapefileDataStore = (ShapefileDataStore) dataStoreFactory.createNewDataStore(params);
+        shapefileDataStore.createSchema(featureTypeDefinition);
+
+        /*
+         * Write the features to the shapefile
+         */
+        DefaultTransaction transaction = new DefaultTransaction("create");
+        String typeName = shapefileDataStore.getTypeNames()[0];
+        SimpleFeatureSource featureSource = shapefileDataStore.getFeatureSource(typeName);
+        SimpleFeatureType SHAPE_TYPE = featureSource.getSchema();
+
+        log.debug("Write temporary shapefile -- SHAPE:" + SHAPE_TYPE);
+        if (featureSource instanceof SimpleFeatureStore) {
+            SimpleFeatureStore featureStore = (SimpleFeatureStore) featureSource;
+            featureStore.setTransaction(transaction);
+            try {
+                featureStore.addFeatures(featureCollection);
+                transaction.commit();
+            } catch (Exception problem) {
+                log.debug("Could not add features to shapefile", problem);
+                transaction.rollback();
+            } finally {
+                transaction.close();
+            }
+            log.info("Successfully created shapefile. Will now pack it to a ZIP file...");
+            return createShapeZip(tmpDirBasePath, schemaName);
+        } else {
+            throw new IOException("Could not create appropriate shapefile datastore");
+        }
+    }
+
+    /**
+     * Generate multipart file (ZIP) for shapefile
+     *
+     * @param tempDir   path to temporary directory
+     * @param shapeName Name pof the shapefile
+     * @return MultipartFile representing ZIP file which contains parts of shapefile
+     * @throws IOException
+     */
+    private MultipartFile createShapeZip(String tempDir, String shapeName) throws IOException {
+        final String basePath = tempDir + "/";
+        final String zipFileName = basePath + shapeName + ".zip";
+        try (
+            FileOutputStream fos = new FileOutputStream(zipFileName);
+            ZipOutputStream zos = new ZipOutputStream(fos);
+        ) {
+            // only "shp", "dbf", "shx" should be included in ZIP file so that the user must set CRS manually
+            for (String ending : new String[]{"shp", "dbf", "shx", "prj"}) {
+                String fileName = basePath + shapeName + "." + ending;
+                File file = new File(fileName);
+                try (
+                    FileInputStream fis = new FileInputStream(file);
+                ) {
+                    ZipEntry zipEntry = new ZipEntry(shapeName + "." + ending);
+                    zos.putNextEntry(zipEntry);
+                    byte[] bytes = new byte[1024];
+                    int length;
+                    while ((length = fis.read(bytes)) >= 0) {
+                        zos.write(bytes, 0, length);
+                    }
+
+                    zos.closeEntry();
+                } finally {
+                    log.trace("Added " + fileName + " to ZIP file");
+                }
+            }
+            zos.finish();
+        } finally {
+            final File zipFile = new File(zipFileName);
+            final DiskFileItem diskFileItem = new DiskFileItem(
+                "file",
+                "application/zip",
+                true,
+                zipFile.getName(),
+                100000000,
+                zipFile.getParentFile()
+            );
+
+            InputStream input = new FileInputStream(zipFile);
+            OutputStream os = diskFileItem.getOutputStream();
+            IOUtils.copy(input, os);
+            os.close();
+
+            return new CommonsMultipartFile(diskFileItem);
+        }
+    }
+
+    /**
+     * Helper method creating feature collection
+     *
+     * @param featureTypeDefinition {@link SimpleFeatureType} of provided features
+     * @param retVals               {@link HashMap} representing features
+     * @return {@link SimpleFeatureCollection} feature collection
+     */
+    private SimpleFeatureCollection createFeatureCollectionFromCsv(SimpleFeatureType featureTypeDefinition, HashMap<String, HashMap<String, String>> retVals) {
+        ArrayList<SimpleFeature> featureList = new ArrayList<SimpleFeature>();
+        PrecisionModel precModel = new PrecisionModel(PrecisionModel.FLOATING);
+        GeometryFactory geomFactory = new GeometryFactory(precModel);
+
+        long internalId = 1;
+        for (String key : retVals.keySet()) {
+            String x, y;
+
+            HashMap<String, String> geoObject = retVals.get(key);
+            x = geoObject.get(NAME_OF_ABSCISSA.toLowerCase());
+            y = geoObject.get(NAME_OF_ORDINATE.toLowerCase());
+
+            if (StringUtils.isBlank(x) || StringUtils.isBlank(y)) {
+                log.warn("Object " + geoObject + " will be ignored from import since one/more coordinate(s) are empty.");
+                continue;
+            }
+
+            double xVal, yVal;
+            try {
+                xVal = Double.parseDouble(x);
+                yVal = Double.parseDouble(y);
+            } catch (NumberFormatException nfe) {
+                log.warn("Object " + geoObject
+                    + " will be ignored from import since one/more cordinates don't contain numerical values.");
+                continue;
+            }
+
+            Point pt = geomFactory.createPoint(new Coordinate(xVal, yVal));
+            SimpleFeatureBuilder featureBuilder = new SimpleFeatureBuilder(featureTypeDefinition);
+
+            // Iterate over featureType
+            List<AttributeDescriptor> attrDescrList = featureTypeDefinition.getAttributeDescriptors();
+            for (AttributeDescriptor attrDesc : attrDescrList) {
+                Name attributeName = attrDesc.getName();
+                if (attributeName.getLocalPart().equalsIgnoreCase(NAME_OF_GEOMETRY)) {
+                    featureBuilder.add(pt);
+                } else {
+                    String attrVal = geoObject.get(attributeName.getLocalPart().toLowerCase());
+                    featureBuilder.add(attrVal);
+                }
+            }
+
+            SimpleFeature feature = featureBuilder.buildFeature(Long.toString(internalId));
+            featureList.add(feature);
+
+            internalId++;
+        }
+
+        SimpleFeatureCollection featureCollection = DataUtilities.collection(featureList);
+        return featureCollection;
+    }
+
+    /**
+     * Generate feature type based on header information of CSV file
+     * Assumptions:
+     * * header row available
+     * * header contains X and Y
+     *
+     * @param header     String array with header description
+     * @param schemaName Name of shapefile
+     * @return SimpleFeature
+     * @throws SchemaException
+     */
+    private SimpleFeatureType createFeatureType(String[] header, String schemaName) throws SchemaException {
+
+        SimpleFeatureType featureTypeDefinition = null;
+
+        StringBuffer headerSb = new StringBuffer();
+        boolean containsXY = false;
+        for (String part : header) {
+
+            if (part.equalsIgnoreCase(NAME_OF_ORDINATE) || part.equalsIgnoreCase(NAME_OF_ABSCISSA)) {
+                containsXY = containsXY || part.equalsIgnoreCase(NAME_OF_ORDINATE)
+                    || part.equalsIgnoreCase(NAME_OF_ABSCISSA);
+                continue;
+            }
+
+            headerSb.append(part.toLowerCase() + ":String");
+            headerSb.append(",");
+        }
+
+        // Geometry needs to be at the first place
+        if (containsXY) {
+            headerSb.insert(0, GEOTOOLS_PT_HEADER + ",");
+            headerSb = headerSb.deleteCharAt(headerSb.length() - 1);
+            featureTypeDefinition = DataUtilities.createType(schemaName, headerSb.toString());
+        }
+        return featureTypeDefinition;
+    }
+
+    /**
+     * @param importJobId
+     * @param uploadFile
+     * @return
+     * @throws Exception
+     */
+    public RESTImportTaskList uploadZipFile(Integer importJobId, MultipartFile uploadFile,
+                                            String fileProjection) throws Exception {
+        File file = File.createTempFile("TMP_SHOGUN_UPLOAD_", uploadFile.getOriginalFilename());
+        uploadFile.transferTo(file);
+        RESTImportTaskList importTaskList = null;
+
+        try {
+            importTaskList = this.geoServerImporter.uploadFile(importJobId, file, fileProjection);
+        } finally {
+            file.delete();
+        }
+
+        return importTaskList;
+    }
+
+    /**
+     * Save the layer in SHOGun
+     *
+     * @param layerName     The layer name
+     * @param layerDataType The datatype of the layer
+     * @return
+     */
+    public Layer saveLayer(String layerName, String layerDataType) throws JsonProcessingException, UnsupportedEncodingException, HttpException, URISyntaxException, GeoServerRESTImporterException {
+        Layer layer = new Layer();
+        layer.setName(layerName);
+        layer.setType(LayerType.WMS);
+
+        Map<String, Object> sourceConfig = new HashMap<>();
+        sourceConfig.put("url", this.importerProperties.getInterceptorEndpoint());
+        sourceConfig.put("layerName", this.importerProperties.getTargetWorkspace() + ":" + layerName);
+
+        layer.setSourceConfig(sourceConfig);
+
+        String serializedLayer = objectMapper.writeValueAsString(layer);
+
+        // Save the layer
+        HttpResponse response = HttpUtil.post(
+            String.format("%s/layers", this.importerProperties.getShogun().getBaseUrl()),
+            serializedLayer,
+            ContentType.APPLICATION_JSON,
+            this.importerProperties.getShogun().getUsername(),
+            this.importerProperties.getShogun().getPassword(),
+            false
+        );
+
+        if (response == null || !response.getStatusCode().is2xxSuccessful()) {
+            throw new GeoServerRESTImporterException("Could not save layer in SHOGun: " + new String(response.getBody()));
+        }
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        keycloakUtil.getKeycloakUserIdFromAuthentication(authentication);
+
+//        projectLayerService.addAndSaveUserPermissions(layer, currentUser, Permission.ADMIN);
+//
+//        // Set the userpermissions for the newly created layer appearance.
+//        layerAppearanceService.addAndSaveUserPermissions(appearance, currentUser, Permission.ADMIN);
+//
+//        // Now insert special rules to always modify any OGC requests.
+//        this.projectInterceptorRuleService.createAllRelevantOgcRules(endpoint, RuleType.MODIFY);
+
+        return layer;
+    }
+
+    /**
+     * @param fileProjection
+     * @param layerType
+     * @param importJobId
+     * @param importTasks
+     * @throws Exception
+     */
+    private void createTransformTasks(String fileProjection, String layerType, Integer importJobId, RESTImportTaskList importTasks) throws Exception {
+
+        for (RESTImportTask importTask : importTasks) {
+            importTask = this.geoServerImporter.getRESTImportTask(importJobId, importTask.getId());
+            if (importTask.getState().equalsIgnoreCase("NO_CRS")) {
+                if (StringUtils.isEmpty(fileProjection)) {
+                    throw new GeoServerRESTImporterException(
+                        "Task state is \"NO_CRS\" and no custom projection found.");
+                }
+
+                log.debug("Try to set CRS definition for import task " + importTask.getId()
+                    + " of import job " + importJobId + " to " + fileProjection);
+
+                Integer importTaskId = importTask.getId();
+                RESTLayer updateLayer = new RESTLayer();
+                updateLayer.setSrs(fileProjection);
+
+                this.geoServerImporter.updateImportTask(importJobId, importTaskId, updateLayer);
+            }
+
+            Integer importTaskId = importTask.getId();
+
+            log.debug("Successfully created Task with ID " + importTaskId + " for ImportJob "
+                + importJobId);
+
+            if (layerType.equalsIgnoreCase("raster")) {
+                if (StringUtils.isEmpty(fileProjection)) {
+                    fileProjection = this.geoServerImporter.getLayer(importJobId, importTaskId).getSrs();
+                    if (StringUtils.isEmpty(fileProjection)) {
+                        String errMsg = "Could not determine the projection of the provided dataset, "
+                            + "please update the import job " + importJobId + " with an CRS to use.";
+                        log.debug(errMsg);
+                        throw new GeoServerRESTImporterException(errMsg);
+                    }
+                    if (StringUtils.equalsIgnoreCase(fileProjection, "EPSG:404000")) {
+                        String errMsg = "No valid CRS could be determined (\"EPSG:404000\"), "
+                            + "please update the import job " + importJobId + " with an CRS to use.";
+                        log.debug(errMsg);
+                        throw new GeoServerRESTImporterException(errMsg);
+                    }
+                }
+
+                // Calculate image transformation.
+                if (this.importerProperties.getRaster().getPerformGdalWarp()) {
+                    log.debug("Perform gdalwarp transform to target SRS during import");
+
+                    ArrayList<String> optsGdalWarp = new ArrayList<String>();
+                    optsGdalWarp.add("-s_srs");
+                    optsGdalWarp.add(fileProjection);
+
+                    optsGdalWarp.add("-t_srs");
+                    optsGdalWarp.add(this.importerProperties.getTargetEPSG());
+
+                    boolean warpTaskSuccess = this.geoServerImporter.createGdalWarpTask(importJobId, importTaskId, optsGdalWarp);
+                    if (warpTaskSuccess) {
+                        log.debug("Successfully created the GdalWarpTask.");
+                    } else {
+                        log.error("Could not create GdalWarpTask.");
+                    }
+                }
+
+                if (this.importerProperties.getRaster().getPerformGdalAddo()) {
+                    log.debug("Perform gdaladdo transform for levels: " + this.importerProperties.getRaster().getGdalAddoLevels());
+                    List<String> optsGdalAddo = Arrays.asList(new String[]{"-r", "cubic"});
+
+                    Boolean gdalAddoTaskSuccess = this.geoServerImporter.createGdalAddOverviewTask(importJobId, importTaskId,
+                        optsGdalAddo, this.importerProperties.getRaster().getGdalAddoLevels());
+                    if (gdalAddoTaskSuccess) {
+                        log.debug("Successfully created the gdalAddoTask.");
+                    } else {
+                        log.error("Could not create gdalAddoTask.");
+                    }
+                }
+
+            } else if (layerType.equalsIgnoreCase("vector")) {
+                log.debug("Create ReprojectTransformTask for vector layer");
+                Boolean transformTask = this.geoServerImporter.createReprojectTransformTask(importJobId,
+                    importTaskId, fileProjection, this.importerProperties.getTargetEPSG());
+                if (transformTask) {
+                    log.debug("Successfully created the TransformTask.");
+                } else {
+                    log.error("Could not create the TransformTask.");
+                }
+            }
+        }
+    }
+
+    /**
+     * @param layerName
+     * @param layerType
+     * @param importJobId
+     * @return
+     * @throws Exception
+     */
+    private Map<String, Object> runJobAndCreateLayer(String layerName, String layerType, Integer importJobId, Boolean updateBbox) throws Exception {
+        try {
+            Map<String, Object> responseMap = new HashMap<>();
+
+            Boolean respImp = false;
+            try {
+                HttpUtil.setHttpTimeout(this.importerProperties.getHttpTimeout());
+                // Run the import job (does not depend on layerType).
+                respImp = this.geoServerImporter.runImportJob(importJobId);
+            } finally {
+                HttpUtil.resetHttpTimeout();
+            }
+
+            if (respImp) {
+                log.info("Successfully run the Import Job with ID " + importJobId);
+            } else {
+                log.error("Error while running the import job.");
+                responseMap.put("success", false);
+                responseMap.put("message", "Error while running the import job.");
+            }
+
+            // at this point will persist/return the layer of the first successful import task
+            // since addition of multiple layers is not implemented in MM admin yet.
+            RESTLayer restLayer = null;
+            RESTImportTaskList restImportTasks = this.geoServerImporter.getRESTImportTasks(importJobId);
+            for (RESTImportTask restImportTask : restImportTasks) {
+                if (restImportTask.getState().equalsIgnoreCase("COMPLETE")) {
+                    restLayer = this.geoServerImporter.getLayer(importJobId, restImportTask.getId());
+                    break;
+                }
+                if (restImportTask.getState().equalsIgnoreCase("ERROR")) {
+                    RESTImportTask importTask = this.geoServerImporter.getRESTImportTask(importJobId, restImportTask.getId());
+                    log.error("Error while processing task with ID " + importTask.getId() + ". Error msg:" +
+                        importTask.getErrorMessage());
+                    throw new GeoServerRESTImporterException("Could not import dataset. Please contact admin");
+                }
+            }
+
+            if (restLayer != null) {
+
+                // If we had to override/force the CRS for an uploaded file, we might need to update
+                // the CRS in GeoServer.
+                // TODO Don't check for getPerformGdalWarp!!!!
+                if (this.importerProperties.getRaster().getPerformGdalWarp()) {
+                    updateReferencingForLayer(restLayer, updateBbox);
+                }
+
+                Layer layer = this.saveLayer(restLayer.getName(), layerType);
+
+                responseMap.put("success", true);
+                responseMap.put("data", layer);
+            } else {
+                responseMap.put("success", false);
+                responseMap.put("message", "No layer of imported dataset could be imported.");
+            }
+
+            return responseMap;
+        } finally {
+            try {
+                if (layerType.toLowerCase().equals("vector")) {
+                    this.deleteTemporaryShapeFiles(importJobId);
+                }
+            } catch (Exception e) {
+                log.info("Could not delete Layer data on the file system for layer: "
+                    + layerName);
+            }
+        }
+    }
+
+    /**
+     * @param importTasks
+     * @return
+     */
+    private RESTImportTaskList checkSrsOfImportTasks(RESTImportTaskList importTasks) {
+        RESTImportTaskList tasksWithoutProjection = new RESTImportTaskList();
+        for (RESTImportTask importTask : importTasks) {
+            if (!importTaskHasCrs(importTask)) {
+                tasksWithoutProjection.add(importTask);
+                log.debug("NO_CRS for importTask " + importTask.getId() + " found.");
+            }
+        }
+        return tasksWithoutProjection;
+    }
+
+    /**
+     * TODO: support all error codes:
+     * <p>
+     * PENDING, READY, RUNNING, NO_CRS, NO_BOUNDS, NO_FORMAT, BAD_FORMAT, ERROR, CANCELED, COMPLETE
+     *
+     * @param importTask
+     * @return
+     */
+    @SuppressWarnings("static-method")
+    private boolean importTaskHasCrs(RESTImportTask importTask) {
+        return !importTask.getState().equalsIgnoreCase("NO_CRS");
+    }
+
+    /**
+     * @param restLayer
+     */
+    private boolean updateReferencingForLayer(RESTLayer restLayer, Boolean updateBbox) throws URISyntaxException, HttpException, GeoServerRESTImporterException {
+
+        log.debug("Updating the referencing configuration of layer: " + restLayer.getName());
+
+        boolean success = false;
+
+        it.geosolutions.geoserver.rest.decoder.RESTLayer gsLayer = this.geoServerManager.getReader().getLayer(
+            this.importerProperties.getTargetWorkspace(), restLayer.getName());
+
+        if (gsLayer == null) {
+            throw new GeoServerRESTImporterException("Could not find layer " + restLayer.getName());
+        }
+
+        if (gsLayer.getTypeString().equalsIgnoreCase("raster")) {
+            RESTCoverage gsCoverage = this.geoServerManager.getReader().getCoverage(gsLayer);
+
+            String nativeCrs = gsCoverage.getNativeCRS();
+            if (!nativeCrs.equalsIgnoreCase(this.importerProperties.getTargetEPSG())) {
+                GSCoverageEncoder coverageEncoder = new GSCoverageEncoder();
+                coverageEncoder.setNativeCRS(this.importerProperties.getTargetEPSG());
+                coverageEncoder.setSRS(this.importerProperties.getTargetEPSG());
+                coverageEncoder.setProjectionPolicy(GSResourceEncoder.ProjectionPolicy.FORCE_DECLARED);
+
+                // update bbox as well
+                if (updateBbox) {
+                    final double maxX = gsCoverage.getNativeBoundingBox().getMaxX();
+                    final double minX = gsCoverage.getNativeBoundingBox().getMinX();
+                    final double maxY = gsCoverage.getNativeBoundingBox().getMaxY();
+                    final double minY = gsCoverage.getNativeBoundingBox().getMinY();
+                    coverageEncoder.setNativeBoundingBox(minX, minY, maxX, maxY, this.importerProperties.getTargetEPSG());
+                }
+
+                String coverageStoreName = gsCoverage.getStoreName();
+                if (StringUtils.contains(coverageStoreName, this.importerProperties.getTargetWorkspace())) {
+                    coverageStoreName = StringUtils.replace(coverageStoreName,
+                        this.importerProperties.getTargetWorkspace() + ":", "");
+                }
+
+                success = this.geoServerManager.getPublisher().configureCoverage(coverageEncoder,
+                    this.importerProperties.getTargetWorkspace(),
+                    coverageStoreName, gsCoverage.getName());
+            }
+        } else if (gsLayer.getTypeString().equalsIgnoreCase("vector")) {
+            RESTFeatureType gsFeatureType = this.geoServerManager.getReader().getFeatureType(gsLayer);
+
+            if (!gsFeatureType.getNativeCRS().equalsIgnoreCase(this.importerProperties.getTargetEPSG())) {
+                GSFeatureTypeEncoder featureTypeEncoder = new GSFeatureTypeEncoder();
+                featureTypeEncoder.setNativeCRS(this.importerProperties.getTargetEPSG());
+                featureTypeEncoder.setSRS(this.importerProperties.getTargetEPSG());
+                featureTypeEncoder.setProjectionPolicy(GSResourceEncoder.ProjectionPolicy.FORCE_DECLARED);
+
+                String dataStoreName = gsFeatureType.getStoreName();
+                if (StringUtils.contains(dataStoreName, this.importerProperties.getTargetWorkspace())) {
+                    dataStoreName = StringUtils.replace(dataStoreName,
+                        this.importerProperties.getTargetWorkspace() + ":", "");
+                }
+
+                success = this.configureFeatureType(featureTypeEncoder, this.importerProperties.getTargetWorkspace(),
+                    dataStoreName, gsFeatureType.getName());
+            }
+        } else {
+            log.debug("Unknown layer type given. Could not check if we had to update the CRS.");
+        }
+
+        if (success) {
+            log.debug("Successfully updated the referencing configuration of the layer.");
+        } else {
+            log.error("Could not update the referencing configuration of the layer.");
+        }
+
+        return success;
+    }
+
+    /**
+     * Imports the features of a given featureType out of the provided WFS server into
+     * the database and creates a GeoServer and SHOGun layer based on it.
+     *
+     * @param wfsUrl          The base URL of the WFS server to fetch the features from,
+     *                        e.g. "http://geoserver:8080/geoserver/ows". Required.
+     * @param wfsVersion      The WFS version to use, possible values are usually one of
+     *                        1.0.0, 1.1.0 or 2.0.0. If not set, {@link #DEFAULT_WFS_VERSION} will be used.
+     * @param featureTypeName The name of the featureType to fetch and import,
+     *                        e.g. "GDA_Wasser:OG_MESSSTELLEN_NETZ_BESCHRIFTUNG". Required.
+     * @param targetEpsg      The EPSG to be used for the imported features, e.g. "EPSG:3857".
+     *                        If not set, geoServerDefaultSrs will be used.
+     * @return The created SHOGun layer.
+     * @throws GeoServerRESTImporterException
+     */
+    // TODO Return layer
+    public void importWfsAndCreateLayer(String wfsUrl, String wfsVersion,
+                                                String featureTypeName, String targetEpsg) throws GeoServerRESTImporterException {
+
+        WFSDataStore wfsDataStore = null;
+
+        if (StringUtils.isEmpty(wfsVersion)) {
+            log.debug("No WFS version given, will use the default version " + DEFAULT_WFS_VERSION);
+            wfsVersion = DEFAULT_WFS_VERSION;
+        }
+
+        if (StringUtils.isEmpty(targetEpsg)) {
+            log.debug("No targetEpsg given, it will be set to the default one: " +
+                this.importerProperties.getTargetEPSG());
+            targetEpsg = this.importerProperties.getTargetEPSG();
+        }
+
+        try {
+            // 1. Create a WFS datastore that contains the given connection params.
+            wfsDataStore = this.createWfsDataStore(wfsUrl, wfsVersion);
+            // 2. Fetch the features from the given featureType using the store created above.
+            SimpleFeatureCollection featureCollection = this.getFeatureCollectionFromDataStore(
+                wfsDataStore, featureTypeName, targetEpsg);
+            // 3. Persist the featureCollection in the database.
+            String tableName = this.importFeatureCollectionToDatabase(featureCollection);
+            // 4. Publish the layer based on the DB table in GeoServer.
+            this.publishGeoServerLayerFromDbTable(tableName, featureTypeName, targetEpsg);
+            // 5. Persist the layer entitiy in SHOGun DB.
+            // TODO HTTP
+//            ProjectLayer layer = this.saveLayer(tableName.toUpperCase(), "vector");
+
+//            return layer;
+        } finally {
+            if (wfsDataStore != null) {
+                wfsDataStore.dispose();
+            }
+        }
+    }
+
+    /**
+     * Creates a {@link WFSDataStore} based on a WFS base URL and a version. The maximum
+     * number of features to be handled/fetched by this store is limited by {WFS_MAX_FEATURES}.
+     *
+     * @param wfsUrl     The base URL of the WFS server to fetch the features from.
+     * @param wfsVersion The WFS version to use.
+     * @return The created {@link WFSDataStore}.
+     * @throws GeoServerRESTImporterException
+     */
+    private WFSDataStore createWfsDataStore(String wfsUrl, String wfsVersion)
+        throws GeoServerRESTImporterException {
+
+        WFSDataStore wfsDataStore = null;
+
+        try {
+            WFSDataStoreFactory wfsFactory = new WFSDataStoreFactory();
+            Map<String, Serializable> wfsDataStoreParams = new HashMap<String, Serializable>();
+
+            List<BasicNameValuePair> wfsGetCapabilitiesQueryParams = new ArrayList<>();
+            wfsGetCapabilitiesQueryParams.add(new BasicNameValuePair(
+                "SERVICE", "WFS"));
+            wfsGetCapabilitiesQueryParams.add(new BasicNameValuePair(
+                "REQUEST", "GetCapabilities"));
+            wfsGetCapabilitiesQueryParams.add(new BasicNameValuePair(
+                "VERSION", wfsVersion));
+            String wfsGetCapabilitiesQueryString = URLEncodedUtils.format(
+                wfsGetCapabilitiesQueryParams, "UTF-8");
+            String wfsGetCapabilitiesUrl = wfsUrl + "?" + wfsGetCapabilitiesQueryString;
+            wfsDataStoreParams.put("WFSDataStoreFactory:GET_CAPABILITIES_URL", wfsGetCapabilitiesUrl);
+            wfsDataStoreParams.put("WFSDataStoreFactory:MAXFEATURES", WFS_MAX_FEATURES);
+
+            log.debug("Creating a WFS dataStore based on the following WFS GetCapabilities: " +
+                wfsGetCapabilitiesUrl);
+
+            wfsDataStore = wfsFactory.createDataStore(wfsDataStoreParams);
+
+            log.debug("Successfully created the WFS dataStore.");
+        } catch (IOException e) {
+            String errMsg = "Error while creating the WFS dataStore";
+            log.error(errMsg + ": ", e);
+            throw new GeoServerRESTImporterException(errMsg + ".");
+        }
+
+        return wfsDataStore;
+    }
+
+    /**
+     * Fetches the features from the given featureType of the {@link DataStore} in the
+     * provided EPSG.
+     *
+     * @param dataStore       The {@link DataStore} to fetch the features from.
+     * @param featureTypeName The featureType to fetch.
+     * @param targetEpsg      The EPSG of the returning collection.
+     * @return The {@link SimpleFeatureCollection} including the features.
+     * @throws GeoServerRESTImporterException
+     */
+    private SimpleFeatureCollection getFeatureCollectionFromDataStore(DataStore dataStore,
+                                                                      String featureTypeName, String targetEpsg) throws GeoServerRESTImporterException {
+
+        SimpleFeatureCollection featureCollection = null;
+        ContentFeatureSource source = null;
+        try {
+            source = (ContentFeatureSource) dataStore.getFeatureSource(featureTypeName);
+            featureCollection = source.getFeatures();
+
+            log.debug("Successfully fetched " + featureCollection.size() + " features " +
+                "from featureType " + featureTypeName);
+        } catch (IOException e) {
+            String errMsg = "Could not fetch the features from the provided dataStore";
+            log.error(errMsg + ": ", e);
+            throw new GeoServerRESTImporterException(errMsg + ".");
+        }
+
+        // Define the target CRS.
+        CoordinateReferenceSystem targetCrs;
+        try {
+            targetCrs = CRS.decode(targetEpsg);
+        } catch (FactoryException e) {
+            String errMsg = "Could not decode the targetEpsg";
+            log.error(errMsg + ": ", e);
+            throw new GeoServerRESTImporterException(errMsg + ".");
+        }
+
+        // Transform the features to target CRS if necessary.
+        CoordinateReferenceSystem sourceCrs = featureCollection.getSchema()
+            .getGeometryDescriptor().getCoordinateReferenceSystem();
+        if (!sourceCrs.equals(targetCrs)) {
+            try {
+                featureCollection = new ReprojectFeatureResults(
+                    featureCollection,
+                    targetCrs
+                );
+            } catch (NoSuchElementException | IOException | SchemaException |
+                TransformException | FactoryException e) {
+                String errMsg = "Could not reproject the feature collection";
+                log.error(errMsg + ": ", e);
+                throw new GeoServerRESTImporterException(errMsg + ".");
+            }
+        }
+
+        return featureCollection;
+    }
+
+    /**
+     * Imports a {@link SimpleFeatureCollection} into the designated import database.
+     * The connection parameters for the connection will be acquired from the
+     * targetDatastore in the GeoServer. Note: These parameters may be overridden
+     * by targetDatastoreConnParams!
+     *
+     * @param featureCollection The featureCollection to import.
+     * @return The name of the new table the features where imported in.
+     * @throws GeoServerRESTImporterException
+     */
+    private String importFeatureCollectionToDatabase(SimpleFeatureCollection featureCollection)
+        throws GeoServerRESTImporterException {
+
+        // Read old feature schema.
+        SimpleFeatureType schemaOrig = featureCollection.getSchema();
+        String origSchemaName = schemaOrig.getTypeName();
+        if (origSchemaName.contains(":")) {
+            origSchemaName = origSchemaName.replace(":", "_");
+        }
+
+        // Create DB schema / table definition with the following table name.
+        String schemaNameDB = WFS_IMPORT_TABLE_PREFIX + "_" + System.currentTimeMillis() + "_" + origSchemaName;
+        if (!TableNameValidator.isValidName(schemaNameDB)) {
+            schemaNameDB = TableNameValidator.createValidTableName(schemaNameDB);
+        }
+        schemaNameDB = schemaNameDB.toUpperCase();
+
+        VectorFeatureTypeTransformer featureTypeTransform = new VectorFeatureTypeTransformer(
+            schemaOrig, schemaNameDB, false);
+
+        it.geosolutions.geoserver.rest.decoder.RESTDataStore restDataStore = this.geoServerManager.getReader().getDatastore(
+            this.importerProperties.getTargetWorkspace(),
+            this.importerProperties.getVector().getTargetDatastore()
+        );
+        Map<String, String> dbParameters = restDataStore.getConnectionParameters();
+        dbParameters.putAll(this.importerProperties.getVector().getTargetDatastoreConnectionParams());
+
+        String errMsg = "Could not write the features to database";
+        JDBCDataStore jdbcDatastore = null;
+        try {
+            // Create JDBC datastore out of the given connection params.
+            jdbcDatastore = (JDBCDataStore) DataStoreFinder.getDataStore(dbParameters);
+
+            if (jdbcDatastore == null) {
+                final String message = "Could not create jdbc datastore based on given dbParameters for WFS import. "
+                    + "Are you sure that you have all necessary dependencies "
+                    + "(like gt-jdbc-oracle or gt-jdbc-postgis)?";
+                log.error(message);
+                throw new Exception(message);
+            }
+
+            // Create DB schema.
+            featureTypeTransform.createSchema();
+            // Apply new schema to features.
+            List<SimpleFeature> updatedFeatures = featureTypeTransform.createFeatureList(featureCollection);
+            // Write features to database.
+            boolean res = featureTypeTransform.toDataStore(jdbcDatastore, updatedFeatures);
+            if (res) {
+                log.info("Succesfully wrote the features to database in table " + schemaNameDB);
+            } else {
+                throw new GeoServerRESTImporterException(errMsg + ".");
+            }
+        } catch (Exception e) {
+            log.error(errMsg + ": ", e);
+            throw new GeoServerRESTImporterException(errMsg + ".");
+        } finally {
+            if (jdbcDatastore != null) {
+                jdbcDatastore.dispose();
+            }
+        }
+
+        return schemaNameDB;
+    }
+
+    /**
+     * @param tableName
+     * @param layerTitle
+     */
+    private boolean publishGeoServerLayerFromDbTable(String tableName, String layerTitle,
+                                                     String targetEpsg) {
+        GSFeatureTypeEncoder gsfte = new GSFeatureTypeEncoder();
+        gsfte.setName(tableName.toUpperCase());
+        gsfte.setTitle(layerTitle);
+        gsfte.setNativeCRS(targetEpsg);
+        gsfte.setSRS(targetEpsg);
+        gsfte.setProjectionPolicy(GSResourceEncoder.ProjectionPolicy.NONE);
+
+        GSLayerEncoder layerEncoder = new GSLayerEncoder();
+        layerEncoder.setEnabled(true);
+
+        boolean success = this.geoServerManager.getPublisher().publishDBLayer(
+            this.importerProperties.getTargetWorkspace(),
+            this.importerProperties.getVector().getTargetDatastore(), gsfte, layerEncoder);
+
+        return success;
+    }
+
+    /**
+     * @param layerName
+     * @param layerType
+     * @param importJobId
+     * @param taskId
+     * @param fileProjection
+     * @return
+     * @throws Exception
+     */
+    public Map<String, Object> updateCrsForImport(String layerName, String layerType,
+                                                  Integer importJobId, Integer taskId, String fileProjection)
+        throws Exception {
+        RESTLayer updateLayer = new RESTLayer();
+        updateLayer.setSrs(fileProjection);
+
+        this.geoServerImporter.updateImportTask(importJobId, taskId, updateLayer);
+
+        RESTImportTaskList importTaskList = this.geoServerImporter.getRESTImportTasks(importJobId);
+        createTransformTasks(fileProjection, layerType, importJobId, importTaskList);
+        return this.runJobAndCreateLayer(layerName, layerType, importJobId, true);
+    }
+
+    /**
+     * @param importJobId
+     * @return
+     * @throws URISyntaxException
+     * @throws HttpException
+     */
+    public Map<String, Object> deleteImportJob(Integer importJobId)
+        throws URISyntaxException, HttpException {
+        Map<String, Object> responseMap = new HashMap<>();
+
+        if (this.geoServerImporter.deleteImportJob(importJobId)) {
+            responseMap.put("success", true);
+            responseMap.put("message", "Deleted ImportJob " + importJobId);
+        } else {
+            responseMap.put("success", false);
+            responseMap.put("message", "Could not delete ImportJob " + importJobId);
+        }
+
+        return responseMap;
+    }
+
+    /**
+     * @param importJobId
+     * @throws Exception
+     */
+    public void deleteTemporaryShapeFiles(Integer importJobId) throws Exception {
+        RESTData data = this.geoServerImporter.getDataOfImportTask(importJobId, 0);
+        String restUrl = this.importerProperties.getGeoserver().getBaseUrl();
+        restUrl += "/rest/resource/";
+
+        // something like /var/lib/tomcat7/webapps/geoserver/data/uploads/tmp638865446314869143
+        String fileUrl = data.getLocation();
+
+        fileUrl = fileUrl.substring(fileUrl.lastIndexOf("uploads/"));
+        restUrl += fileUrl;
+
+        HttpResponse layerDeleted = HttpUtil.delete(restUrl,
+            this.importerProperties.getGeoserver().getUsername(),
+            this.importerProperties.getGeoserver().getPassword()
+        );
+        if (layerDeleted.getStatusCode().is2xxSuccessful()) {
+            log.info("Successfully deleted Layer data on the file system: " + fileUrl);
+        } else {
+            throw new Exception("Could not delete Layer data on the file system: " + fileUrl);
+        }
+    }
+
+    /**
+     *
+     * @param featureTypeEncoder
+     * @param workspace
+     * @param dataStoreName
+     * @param featureTypeName
+     * @return
+     */
+    public boolean configureFeatureType(final GSFeatureTypeEncoder featureTypeEncoder,
+                                        final String workspace, final String dataStoreName, final String featureTypeName) throws URISyntaxException, HttpException {
+
+        if (featureTypeEncoder == null) {
+            log.error("Unable to configure a featureType without a GSFeatureTypeEncoder.");
+            return false;
+        }
+
+        if (StringUtils.isEmpty(workspace)) {
+            log.error("Unable to configure a featureType without a workspace name.");
+            return false;
+        }
+
+        if (StringUtils.isEmpty(dataStoreName)) {
+            log.error("Unable to configure a featureType without a dataStoreName name.");
+            return false;
+        }
+
+        if (StringUtils.isEmpty(featureTypeName)) {
+            log.error("Unable to configure a featureType without a featureTypeName name.");
+            return false;
+        }
+
+        GeoServerRESTReader reader = geoServerManager.getReader();
+
+        // Check if the featureType is available.
+        boolean existsFeatureType = reader.existsFeatureType(workspace, dataStoreName, featureTypeName);
+        if (!existsFeatureType) {
+            log.error("FeatureType does not exist in GeoServer!");
+            return false;
+        }
+
+        final String url = this.importerProperties.getGeoserver().getBaseUrl() + "/rest/workspaces/" + workspace +
+            "/datastores/" + dataStoreName + "/featuretypes/" + featureTypeName + ".xml";
+
+        final String xmlBody = featureTypeEncoder.toString();
+        final HttpResponse response = HttpUtil.put(
+            url,
+            xmlBody,
+            ContentType.APPLICATION_XML,
+            this.importerProperties.getGeoserver().getUsername(),
+            this.importerProperties.getGeoserver().getPassword(),
+            false
+        );
+
+        if (response == null || !response.getStatusCode().is2xxSuccessful()) {
+            log.error("Error configuring featureType " + workspace + ":" +
+                dataStoreName + ":" + featureTypeName + " (" + new String(response.getBody()) + ")");
+        } else {
+            log.debug("FeatureType successfully configured " + workspace + ":" +
+                dataStoreName + ": " + featureTypeName);
+        }
+
+        return response != null;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/transformer/VectorFeatureTypeTransformer.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/transformer/VectorFeatureTypeTransformer.java
@@ -1,0 +1,311 @@
+package de.terrestris.shogun.importer.transformer;
+
+import lombok.extern.log4j.Log4j2;
+import org.geotools.data.DataStore;
+import org.geotools.data.DefaultTransaction;
+import org.geotools.data.FeatureWriter;
+import org.geotools.data.Transaction;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.data.simple.SimpleFeatureSource;
+import org.geotools.feature.SchemaException;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.feature.type.AttributeTypeImpl;
+import org.geotools.feature.type.GeometryTypeImpl;
+import org.geotools.jdbc.JDBCDataStore;
+import org.geotools.referencing.CRS;
+import org.locationtech.jts.geom.Geometry;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.AttributeType;
+import org.opengis.referencing.FactoryException;
+import org.opengis.referencing.NoSuchAuthorityCodeException;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Class for transformation of shape features into features of a JDBC-data store
+ *
+ * @author Andre Henn
+ */
+@Log4j2
+public class VectorFeatureTypeTransformer {
+
+    public static int DEFAULT_SRID = -1;
+    public static CoordinateReferenceSystem DEFAULT_CRS;
+
+    private SimpleFeatureType sft_original;
+    private SimpleFeatureType sft_database;
+    private String tNameNew;
+    private HashMap<String, String> hashMapAttributeNamesOrig_After;
+    private HashMap<String, String> hashMapAttributeNamesDatatypes;
+
+    private boolean resetSchema;
+    private int successfullyImported;
+
+    /**
+     * Constructor
+     *
+     * @param sft_old   SimpleFeatureType of original data (e.g. shape file)
+     * @param schemaNew name of new schema (e.g. table name in db)
+     * @param reset     Should new data be appended to existing table (yes / no)
+     */
+    public VectorFeatureTypeTransformer(SimpleFeatureType sft_old, String schemaNew, boolean reset) {
+        this.sft_original = sft_old;
+        this.tNameNew = schemaNew;
+        this.hashMapAttributeNamesOrig_After = new HashMap<String, String>();
+        this.hashMapAttributeNamesDatatypes = new HashMap<String, String>();
+        this.resetSchema = reset;
+        this.successfullyImported = 0;
+
+        assert (DEFAULT_CRS != null);
+    }
+
+    /**
+     * Method to create the SimpleFeatureType
+     *
+     * @throws org.opengis.referencing.NoSuchAuthorityCodeException
+     * @throws org.geotools.feature.SchemaException
+     * @throws org.opengis.referencing.FactoryException
+     */
+    public void createSchema() throws NoSuchAuthorityCodeException, SchemaException, FactoryException {
+        createSchema(this.tNameNew);
+    }
+
+    /**
+     * Method to create the SimpleFeatureType
+     *
+     * @param nameNew name of the new SimpleFeatureType
+     * @throws org.geotools.feature.SchemaException
+     * @throws org.opengis.referencing.NoSuchAuthorityCodeException
+     * @throws org.opengis.referencing.FactoryException
+     */
+    public void createSchema(String nameNew) throws SchemaException, NoSuchAuthorityCodeException, FactoryException {
+
+        SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
+        CoordinateReferenceSystem crs = this.sft_original.getCoordinateReferenceSystem();
+
+        if (crs == null) {
+            crs = DEFAULT_CRS;
+            log.warn("DEFAULT CRS " + DEFAULT_CRS + " used for import!");
+        }
+
+        builder.setCRS(crs);
+        builder.setName(nameNew);
+
+        List<AttributeType> typen = this.sft_original.getTypes();
+        for (AttributeType at : typen) {
+            if (at instanceof GeometryTypeImpl) {
+                GeometryTypeImpl geom = (GeometryTypeImpl) at;
+                Class<?> binding = geom.getBinding();
+                String oldName = geom.getName().getLocalPart();
+                /* The shape file format has a couple limitations:
+                 * - "THE_GEOM" is always first, and used for the geometry attribute name
+                 * - "THE_GEOM" must be of type Point, MultiPoint, MuiltiLineString, MultiPolygon
+                 * - attribute name of geometry column has to be uppercase
+                 * - Attribute names are limited in length
+                 * - Not all data types are supported (example timestamp represented as Date)
+                 */
+                String mappedName = "THE_GEOM";
+                builder.setCRS(crs);
+                builder.add(mappedName, binding);
+                String simpleName = binding.getSimpleName();
+
+                // Add geometry.
+                this.hashMapAttributeNamesOrig_After.put(oldName, mappedName);
+                this.hashMapAttributeNamesDatatypes.put(mappedName, simpleName.toUpperCase());
+
+            } else if (at instanceof AttributeTypeImpl) {
+                AttributeTypeImpl atImpl = (AttributeTypeImpl) at;
+                String oldName = atImpl.getName().getLocalPart();
+                Class<?> binding = atImpl.getBinding();
+                builder.add(oldName, binding);
+                String simpleName = binding.getSimpleName();
+
+                this.hashMapAttributeNamesOrig_After.put(oldName, oldName);
+                this.hashMapAttributeNamesDatatypes.put(oldName, simpleName.toUpperCase());
+            }
+        }
+
+        final SimpleFeatureType dbSchemaNew = builder.buildFeatureType();
+        this.sft_database = dbSchemaNew;
+    }
+
+    /**
+     * Create list of {@link org.opengis.feature.simple.SimpleFeature} based on a given {@link org.geotools.data.simple.SimpleFeatureCollection}
+     * - for geometries that are not <code>null</code>
+     * - for new before constructed feature type
+     *
+     * @param featureCollection {@link org.geotools.feature.FeatureCollection} to be transformed
+     * @return {@link org.opengis.feature.simple.SimpleFeature} list
+     * @throws java.io.IOException
+     * @throws org.opengis.referencing.FactoryException
+     */
+    public List<SimpleFeature> createFeatureList(SimpleFeatureCollection featureCollection) throws IOException, FactoryException {
+        ArrayList<SimpleFeature> featureList = new ArrayList<SimpleFeature>();
+        SimpleFeatureIterator sfi = featureCollection.features();
+
+        SimpleFeatureBuilder featureBuilder = new SimpleFeatureBuilder(this.sft_database);
+
+        int sridDecoded = -1;
+        while (sfi.hasNext()) {
+            SimpleFeature sd = sfi.next();
+            if (sd == null) {
+                log.warn("SimpleFeature is null => ignored");
+                continue;
+            }
+            String id = sd.getID();
+            for (String oldKey : this.hashMapAttributeNamesOrig_After.keySet()) {
+                String newKey = this.hashMapAttributeNamesOrig_After.get(oldKey);
+                if (!newKey.equalsIgnoreCase("the_geom")) {
+                    Object objCurrent = sd.getAttribute(oldKey);
+                    if (objCurrent != null) {
+                        featureBuilder.set(newKey, objCurrent);
+                    } else {
+                        log.warn("Attribute (old key: " + oldKey + ") null / not found => ignored");
+                        continue;
+                    }
+                } else {
+                    Geometry gOld = (Geometry) sd.getDefaultGeometry();
+                    if (gOld == null) {
+                        log.warn("Geometry of feature " + sd + " is null / not found => feature ignored");
+                        continue;
+                    }
+
+                    // Check if SRID is set
+                    if (gOld.getSRID() == 0) {
+                        if (sridDecoded == -1) {
+                            Integer srid = CRS.lookupEpsgCode(this.sft_original
+                                .getCoordinateReferenceSystem(), true);
+                            if (srid != null) {
+                                sridDecoded = srid.intValue();
+                            } else {
+                                assert (DEFAULT_SRID > 0);
+                                sridDecoded = DEFAULT_SRID;
+                            }
+                        }
+                        gOld.setSRID(sridDecoded);
+                    }
+
+                    featureBuilder.set(newKey, gOld);
+                }
+            }
+            SimpleFeature featureNew = featureBuilder.buildFeature(id);
+            featureList.add(featureNew);
+
+        }
+        sfi.close();
+        return featureList;
+    }
+
+    /**
+     * Save {@link org.opengis.feature.simple.SimpleFeature} list in database (or another {@link org.geotools.data.DataStore})
+     *
+     * @param store           (JDBC)-Datastore
+     * @param featuresToWrite list of features
+     * @return <code>true</code> if insert was successful, <code>false</code> otherwise
+     * @throws java.io.IOException
+     */
+    public boolean toDataStore(DataStore store, List<SimpleFeature> featuresToWrite) throws IOException {
+
+        String typename = this.sft_database.getTypeName();
+        // Try to reset the schema.
+        if (this.resetSchema) {
+            try {
+                log.info("Reset schema");
+                store.removeSchema(typename);
+                log.info("done.");
+            } catch (IllegalArgumentException iae) {
+                log.warn("Table: " + this.sft_database.getName() + " does not exist "
+                    + "in the database; no reset of the feature.");
+            }
+        }
+
+        try {
+            log.info("Create schema");
+            store.createSchema(this.sft_database);
+        } catch (IOException e) {
+            log.error("Error while creating the shema: ", e);
+
+            // TODO add option, if table should be created with another name
+            return false;
+        }
+
+        String typeName = typename.toUpperCase(); // oracle
+        SimpleFeatureSource featureSource = store.getFeatureSource(typeName);
+        SimpleFeatureType SHAPE_TYPE = featureSource.getSchema();
+        /*
+         * The Shapefile format has a couple limitations:
+         * - "the_geom" is always first, and used for the geometry attribute name
+         * - "the_geom" must be of type Point, MultiPoint, MuiltiLineString, MultiPolygon
+         * - Attribute names are limited in length
+         * - Not all data types are supported (example Timestamp represented as Date)
+         *
+         * Each data store has different limitations so check the resulting SimpleFeatureType.
+         */
+
+        log.info("Write SHAPE: " + SHAPE_TYPE);
+
+        if (store instanceof JDBCDataStore) {
+
+            JDBCDataStore jdbcDS = (JDBCDataStore) store;
+            Transaction transaction = new DefaultTransaction("Add features");
+
+            FeatureWriter<SimpleFeatureType, SimpleFeature> featureWriterDB =
+                jdbcDS.getFeatureWriterAppend(typeName, transaction);
+
+            try {
+                for (SimpleFeature feature : featuresToWrite) {
+                    SimpleFeature copy = featureWriterDB.next();
+                    copy.setAttributes(feature.getAttributes());
+
+                    Geometry geometry2 = (Geometry) feature.getDefaultGeometry();
+                    copy.setDefaultGeometry(geometry2);
+
+                    featureWriterDB.write();
+                    this.successfullyImported++;
+                }
+
+                transaction.commit();
+
+                log.info("Data of " + typename + " succesfully written to database.");
+            } catch (Exception e) {
+                log.error("Error while writing to the database: " + e);
+                transaction.rollback();
+            } finally {
+                featureWriterDB.close();
+                transaction.close();
+            }
+
+            return true;
+        } else {
+            log.error(typename + " does not support read/write access.");
+        }
+
+        return false;
+    }
+
+    /**
+     * <p>Getter for the field <code>hashMapAttributeNamesDatatypes</code>.</p>
+     *
+     * @return the hashMapAttributeNamesDatatypes
+     */
+    public HashMap<String, String> getHashMapAttributeNamesDatatypes() {
+        return hashMapAttributeNamesDatatypes;
+    }
+
+    /**
+     * <p>getNumberOfSuccessfullyImportedRecords.</p>
+     *
+     * @return number of successfully imported records to database / {@link org.geotools.data.DataStore}
+     */
+    public int getNumberOfSuccessfullyImportedRecords() {
+        return this.successfullyImported;
+    }
+
+}

--- a/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/validator/TableNameValidator.java
+++ b/shogun-gs-importer/src/main/java/de/terrestris/shogun/importer/validator/TableNameValidator.java
@@ -1,0 +1,58 @@
+package de.terrestris.shogun.importer.validator;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.regex.Pattern;
+
+/**
+ * @author Andre Henn
+ */
+public class TableNameValidator {
+
+    /**
+     * assumption only lower case letters
+     */
+    protected static final String[] SEARCH_ARRAY = {"ä", "ü", "ö", "ß", "õ", " ", ".-", "-", ",", "+", "´", "(", ")", ":"};
+    /**
+     * Constant <code>REPLACEMENT_ARRAY</code>
+     */
+    protected static final String[] REPLACEMENT_ARRAY = {"ae", "ue", "oe", "sz", "oe", "_", "", "_", "_", "u", "", "_", "_", "_"};
+
+    /**
+     * constant value of maximum table name length in db
+     */
+    private static int MAX_TABLE_NAME_WIDTH = 30;
+
+    /**
+     * Apply naming convention to the input string
+     * using {@link org.apache.commons.lang3.StringUtils}
+     *
+     * @param oldName input string
+     * @return converted string according to naming convention
+     */
+    public static String createValidTableName(String oldName) {
+
+        assert (SEARCH_ARRAY.length == REPLACEMENT_ARRAY.length) : "Search array and replacement array in class NamingConvention have different sizes: " + SEARCH_ARRAY.length + " vs. " + REPLACEMENT_ARRAY.length;
+
+        String lowerCaseString = StringUtils.lowerCase(oldName);
+        String val = StringUtils.replaceEachRepeatedly(lowerCaseString, SEARCH_ARRAY, REPLACEMENT_ARRAY);
+        if (val.length() > MAX_TABLE_NAME_WIDTH) {
+            val = StringUtils.left(val, MAX_TABLE_NAME_WIDTH);
+        }
+        return val;
+    }
+
+    /**
+     * check, if filename / tablename / attributename is valid
+     *
+     * @param s filename / tablename / attributename
+     * @return <code>true</code> valid; <code>false</code> not valid
+     */
+    public static boolean isValidName(String s) {
+        if (Pattern.matches("[a-z0-9\\.\\_\\/]+", s)) {
+            return true;
+        }
+        return false;
+    }
+}
+

--- a/shogun-gs-importer/src/main/resources/application.yml
+++ b/shogun-gs-importer/src/main/resources/application.yml
@@ -1,0 +1,57 @@
+spring:
+  profiles:
+    include: base
+    active: base, importer
+
+---
+spring:
+  profiles: importer
+
+server:
+  port: 8083
+  servlet:
+    context-path: /shogun-gs-importer
+
+importer:
+  geoserver:
+    baseUrl: http://localhost:8080/geoserver
+    username: admin
+    password: geoserver
+  shogun:
+    baseUrl: http://localhost:8080/shogun-boot
+    username: admin
+    password: shogun
+  raster:
+    performGdalAddo: true
+    gdalAddoLevels:
+      - 2
+      - 4
+      - 8
+      - 16
+    performGdalWarp: true
+  vector:
+    targetDatastore: IMPORT
+    targetDatastoreConnectionParams:
+      host: shogun-postgis
+      passwd: shogun
+      create spatial index: true
+      create index: true
+      Expose primary keys: false
+  targetWorkspace: SHOGUN
+  targetEPSG: EPSG:3857
+  interceptorEndpoint: geoserver.action
+  httpTimeout: 60000
+
+keycloak:
+  auth-server-url: http://localhost:8000/auth
+  realm: SpringBootKeycloak
+  resource: shogun-app
+  public-client: true
+  principal-attribute: preferred_username
+
+## TODO: use auth! / Token!
+keycloakauth:
+  username: admin
+  password: shogun
+  master-realm: master
+  admin-client: admin-cli

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/listener/LoginListener.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/listener/LoginListener.java
@@ -56,7 +56,7 @@ public class LoginListener implements ApplicationListener<InteractiveAuthenticat
             return;
         }
 
-        String keycloakUserId = SecurityContextUtil.getKeycloakUserIdFromAuthentication(authentication);
+        String keycloakUserId = keycloakUtil.getKeycloakUserIdFromAuthentication(authentication);
 
         // Add missing user to shogun db
         Optional<User> userOptional = userRepository.findByKeycloakId(keycloakUserId);


### PR DESCRIPTION
This adds a new submodule `shogun-gs-importer` for managing uploads to the GeoServer via the `importer` extension.

Basically this is a port of the existing code base found in [shogun-core](https://github.com/terrestris/shogun-core/tree/master/src/shogun-core-main/src/main/java/de/terrestris/shoguncore/importer).