### PR TITLE
adjust logging level for deleted permissions

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionService.java
@@ -138,6 +138,7 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
 
         repository.deleteAll(groupInstancePermissions);
 
-        LOG.info("Successfully deleted all group instance permissions for entity {}", persistedEntity);
+        LOG.info("Successfully deleted all group instance permissions for entity with id {}", persistedEntity.getId());
+        LOG.trace("Deleted entity: {}", persistedEntity);
     }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/UserInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/UserInstancePermissionService.java
@@ -107,6 +107,7 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
 
         repository.deleteAll(userInstancePermissions);
 
-        LOG.info("Successfully deleted all user instance permissions for entity {}", persistedEntity);
+        LOG.info("Successfully deleted all user instance permissions for entity with id {}", persistedEntity.getId());
+        LOG.trace("Deleted entity: {}", persistedEntity);
     }
 }


### PR DESCRIPTION
This tones down the logging when deleting permissions.

I saw `getGenericClassName` being used in other classes to log the entity type. Can we include that here as well?

@devs Please review