### PR TITLE
Removes camelcase from userName in graphql schema

### DIFF
--- a/shogun-lib/src/main/resources/graphql/shogun.graphqls
+++ b/shogun-lib/src/main/resources/graphql/shogun.graphqls
@@ -36,7 +36,7 @@ type Layer {
 
 type UserRepresentation {
     id: String
-    userName: String
+    username: String
     firstName: String
     lastName: String
     email: String


### PR DESCRIPTION
This adapts the GraphQL schema to replace `userName` with `username` as it is written like this in the keycloak `UserRepresentation`.