### PR TITLE
Update baseline (!)

### DIFF
--- a/shogun-boot/src/main/resources/db/migration/V0.1.0__Baseline.sql
+++ b/shogun-boot/src/main/resources/db/migration/V0.1.0__Baseline.sql
@@ -11,7 +11,7 @@ CREATE SEQUENCE IF NOT EXISTS hibernate_sequence
     CACHE 1;
 
 CREATE TABLE IF NOT EXISTS applications (
-    id bigint NOT NULL,
+    id bigint PRIMARY KEY,
     created timestamp without time zone,
     modified timestamp without time zone,
     client_config jsonb,
@@ -20,98 +20,63 @@ CREATE TABLE IF NOT EXISTS applications (
     layer_tree jsonb,
     name text,
     state_only boolean,
-    tool_config jsonb,
-    CONSTRAINT applications_pkey PRIMARY KEY (id),
-    CONSTRAINT applications_unique_id UNIQUE (id)
+    tool_config jsonb
 );
 
 CREATE TABLE IF NOT EXISTS files (
-    id bigint NOT NULL,
+    id bigint PRIMARY KEY,
     created timestamp without time zone,
     modified timestamp without time zone,
     active boolean,
     file bytea,
     file_name text NOT NULL,
     file_type text NOT NULL,
-    file_uuid uuid NOT NULL,
-    CONSTRAINT files_pkey PRIMARY KEY (id),
-    CONSTRAINT files_unique_id UNIQUE (id)
+    file_uuid uuid NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS users (
-    id bigint NOT NULL,
+    id bigint PRIMARY KEY,
     created timestamp without time zone,
     modified timestamp without time zone,
     keycloak_id text NOT NULL,
     client_config jsonb,
-    details jsonb,
-    CONSTRAINT users_pkey PRIMARY KEY (id),
-    CONSTRAINT users_unique_id UNIQUE (id)
+    details jsonb
 );
 
 CREATE TABLE IF NOT EXISTS groups (
-    id bigint NOT NULL,
+    id bigint PRIMARY KEY,
     created timestamp without time zone,
     modified timestamp without time zone,
-    keycloak_id text NOT NULL,
-    CONSTRAINT groups_pkey PRIMARY KEY (id),
-    CONSTRAINT groups_unique_id UNIQUE (id)
+    keycloak_id text NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS permissions (
-    id bigint NOT NULL,
+    id bigint PRIMARY KEY,
     created timestamp without time zone,
     modified timestamp without time zone,
-    name text NOT NULL,
-    CONSTRAINT permissions_pkey PRIMARY KEY (id),
-    CONSTRAINT permissions_unique_id UNIQUE (id),
-    CONSTRAINT permissions_unique_name UNIQUE (name)
+    name text NOT NULL UNIQUE
 );
 
 CREATE TABLE IF NOT EXISTS groupclasspermissions (
-    id bigint NOT NULL,
+    id bigint PRIMARY KEY,
     created timestamp without time zone,
     modified timestamp without time zone,
     class_name text,
-    permissions_id bigint NOT NULL,
-    group_id bigint NOT NULL,
-    CONSTRAINT groupclasspermissions_pkey PRIMARY KEY (id),
-    CONSTRAINT groupclasspermissions_unique_id UNIQUE (id),
-    CONSTRAINT groupclasspermissions_fkey_group_id FOREIGN KEY (group_id)
-        REFERENCES groups (id) MATCH SIMPLE
-        ON UPDATE NO ACTION
-        ON DELETE NO ACTION
-        NOT VALID,
-    CONSTRAINT groupclasspermissions_fkey_permissions_id FOREIGN KEY (permissions_id)
-        REFERENCES permissions (id) MATCH SIMPLE
-        ON UPDATE NO ACTION
-        ON DELETE NO ACTION
-        NOT VALID
+    permissions_id bigint NOT NULL REFERENCES permissions (id),
+    group_id bigint NOT NULL REFERENCES groups (id)
 );
 
 CREATE TABLE IF NOT EXISTS groupinstancepermissions (
-    id bigint NOT NULL,
+    id bigint PRIMARY KEY,
     created timestamp without time zone,
     modified timestamp without time zone,
     entity_id bigint NOT NULL,
-    permissions_id bigint NOT NULL,
-    group_id bigint NOT NULL,
-    CONSTRAINT groupinstancepermissions_pkey PRIMARY KEY (id),
-    CONSTRAINT groupinstancepermissions_unique_id UNIQUE (id),
-    CONSTRAINT groupinstancepermissions_fkey_group_id FOREIGN KEY (group_id)
-        REFERENCES groups (id) MATCH SIMPLE
-        ON UPDATE NO ACTION
-        ON DELETE NO ACTION
-        NOT VALID,
-    CONSTRAINT groupinstancepermissions_fkey_permissions_id FOREIGN KEY (permissions_id)
-        REFERENCES permissions (id) MATCH SIMPLE
-        ON UPDATE NO ACTION
-        ON DELETE NO ACTION
-        NOT VALID
+    permissions_id bigint NOT NULL REFERENCES permissions (id),
+    group_id bigint NOT NULL REFERENCES groups (id)
 );
 
 CREATE TABLE IF NOT EXISTS imagefiles (
-    id bigint NOT NULL,
+    id bigint PRIMARY KEY,
     created timestamp without time zone,
     modified timestamp without time zone,
     active boolean,
@@ -121,73 +86,39 @@ CREATE TABLE IF NOT EXISTS imagefiles (
     file_uuid uuid NOT NULL,
     height integer NOT NULL,
     thumbnail bytea,
-    width integer NOT NULL,
-    CONSTRAINT imagefiles_pkey PRIMARY KEY (id),
-    CONSTRAINT imagefiles_unique_id UNIQUE (id)
+    width integer NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS layers (
-    id bigint NOT NULL,
+    id bigint PRIMARY KEY,
     created timestamp without time zone,
     modified timestamp without time zone,
     client_config jsonb,
     features jsonb,
     name text NOT NULL,
     source_config jsonb NOT NULL,
-    type text NOT NULL,
-    CONSTRAINT layers_pkey PRIMARY KEY (id),
-    CONSTRAINT layers_unique_id UNIQUE (id),
-    CONSTRAINT layers_unique_name UNIQUE (name)
+    type text NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS permission (
-    permissions_id bigint NOT NULL,
-    permissions text,
-    CONSTRAINT permission_fkey_permissions_id FOREIGN KEY (permissions_id)
-        REFERENCES permissions (id) MATCH SIMPLE
-        ON UPDATE NO ACTION
-        ON DELETE NO ACTION
-        NOT VALID
+    permissions_id bigint NOT NULL REFERENCES permissions (id),
+    permissions text
 );
 
 CREATE TABLE IF NOT EXISTS userclasspermissions (
-    id bigint NOT NULL,
+    id bigint PRIMARY KEY,
     created timestamp without time zone,
     modified timestamp without time zone,
     class_name text,
-    permissions_id bigint NOT NULL,
-    user_id bigint NOT NULL,
-    CONSTRAINT userclasspermissions_pkey PRIMARY KEY (id),
-    CONSTRAINT userclasspermissions_unique_id UNIQUE (id),
-    CONSTRAINT userclasspermissions_fkey_user_id FOREIGN KEY (user_id)
-        REFERENCES users (id) MATCH SIMPLE
-        ON UPDATE NO ACTION
-        ON DELETE NO ACTION
-        NOT VALID,
-    CONSTRAINT userclasspermissions_fkey_permissions_id FOREIGN KEY (permissions_id)
-        REFERENCES permissions (id) MATCH SIMPLE
-        ON UPDATE NO ACTION
-        ON DELETE NO ACTION
-        NOT VALID
+    permissions_id bigint NOT NULL REFERENCES permissions (id),
+    user_id bigint NOT NULL REFERENCES users (id)
 );
 
 CREATE TABLE IF NOT EXISTS userinstancepermissions (
-    id bigint NOT NULL,
+    id bigint PRIMARY KEY,
     created timestamp without time zone,
     modified timestamp without time zone,
     entity_id bigint NOT NULL,
-    permissions_id bigint NOT NULL,
-    user_id bigint NOT NULL,
-    CONSTRAINT userinstancepermissions_pkey PRIMARY KEY (id),
-    CONSTRAINT userinstancepermissions_unique_id UNIQUE (id),
-    CONSTRAINT userinstancepermissions_fkey_user_id FOREIGN KEY (user_id)
-        REFERENCES users (id) MATCH SIMPLE
-        ON UPDATE NO ACTION
-        ON DELETE NO ACTION
-        NOT VALID,
-    CONSTRAINT userinstancepermissions_fkey_permissions_id FOREIGN KEY (permissions_id)
-        REFERENCES permissions (id) MATCH SIMPLE
-        ON UPDATE NO ACTION
-        ON DELETE NO ACTION
-        NOT VALID
+    permissions_id bigint NOT NULL REFERENCES permissions (id),
+    user_id bigint NOT NULL REFERENCES users (id)
 );

--- a/shogun-boot/src/main/resources/db/migration/V0.1.0__Baseline.sql
+++ b/shogun-boot/src/main/resources/db/migration/V0.1.0__Baseline.sql
@@ -10,7 +10,7 @@ CREATE SEQUENCE IF NOT EXISTS hibernate_sequence
     MAXVALUE 9223372036854775807
     CACHE 1;
 
-CREATE TABLE applications (
+CREATE TABLE IF NOT EXISTS applications (
     id bigint NOT NULL,
     created timestamp without time zone,
     modified timestamp without time zone,
@@ -25,7 +25,7 @@ CREATE TABLE applications (
     CONSTRAINT applications_unique_id UNIQUE (id)
 );
 
-CREATE TABLE files (
+CREATE TABLE IF NOT EXISTS files (
     id bigint NOT NULL,
     created timestamp without time zone,
     modified timestamp without time zone,
@@ -38,7 +38,7 @@ CREATE TABLE files (
     CONSTRAINT files_unique_id UNIQUE (id)
 );
 
-CREATE TABLE users (
+CREATE TABLE IF NOT EXISTS users (
     id bigint NOT NULL,
     created timestamp without time zone,
     modified timestamp without time zone,
@@ -49,7 +49,7 @@ CREATE TABLE users (
     CONSTRAINT users_unique_id UNIQUE (id)
 );
 
-CREATE TABLE groups (
+CREATE TABLE IF NOT EXISTS groups (
     id bigint NOT NULL,
     created timestamp without time zone,
     modified timestamp without time zone,
@@ -58,7 +58,7 @@ CREATE TABLE groups (
     CONSTRAINT groups_unique_id UNIQUE (id)
 );
 
-CREATE TABLE permissions (
+CREATE TABLE IF NOT EXISTS permissions (
     id bigint NOT NULL,
     created timestamp without time zone,
     modified timestamp without time zone,
@@ -68,7 +68,7 @@ CREATE TABLE permissions (
     CONSTRAINT permissions_unique_name UNIQUE (name)
 );
 
-CREATE TABLE groupclasspermissions (
+CREATE TABLE IF NOT EXISTS groupclasspermissions (
     id bigint NOT NULL,
     created timestamp without time zone,
     modified timestamp without time zone,
@@ -89,7 +89,7 @@ CREATE TABLE groupclasspermissions (
         NOT VALID
 );
 
-CREATE TABLE groupinstancepermissions (
+CREATE TABLE IF NOT EXISTS groupinstancepermissions (
     id bigint NOT NULL,
     created timestamp without time zone,
     modified timestamp without time zone,
@@ -110,7 +110,7 @@ CREATE TABLE groupinstancepermissions (
         NOT VALID
 );
 
-CREATE TABLE imagefiles (
+CREATE TABLE IF NOT EXISTS imagefiles (
     id bigint NOT NULL,
     created timestamp without time zone,
     modified timestamp without time zone,
@@ -126,7 +126,7 @@ CREATE TABLE imagefiles (
     CONSTRAINT imagefiles_unique_id UNIQUE (id)
 );
 
-CREATE TABLE layers (
+CREATE TABLE IF NOT EXISTS layers (
     id bigint NOT NULL,
     created timestamp without time zone,
     modified timestamp without time zone,
@@ -140,7 +140,7 @@ CREATE TABLE layers (
     CONSTRAINT layers_unique_name UNIQUE (name)
 );
 
-CREATE TABLE permission (
+CREATE TABLE IF NOT EXISTS permission (
     permissions_id bigint NOT NULL,
     permissions text,
     CONSTRAINT permission_fkey_permissions_id FOREIGN KEY (permissions_id)
@@ -150,7 +150,7 @@ CREATE TABLE permission (
         NOT VALID
 );
 
-CREATE TABLE userclasspermissions (
+CREATE TABLE IF NOT EXISTS userclasspermissions (
     id bigint NOT NULL,
     created timestamp without time zone,
     modified timestamp without time zone,
@@ -171,7 +171,7 @@ CREATE TABLE userclasspermissions (
         NOT VALID
 );
 
-CREATE TABLE userinstancepermissions (
+CREATE TABLE IF NOT EXISTS userinstancepermissions (
     id bigint NOT NULL,
     created timestamp without time zone,
     modified timestamp without time zone,

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Layer.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Layer.java
@@ -16,7 +16,7 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 public class Layer extends BaseEntity {
 
-    @Column(unique = true, nullable = false)
+    @Column(nullable = false)
     private String name;
 
     @Type(type = "jsonb")


### PR DESCRIPTION
This updates the baseline to create the tables if needed only.

Yes, changing an existing baseline is against the best-practices, but I think the current baseline might also produce conflicts in the future. 

At the current state existing installations should fix the update while removing the appropriate entry from the `flyway_schema_history` table.

@terrestris/devs What do you think?