### PR TITLE
Enable Spring Boot actuator endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ curl \
   http://localhost:8080/shogun-boot/applications/1
 ``` 
 
-## GeoServer interceptor:
+## GeoServer interceptor
+
 To use REST API of GeoServer interceptor its necessary to create a role `interceptor_admin` in Keycloak.
 Users having this role are allowed to use them.
 
@@ -145,6 +146,38 @@ If you want to create a report with detailed information about the projects depe
 `mvn site -Preporting`
 
 Just have a look at `/target/site/index.html` afterwards.
+
+## Actuator
+
+[Spring Boot Actuator](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready) is
+enabled by default and is available via the `actuator/` endpoints. The following list demonstrates some usecases:
+
+* List current properties:
+  * `http://localhost:8080/shogun-boot/actuator/configprops`
+* List current status of flyway migrations:
+  * `http://localhost:8080/shogun-boot/actuator/flyway`
+* List current health information:
+  * `http://localhost:8080/shogun-boot/actuator/health`
+* List build and git informations:
+  * `http://localhost:8080/shogun-boot/actuator/info`
+* List current loglevels:
+  * `http://localhost:8080/shogun-boot/actuator/loggers`
+* List current log level of a specific module:
+  * `http://localhost:8080/shogun-boot/actuator/loggers/de.terrestris`
+* Set log level for a specific module to the desired level (e.g. `DEBUG` for `de.terrestris`):
+```
+curl \
+  -v \
+  -X POST \
+  -u shogun:shogun \
+  -H 'Content-Type: application/json' \
+  -d '{"configuredLevel": "DEBUG"}' \
+  'http://localhost:8080/shogun-boot/actuator/loggers/de.terrestris'
+```
+* List all available endpoint mappings:
+  * `http://localhost:8080/shogun-boot/actuator/mappings`
+
+Note: All endpoints are accessible by users with the `ADMIN` role only.
 
 ## Release
 

--- a/shogun-boot/pom.xml
+++ b/shogun-boot/pom.xml
@@ -54,6 +54,10 @@
       <artifactId>spring-boot-devtools</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
 
     <!-- Spring -->
     <dependency>

--- a/shogun-boot/pom.xml
+++ b/shogun-boot/pom.xml
@@ -159,6 +159,10 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootWebSecurityConfig.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootWebSecurityConfig.java
@@ -58,7 +58,8 @@ public class BootWebSecurityConfig extends WebSecurityConfig {
                 .csrf()
                     .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
                     .ignoringRequestMatchers(csrfRequestMatcher)
-                    .ignoringAntMatchers("/graphql");
+                    .ignoringAntMatchers("/graphql")
+                    .ignoringAntMatchers("/actuator/**");
     }
 
 }

--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootWebSecurityConfig.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootWebSecurityConfig.java
@@ -35,6 +35,11 @@ public class BootWebSecurityConfig extends WebSecurityConfig {
                     "/index.html"
                 )
                     .permitAll()
+                .antMatchers(
+                    "/swagger-ui.html",
+                    "/actuator/**"
+                )
+                    .hasRole("ADMIN")
                 .anyRequest()
                     .authenticated()
             .and()

--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootWebSecurityConfig.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootWebSecurityConfig.java
@@ -7,22 +7,14 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
-import javax.servlet.http.HttpServletRequest;
-
 @Configuration
 @EnableWebSecurity
 public class BootWebSecurityConfig extends WebSecurityConfig {
 
-    RequestMatcher csrfRequestMatcher = new RequestMatcher() {
-        public boolean matches(HttpServletRequest httpServletRequest) {
-            String refererHeader = httpServletRequest.getHeader("Referer");
+    RequestMatcher csrfRequestMatcher = httpServletRequest -> {
+        String refererHeader = httpServletRequest.getHeader("Referer");
 
-            if (refererHeader != null && refererHeader.endsWith("swagger-ui.html")) {
-                return true;
-            }
-
-            return false;
-        }
+        return refererHeader != null && refererHeader.endsWith("swagger-ui.html");
     };
 
     @Override
@@ -32,11 +24,15 @@ public class BootWebSecurityConfig extends WebSecurityConfig {
                 .antMatchers(
                     "/",
                     "/auth/**",
-                    "/index.html"
+                    "/index.html",
+                    // Enable anonymous access to swagger docs
+                    "/swagger-ui.html",
+                    "/webjars/springfox-swagger-ui/**",
+                    "/swagger-resources/**",
+                    "/v2/api-docs"
                 )
                     .permitAll()
                 .antMatchers(
-                    "/swagger-ui.html",
                     "/actuator/**"
                 )
                     .hasRole("ADMIN")

--- a/shogun-boot/src/main/resources/application.yml
+++ b/shogun-boot/src/main/resources/application.yml
@@ -41,3 +41,8 @@ server:
 support:
   email: noreply@terrestris.de
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"

--- a/shogun-lib/pom.xml
+++ b/shogun-lib/pom.xml
@@ -83,10 +83,6 @@
       <artifactId>spring-context-support</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-actuator</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-envers</artifactId>
     </dependency>


### PR DESCRIPTION
This enables all endpoints from the [Spring Boot Actuator](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-endpoints) (except the `shutdown` one) and adds some notes about its usage to the README.

Please review @terrestris/devs.