### PR TITLE
Set FAIL_ON_EMPTY_BEANS to false

### DIFF
--- a/shogun-config/src/main/resources/application-base.yml
+++ b/shogun-config/src/main/resources/application-base.yml
@@ -32,6 +32,9 @@ spring:
           envers:
             # Set this to false to disable auditing entity changes
             enabled: true
+  jackson:
+    serialization:
+      fail-on-empty-beans: false
   flyway:
     enabled: true
     baselineOnMigrate: true


### PR DESCRIPTION
This ensures the entity revisions can be received successfully.

Please review @terrestris/devs.