### PR TITLE
Fix column definition for UUID type

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/File.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/File.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 @EqualsAndHashCode(callSuper = true)
 public class File extends BaseEntity {
 
-    @Column(updatable = false, nullable = false)
+    @Column(columnDefinition = "uuid", updatable = false, nullable = false)
     @Type(type="pg-uuid")
     private UUID fileUuid = UUID.randomUUID();
 


### PR DESCRIPTION
Set column definition to ensure correct creation of the column via Hibernate. This won't have any effect to existing db installations, it'll just ensure a valid creation of the database via Hibernate (if ever needed…).

Please review @terrestris/devs.