### PR TITLE
Fix location of (non-default) shogun messages

### DIFF
--- a/shogun-boot/src/main/resources/application.yml
+++ b/shogun-boot/src/main/resources/application.yml
@@ -11,6 +11,8 @@ spring:
   flyway:
     schemas: shogun, public
     defaultSchema: shogun
+  messages:
+    basename: org/springframework/security/messages, de/terrestris/shogun/lib/messages
   mail:
     host: mail.terrestris.de
     port: 587


### PR DESCRIPTION
Fixes the configuration for the location of the (non-default) shogun messages. See [here](https://github.com/terrestris/shogun/tree/master/shogun-lib/src/main/resources/de/terrestris/shogun/lib).

Please review @terrestris/devs.