### PR TITLE
Fix spring security versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -316,6 +316,11 @@
         <version>${spring.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-context-support</artifactId>
+        <version>${spring.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.data</groupId>
         <artifactId>spring-data-jpa</artifactId>
         <version>${spring-data.version}</version>
@@ -333,11 +338,6 @@
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-config</artifactId>
-        <version>${spring-security.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-context-support</artifactId>
         <version>${spring-security.version}</version>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 
     <!-- Spring -->
     <spring.version>5.2.8.RELEASE</spring.version>
-    <spring-security.version>5.2.1.RELEASE</spring-security.version>
+    <spring-security.version>5.3.4.RELEASE</spring-security.version>
     <spring-boot.version>2.3.3.RELEASE</spring-boot.version>
     <spring-data.version>2.3.3.RELEASE</spring-data.version>
 


### PR DESCRIPTION
As artifact `spring-context-support` belongs to the `org.springframework`, the spring version should be used instead of the spring-security version.

This also updates the spring-security version.

**NOTE**: Due to the update it _might_ become necessary to invalidate all sessions in projects to fix version incompatibility errors (watch out for `java.io.InvalidClassException` exceptions)!

Please review @terrestris/devs.