### PR TITLE
Check if Keycloak representations for user and group are available

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/GroupService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/GroupService.java
@@ -61,7 +61,7 @@ public class GroupService extends BaseService<GroupRepository, Group> {
         Optional<Group> group = repository.findById(id);
 
         if (group.isPresent()) {
-            group = Optional.of(this.setTransientKeycloakRepresentations(group.get()));
+            this.setTransientKeycloakRepresentations(group.get());
         }
 
         return group;
@@ -109,9 +109,15 @@ public class GroupService extends BaseService<GroupRepository, Group> {
 
     private Group setTransientKeycloakRepresentations(Group group) {
         GroupResource groupResource = keycloakUtil.getGroupResource(group);
-        GroupRepresentation groupRepresentation = groupResource.toRepresentation();
 
-        group.setKeycloakRepresentation(groupRepresentation);
+        try {
+            GroupRepresentation groupRepresentation = groupResource.toRepresentation();
+            group.setKeycloakRepresentation(groupRepresentation);
+        } catch (Exception e) {
+            LOG.warn("Could not get the GroupRepresentation for group with SHOGun ID {} and " +
+                    "Keycloak ID {}. This may happen if the group is not available in Keycloak.",
+                    group.getId(), group.getKeycloakId());
+        }
 
         return group;
     }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/GroupService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/GroupService.java
@@ -117,6 +117,7 @@ public class GroupService extends BaseService<GroupRepository, Group> {
             LOG.warn("Could not get the GroupRepresentation for group with SHOGun ID {} and " +
                     "Keycloak ID {}. This may happen if the group is not available in Keycloak.",
                     group.getId(), group.getKeycloakId());
+            LOG.trace("Full stack trace: ", e);
         }
 
         return group;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/UserService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/UserService.java
@@ -70,6 +70,7 @@ public class UserService extends BaseService<UserRepository, User> {
             LOG.warn("Could not get the UserRepresentation for user with SHOGun ID {} and " +
                     "Keycloak ID {}. This may happen if the user is not available in Keycloak.",
                     user.getId(), user.getKeycloakId());
+            LOG.trace("Full stack trace: ", e);
         }
 
         return user;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/UserService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/UserService.java
@@ -28,9 +28,7 @@ public class UserService extends BaseService<UserRepository, User> {
         List<User> users = (List<User>) repository.findAll();
 
         for (User user : users) {
-            UserResource userResource = keycloakUtil.getUserResource(user);
-            UserRepresentation userRepresentation = userResource.toRepresentation();
-            user.setKeycloakRepresentation(userRepresentation);
+            this.setTransientKeycloakRepresentations(user);
         }
 
         return users;
@@ -43,9 +41,7 @@ public class UserService extends BaseService<UserRepository, User> {
         List<User> users = (List<User>) repository.findAll(specification);
 
         for (User user : users) {
-            UserResource userResource = keycloakUtil.getUserResource(user);
-            UserRepresentation userRepresentation = userResource.toRepresentation();
-            user.setKeycloakRepresentation(userRepresentation);
+            this.setTransientKeycloakRepresentations(user);
         }
 
         return users;
@@ -58,9 +54,22 @@ public class UserService extends BaseService<UserRepository, User> {
         Optional<User> user = repository.findById(id);
 
         if (user.isPresent()) {
-            UserResource userResource = keycloakUtil.getUserResource(user.get());
+            this.setTransientKeycloakRepresentations(user.get());
+        }
+
+        return user;
+    }
+
+    private User setTransientKeycloakRepresentations(User user) {
+        UserResource userResource = keycloakUtil.getUserResource(user);
+
+        try {
             UserRepresentation userRepresentation = userResource.toRepresentation();
-            user.get().setKeycloakRepresentation(userRepresentation);
+            user.setKeycloakRepresentation(userRepresentation);
+        } catch (Exception e) {
+            LOG.warn("Could not get the UserRepresentation for user with SHOGun ID {} and " +
+                    "Keycloak ID {}. This may happen if the user is not available in Keycloak.",
+                    user.getId(), user.getKeycloakId());
         }
 
         return user;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/KeycloakUtil.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/KeycloakUtil.java
@@ -173,6 +173,7 @@ public class KeycloakUtil {
             log.warn("Could not get the GroupRepresentations for the groups of user with SHOGun ID {} and " +
                     "Keycloak ID {}. This may happen if the user is not available in Keycloak.",
                      user.getId(), user.getKeycloakId());
+            log.trace("Full stack trace: ", e);
         }
 
         return groups;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/KeycloakUtil.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/KeycloakUtil.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Component;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -163,7 +164,16 @@ public class KeycloakUtil {
     }
 
     public List<GroupRepresentation> getUserGroups(User user) {
-        List<GroupRepresentation> groups = this.keycloakRealm.users().get(user.getKeycloakId()).groups();
+        UserResource userResource = this.getUserResource(user);
+        List<GroupRepresentation> groups = new ArrayList<>();
+
+        try {
+            groups = userResource.groups();
+        } catch (Exception e) {
+            log.warn("Could not get the GroupRepresentations for the groups of user with SHOGun ID {} and " +
+                    "Keycloak ID {}. This may happen if the user is not available in Keycloak.",
+                     user.getId(), user.getKeycloakId());
+        }
 
         return groups;
     }


### PR DESCRIPTION
This adds some checks for the existence of the Keycloak representations of the given `User` and `Group`. This may occur when the `User` / `Group` is still available in SHOGun, but was removed from Keycloak -  espacially during development.

Please review @terrestris/devs.