### PR TITLE
Support basic authentication in Swagger UI

### DIFF
--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootSwaggerConfig.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootSwaggerConfig.java
@@ -1,8 +1,10 @@
 package de.terrestris.shogun.boot.config;
 
+import com.google.common.base.Predicate;
 import de.terrestris.shogun.config.SwaggerConfig;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.service.ApiInfo;
 
 import java.util.Collections;
@@ -25,5 +27,10 @@ public class BootSwaggerConfig extends SwaggerConfig {
         );
 
         return apiInfo;
+    }
+
+    @Override
+    protected Predicate<String> setSecurityContextPaths() {
+        return PathSelectors.any();
     }
 }

--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootWebSecurityConfig.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootWebSecurityConfig.java
@@ -5,10 +5,25 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import javax.servlet.http.HttpServletRequest;
 
 @Configuration
 @EnableWebSecurity
 public class BootWebSecurityConfig extends WebSecurityConfig {
+
+    RequestMatcher csrfRequestMatcher = new RequestMatcher() {
+        public boolean matches(HttpServletRequest httpServletRequest) {
+            String refererHeader = httpServletRequest.getHeader("Referer");
+
+            if (refererHeader != null && refererHeader.endsWith("swagger-ui.html")) {
+                return true;
+            }
+
+            return false;
+        }
+    };
 
     @Override
     protected void customHttpConfiguration(HttpSecurity http) throws Exception {
@@ -37,6 +52,7 @@ public class BootWebSecurityConfig extends WebSecurityConfig {
             .and()
                 .csrf()
                     .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                    .ignoringRequestMatchers(csrfRequestMatcher)
                     .ignoringAntMatchers("/graphql");
     }
 

--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootWebSecurityConfig.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootWebSecurityConfig.java
@@ -1,7 +1,6 @@
 package de.terrestris.shogun.boot.config;
 
 import de.terrestris.shogun.config.WebSecurityConfig;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -10,18 +9,6 @@ import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 @Configuration
 @EnableWebSecurity
 public class BootWebSecurityConfig extends WebSecurityConfig {
-
-//    @Autowired
-//    private ShogunAuthenticationProvider authProvider;
-//
-//    @Autowired
-//    public ShogunUserDetailsService userDetailsService;
-//
-//    @Override
-//    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-//        auth.userDetailsService(userDetailsService);
-//        auth.authenticationProvider(authProvider);
-//    }
 
     @Override
     protected void customHttpConfiguration(HttpSecurity http) throws Exception {

--- a/shogun-config/src/main/java/de/terrestris/shogun/config/SwaggerConfig.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/config/SwaggerConfig.java
@@ -1,16 +1,18 @@
 package de.terrestris.shogun.config;
 
+import com.google.common.base.Predicate;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.Contact;
+import springfox.documentation.service.*;
 import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 @Configuration
@@ -33,7 +35,24 @@ public abstract class SwaggerConfig {
             .apis(RequestHandlerSelectors.any())
             .paths(PathSelectors.any())
             .build()
-            .apiInfo(apiInfo());
+            .apiInfo(apiInfo())
+            .securityContexts(Arrays.asList(actuatorSecurityContext()))
+            .securitySchemes(Arrays.asList(basicAuthScheme()));
+    }
+
+    private SecurityContext actuatorSecurityContext() {
+        return SecurityContext.builder()
+            .securityReferences(Arrays.asList(basicAuthReference()))
+            .forPaths(setSecurityContextPaths())
+            .build();
+    }
+
+    private SecurityReference basicAuthReference() {
+        return new SecurityReference("basicAuth", new AuthorizationScope[0]);
+    }
+
+    private SecurityScheme basicAuthScheme() {
+        return new BasicAuth("basicAuth");
     }
 
     protected ApiInfo apiInfo() {
@@ -50,4 +69,33 @@ public abstract class SwaggerConfig {
 
         return apiInfo;
     }
+
+    /**
+     * Define the project specific paths that require BasicAuth authentication.
+     *
+     * Possible return values could be:
+     * <ul>
+     *     <li>{@link PathSelectors#none()}</li>
+     *     <li>{@link PathSelectors#any()}</li>
+     *     <li>{@link PathSelectors#regex(String)}</li>
+     *     <li>{@link PathSelectors#ant(String)}</li>
+     * </ul>
+     *
+     *  Some examples for specifying a custom list of endpoints:
+     *  <pre>
+     *  PathSelectors.ant("/files/**");
+     *  </pre>
+     *
+     *  <pre>
+     *  Predicates.or(
+     *      PathSelectors.ant("/files/**"),
+     *      PathSelectors.ant("/applications/**")
+     *  );
+     *  </pre>
+     *
+     *  The latter requires {@code com.google.guava} on the classpath.
+     *
+     * @return The predicate that defines the secured paths.
+     */
+    protected abstract Predicate<String> setSecurityContextPaths();
 }

--- a/shogun-config/src/main/resources/application-base.yml
+++ b/shogun-config/src/main/resources/application-base.yml
@@ -43,6 +43,7 @@ keycloak:
   public-client: true
   ssl-required: external
   principal-attribute: preferred_username
+  enable-basic-auth: true
 #  security-constraints:
 #    - authRoles:
 #      - user

--- a/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/config/InterceptorSwaggerConfig.java
+++ b/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/config/InterceptorSwaggerConfig.java
@@ -1,8 +1,10 @@
 package de.terrestris.shogun.interceptor.config;
 
+import com.google.common.base.Predicate;
 import de.terrestris.shogun.config.SwaggerConfig;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.service.ApiInfo;
 
 import java.util.Collections;
@@ -25,5 +27,10 @@ public class InterceptorSwaggerConfig extends SwaggerConfig {
         );
 
         return apiInfo;
+    }
+
+    @Override
+    protected Predicate<String> setSecurityContextPaths() {
+        return PathSelectors.any();
     }
 }


### PR DESCRIPTION
This allows the Swagger UI to send credentials to SHOgun endoints using BasicAuth.

Protected endpoints will be marked with a lock and to send credentials to the appropriate endpoints, user credentials must be set:

![Bildschirmfoto vom 2020-06-02 11-52-40](https://user-images.githubusercontent.com/1137620/83506580-a8766500-a4c7-11ea-8011-bc54ee2c493f.png)

Please review @terrestris/devs.