### PR TITLE
Init jackson ID resolver

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Topic.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Topic.java
@@ -1,5 +1,9 @@
 package de.terrestris.shogun.lib.model;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import de.terrestris.shogun.lib.resolver.ImageFileIdResolver;
 import lombok.*;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
@@ -33,12 +37,18 @@ public class Topic extends BaseEntity {
     @Column(unique = true, nullable = false)
     private String title;
 
-    @Column(columnDefinition="text")
+    @Column(columnDefinition = "text")
     private String description;
 
     @OneToOne
     @Fetch(FetchMode.JOIN)
     @Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
+    @JsonIdentityInfo(
+        generator = ObjectIdGenerators.PropertyGenerator.class,
+        property = "id",
+        resolver = ImageFileIdResolver.class
+    )
+    @JsonIdentityReference(alwaysAsId = true)
     private ImageFile imgSrc;
 
     @Type(type = "jsonb")

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/resolver/BaseEntityIdResolver.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/resolver/BaseEntityIdResolver.java
@@ -1,0 +1,61 @@
+package de.terrestris.shogun.lib.resolver;
+
+import com.fasterxml.jackson.annotation.ObjectIdGenerator.IdKey;
+import com.fasterxml.jackson.annotation.ObjectIdResolver;
+import com.fasterxml.jackson.annotation.SimpleObjectIdResolver;
+import com.sun.jdi.InvalidTypeException;
+import de.terrestris.shogun.lib.model.BaseEntity;
+import de.terrestris.shogun.lib.service.BaseService;
+import de.terrestris.shogun.lib.util.ApplicationContextProvider;
+import javassist.NotFoundException;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Optional;
+
+@Log4j2
+public abstract class BaseEntityIdResolver<E extends BaseEntity, S extends BaseService> extends SimpleObjectIdResolver {
+
+    @Autowired
+    protected S service;
+
+    @Override
+    public E resolveId(IdKey idKey) {
+        try {
+            if (idKey.key instanceof Long) {
+                final Long id = (Long) idKey.key;
+                Optional<E> entity = service.findOne(id);
+
+                if (entity.isPresent()) {
+                    return entity.get();
+                } else {
+                    throw new NotFoundException("Could not find entity with ID " + id);
+                }
+            } else {
+                throw new InvalidTypeException("ID is not of type Long.");
+            }
+        } catch (Exception e) {
+            log.error("Could not resolve object: {}", e.getMessage());
+            log.trace("Full stack trace: ", e);
+            return null;
+        }
+    }
+
+    @Override
+    public ObjectIdResolver newForDeserialization(Object context) {
+        try {
+            BaseEntityIdResolver instance = getClass().getDeclaredConstructor().newInstance();
+            ApplicationContext applicationContext = ApplicationContextProvider.getContext();
+            applicationContext.getAutowireCapableBeanFactory().autowireBean(instance);
+
+            return instance;
+        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+            log.error("Error instantiating a BaseEntityIdResolver: " + e.getMessage());
+            log.trace("Full stack trace: ", e);
+        }
+        return null;
+    }
+
+}

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/resolver/ImageFileIdResolver.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/resolver/ImageFileIdResolver.java
@@ -1,0 +1,6 @@
+package de.terrestris.shogun.lib.resolver;
+
+import de.terrestris.shogun.lib.model.ImageFile;
+import de.terrestris.shogun.lib.service.ImageFileService;
+
+public class ImageFileIdResolver extends BaseEntityIdResolver<ImageFile, ImageFileService> { }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/ApplicationContextProvider.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/ApplicationContextProvider.java
@@ -1,0 +1,21 @@
+package de.terrestris.shogun.lib.util;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApplicationContextProvider implements ApplicationContextAware {
+
+    private static ApplicationContext applicationContext;
+
+    public static ApplicationContext getContext() {
+        return applicationContext;
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+}


### PR DESCRIPTION
This adds the `BaseEntityIdResolver` class that can be used to implement custom jackson ID serializers (see the `ImageFileIdResolver` class as an example).

Please review @terrestris/devs.