### PR TITLE
Enable second level and query caching via ehcache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,8 @@ nb-configuration.xml
 ## OS X
 ##########################
 .DS_Store
+
+##########################
+## Cache
+##########################
+shogun-ehcache

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
     <hibernate-extra-types.version>2.9.13</hibernate-extra-types.version>
     <postgres.version>42.2.16</postgres.version>
     <flyway.version>6.5.6</flyway.version>
+    <ehcache.version>3.8.0</ehcache.version>
 
     <!-- GraphQL -->
     <graphql-spring-boot-starter.version>5.0.2</graphql-spring-boot-starter.version>
@@ -367,6 +368,16 @@
         <groupId>com.vladmihalcea</groupId>
         <artifactId>hibernate-types-52</artifactId>
         <version>${hibernate-extra-types.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-jcache</artifactId>
+        <version>${hibernate.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ehcache</groupId>
+        <artifactId>ehcache</artifactId>
+        <version>${ehcache.version}</version>
       </dependency>
 
       <!-- GraphQL -->

--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootWebSecurityConfig.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootWebSecurityConfig.java
@@ -33,7 +33,8 @@ public class BootWebSecurityConfig extends WebSecurityConfig {
                 )
                     .permitAll()
                 .antMatchers(
-                    "/actuator/**"
+                    "/actuator/**",
+                    "/cache/**"
                 )
                     .hasRole("ADMIN")
                 .anyRequest()

--- a/shogun-config/src/main/resources/application-base.yml
+++ b/shogun-config/src/main/resources/application-base.yml
@@ -13,6 +13,8 @@ spring:
   main:
     banner-mode: off
   jpa:
+    # Show SQL statements
+    show-sql: true
     open-in-view: true
     database-platform: org.hibernate.spatial.dialect.postgis.PostgisPG95Dialect
     hibernate:
@@ -21,6 +23,11 @@ spring:
           non_contextual_creation: true
       ddl-auto: none
     properties:
+      javax:
+        persistence:
+          sharedCache:
+            # Only entities with @Cacheable annotation will use L2 cache
+            mode: ENABLE_SELECTIVE
       org:
         hibernate:
           # See https://docs.jboss.org/envers/docs/#configuration
@@ -28,6 +35,20 @@ spring:
             default_schema: shogun_rev
             audit_table_prefix: _rev
       hibernate:
+        javax:
+          cache:
+            provider: org.ehcache.jsr107.EhcacheCachingProvider
+            uri: ehcache.xml
+        format_sql: true
+        # Generate statistics to check if L2/query cache is actually being used
+        generate_statistics: true
+        cache:
+          # Enable L2 cache
+          use_second_level_cache: true
+          # Enable query cache
+          use_query_cache: true
+          region:
+            factory_class: org.hibernate.cache.jcache.JCacheRegionFactory
         integration:
           envers:
             # Set this to false to disable auditing entity changes

--- a/shogun-config/src/main/resources/ehcache.xml
+++ b/shogun-config/src/main/resources/ehcache.xml
@@ -40,11 +40,35 @@
       <heap unit="entries">1000</heap>
       <offheap unit="MB">10</offheap>
       <!-- Note: Data cached in the disk tier will persist even if the JVM stops! -->
-      <disk persistent="false" unit="MB">100</disk>
+<!--      <disk persistent="true" unit="MB">100</disk>-->
     </resources>
   </cache-template>
 
-  <cache alias="permissionCollectionCache" uses-template="default" />
-  <cache alias="applicationCache" uses-template="default" />
+  <cache alias="default-query-results-region" uses-template="default">
+    <expiry>
+      <tti unit="seconds">300</tti>
+    </expiry>
+    <heap>1024</heap>
+  </cache>
+
+  <cache alias="default-update-timestamps-region" uses-template="default">
+    <expiry>
+      <none />
+    </expiry>
+    <heap>4096</heap>
+  </cache>
+
+  <cache alias="groupclasspermissions" uses-template="default" />
+  <cache alias="groupinstancepermissions" uses-template="default" />
+  <cache alias="permissions" uses-template="default" />
+  <cache alias="permission" uses-template="default" />
+  <cache alias="userclasspermissions" uses-template="default" />
+  <cache alias="userinstancepermissions" uses-template="default" />
+  <cache alias="applications" uses-template="default" />
+  <cache alias="files" uses-template="default" />
+  <cache alias="groups" uses-template="default" />
+  <cache alias="layers" uses-template="default" />
+  <cache alias="topics" uses-template="default" />
+  <cache alias="users" uses-template="default" />
 
 </config>

--- a/shogun-config/src/main/resources/ehcache.xml
+++ b/shogun-config/src/main/resources/ehcache.xml
@@ -1,0 +1,50 @@
+<config
+  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+  xmlns='http://www.ehcache.org/v3'
+  xmlns:jsr107='http://www.ehcache.org/v3/jsr107'
+  xsi:schemaLocation="
+    http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.8.xsd
+    http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.8.xsd
+">
+
+  <!-- See https://www.ehcache.org/documentation/3.8/xml.html for documentation -->
+
+  <service>
+    <jsr107:defaults enable-management="false" enable-statistics="true" default-template="default" />
+  </service>
+
+  <!-- Persistent cache directory -->
+  <persistence directory="shogun-ehcache"/>
+
+  <!-- Default cache template -->
+  <cache-template name="default">
+    <expiry>
+      <none/>
+    </expiry>
+    <listeners>
+      <listener>
+        <class>de.terrestris.shogun.lib.listener.CacheLogger</class>
+        <event-firing-mode>ASYNCHRONOUS</event-firing-mode>
+        <event-ordering-mode>UNORDERED</event-ordering-mode>
+        <events-to-fire-on>CREATED</events-to-fire-on>
+        <events-to-fire-on>EXPIRED</events-to-fire-on>
+        <events-to-fire-on>EVICTED</events-to-fire-on>
+        <events-to-fire-on>REMOVED</events-to-fire-on>
+        <events-to-fire-on>UPDATED</events-to-fire-on>
+      </listener>
+    </listeners>
+
+    <!-- See https://www.ehcache.org/documentation/3.8/tiering.html#multiple-tier-setup -->
+    <resources>
+      <!-- Calculation of the heap size has an impact on the performance, make use of entries here -->
+      <heap unit="entries">1000</heap>
+      <offheap unit="MB">10</offheap>
+      <!-- Note: Data cached in the disk tier will persist even if the JVM stops! -->
+      <disk persistent="false" unit="MB">100</disk>
+    </resources>
+  </cache-template>
+
+  <cache alias="permissionCollectionCache" uses-template="default" />
+  <cache alias="applicationCache" uses-template="default" />
+
+</config>

--- a/shogun-lib/pom.xml
+++ b/shogun-lib/pom.xml
@@ -106,6 +106,14 @@
       <groupId>com.vladmihalcea</groupId>
       <artifactId>hibernate-types-52</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-jcache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
+    </dependency>
 
     <!-- GraphQL -->
     <dependency>

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/CacheController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/CacheController.java
@@ -1,0 +1,53 @@
+package de.terrestris.shogun.lib.controller;
+
+import de.terrestris.shogun.lib.service.CacheService;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@Log4j2
+@RestController
+@RequestMapping("/cache")
+public class CacheController {
+
+    @Autowired
+    CacheService service;
+
+    @Autowired
+    protected MessageSource messageSource;
+
+    @PostMapping("/evict")
+    public ResponseEntity<?> evictCache() {
+
+        log.info("Requested to evict the cache.");
+
+        try {
+            service.evictCache();
+
+            log.info("Successfully evicted the cache.");
+
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            log.error("Could not evict the cache: {}", e.getMessage());
+            log.trace("Full stack trace: {}", e);
+
+            throw new ResponseStatusException(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                messageSource.getMessage(
+                    "BaseController.INTERNAL_SERVER_ERROR",
+                    null,
+                    LocaleContextHolder.getLocale()
+                ),
+                e
+            );
+        }
+
+    }
+}

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/listener/CacheLogger.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/listener/CacheLogger.java
@@ -1,0 +1,26 @@
+package de.terrestris.shogun.lib.listener;
+
+import lombok.extern.log4j.Log4j2;
+import org.ehcache.event.*;
+
+@Log4j2
+public class CacheLogger implements CacheEventListener<Object, Object> {
+
+    /**
+     * Invoked on {@link CacheEvent CacheEvent} firing.
+     * <p>
+     * This method is invoked according to the {@link EventOrdering}, {@link EventFiring} and
+     * {@link EventType} requirements provided at listener registration time.
+     * <p>
+     * Any exception thrown from this listener will be swallowed and logged but will not prevent
+     * other listeners to run.
+     *
+     * @param event the actual {@code CacheEvent}
+     */
+    @Override
+    public void onEvent(CacheEvent<?, ?> event) {
+        log.info("Key: {} | EventType: {} | Old value: {} | New value: {}",
+            event.getKey(), event.getType(), event.getOldValue(),
+            event.getNewValue());
+    }
+}

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Application.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Application.java
@@ -25,7 +25,7 @@ import org.hibernate.envers.Audited;
 @Audited
 @AuditTable(value = "applications_rev", schema = "shogun_rev")
 @Cacheable
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="applications")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Application.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Application.java
@@ -1,19 +1,31 @@
 package de.terrestris.shogun.lib.model;
 
-import de.terrestris.shogun.lib.model.jsonb.ApplicationClientConfig;
-import de.terrestris.shogun.lib.model.jsonb.Locale;
-import lombok.*;
+import de.terrestris.shogun.lib.model.jsonb.application.ApplicationClientConfig;
+import java.util.Locale;
+import java.util.Map;
+import javax.persistence.Basic;
+import javax.persistence.Cacheable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Type;
 import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
-
-import javax.persistence.*;
-import java.util.Map;
 
 @Entity(name = "applications")
 @Table(schema = "shogun")
 @Audited
 @AuditTable(value = "applications_rev", schema = "shogun_rev")
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -21,7 +33,7 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 public class Application extends BaseEntity {
 
-    @Column()
+    @Column
     private String name;
 
     @Type(type = "jsonb")
@@ -29,7 +41,7 @@ public class Application extends BaseEntity {
     @Basic(fetch = FetchType.LAZY)
     private Locale i18n;
 
-    @Column()
+    @Column
     private Boolean stateOnly;
 
     @Type(type = "jsonb")

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/File.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/File.java
@@ -21,7 +21,7 @@ import org.hibernate.annotations.Type;
 @Entity(name = "files")
 @Table(schema = "shogun")
 @Cacheable
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "files")
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString(callSuper = true)

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/File.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/File.java
@@ -1,14 +1,27 @@
 package de.terrestris.shogun.lib.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.*;
-import org.hibernate.annotations.Type;
-
-import javax.persistence.*;
 import java.util.UUID;
+import javax.persistence.Cacheable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Type;
 
 @Entity(name = "files")
 @Table(schema = "shogun")
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString(callSuper = true)

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Group.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Group.java
@@ -1,19 +1,27 @@
 package de.terrestris.shogun.lib.model;
 
-import lombok.*;
-import org.hibernate.envers.AuditTable;
-import org.hibernate.envers.Audited;
-import org.keycloak.representations.idm.GroupRepresentation;
-
+import javax.persistence.Cacheable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 import javax.persistence.Transient;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.envers.AuditTable;
+import org.hibernate.envers.Audited;
+import org.keycloak.representations.idm.GroupRepresentation;
 
 @Entity(name = "groups")
 @Table(schema = "shogun")
 @Audited
 @AuditTable(value = "groups_rev", schema = "shogun_rev")
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Group.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Group.java
@@ -21,7 +21,7 @@ import org.keycloak.representations.idm.GroupRepresentation;
 @Audited
 @AuditTable(value = "groups_rev", schema = "shogun_rev")
 @Cacheable
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "groups")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/ImageFile.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/ImageFile.java
@@ -10,13 +10,10 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 @Entity(name = "imagefiles")
 @Table(schema = "shogun")
 @Cacheable
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/ImageFile.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/ImageFile.java
@@ -1,14 +1,22 @@
 package de.terrestris.shogun.lib.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.*;
-
+import javax.persistence.Cacheable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 @Entity(name = "imagefiles")
 @Table(schema = "shogun")
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Layer.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Layer.java
@@ -26,7 +26,7 @@ import org.hibernate.envers.Audited;
 @Audited
 @AuditTable(value = "layers_rev", schema = "shogun_rev")
 @Cacheable
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "layers")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Layer.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Layer.java
@@ -1,18 +1,32 @@
 package de.terrestris.shogun.lib.model;
 
 import de.terrestris.shogun.lib.enumeration.LayerType;
-import lombok.*;
+import java.util.Map;
+import javax.persistence.Basic;
+import javax.persistence.Cacheable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Type;
 import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
-
-import javax.persistence.*;
-import java.util.Map;
 
 @Entity(name = "layers")
 @Table(schema = "shogun")
 @Audited
 @AuditTable(value = "layers_rev", schema = "shogun_rev")
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Topic.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Topic.java
@@ -4,18 +4,28 @@ import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import de.terrestris.shogun.lib.resolver.ImageFileIdResolver;
-import lombok.*;
+import java.util.Map;
+import java.util.Set;
+import javax.persistence.Basic;
+import javax.persistence.Cacheable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.Type;
 import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
 import org.hibernate.envers.RelationTargetAuditMode;
-
-import javax.persistence.*;
-import java.awt.*;
-import java.util.Map;
-import java.util.Set;
 
 /**
  Entity representing a topic configuration, in particular:
@@ -27,6 +37,8 @@ import java.util.Set;
 @Table(schema = "shogun")
 @Audited
 @AuditTable(value = "topics_rev", schema = "shogun_rev")
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -43,6 +55,7 @@ public class Topic extends BaseEntity {
     @OneToOne
     @Fetch(FetchMode.JOIN)
     @Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     @JsonIdentityInfo(
         generator = ObjectIdGenerators.PropertyGenerator.class,
         property = "id",
@@ -59,6 +72,7 @@ public class Topic extends BaseEntity {
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb", name = "searchlayerconfigs")
     @Basic(fetch = FetchType.LAZY)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     private Set<Map<String, Object>> searchLayerConfigs;
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Topic.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Topic.java
@@ -38,7 +38,7 @@ import org.hibernate.envers.RelationTargetAuditMode;
 @Audited
 @AuditTable(value = "topics_rev", schema = "shogun_rev")
 @Cacheable
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "topics")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/User.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/User.java
@@ -26,7 +26,7 @@ import org.keycloak.representations.idm.UserRepresentation;
 @Audited
 @AuditTable(value = "users_rev", schema = "shogun_rev")
 @Cacheable
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "users")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/User.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/User.java
@@ -1,19 +1,32 @@
 package de.terrestris.shogun.lib.model;
 
-import lombok.*;
+import java.util.HashMap;
+import java.util.Map;
+import javax.persistence.Basic;
+import javax.persistence.Cacheable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Type;
 import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
 import org.keycloak.representations.idm.UserRepresentation;
 
-import javax.persistence.*;
-import java.util.HashMap;
-import java.util.Map;
-
 @Entity(name = "users")
 @Table(schema = "shogun")
 @Audited
 @AuditTable(value = "users_rev", schema = "shogun_rev")
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/ApplicationClientConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/ApplicationClientConfig.java
@@ -1,8 +1,6 @@
-package de.terrestris.shogun.lib.model.jsonb;
+package de.terrestris.shogun.lib.model.jsonb.application;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.io.Serializable;
 import java.util.Map;
@@ -10,6 +8,8 @@ import java.util.Map;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@ToString
+@EqualsAndHashCode
 public class ApplicationClientConfig implements Serializable {
     private String logoPath;
     private Map<String, Object> mapView;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/ClassPermission.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/ClassPermission.java
@@ -1,17 +1,21 @@
 package de.terrestris.shogun.lib.model.security.permission;
 
-import de.terrestris.shogun.lib.model.BaseEntity;
-import lombok.*;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
-import org.hibernate.envers.Audited;
+import static org.hibernate.envers.RelationTargetAuditMode.NOT_AUDITED;
 
+
+import de.terrestris.shogun.lib.model.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.FetchType;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.OneToOne;
-
-import static org.hibernate.envers.RelationTargetAuditMode.NOT_AUDITED;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.envers.Audited;
 
 @MappedSuperclass
 @Audited

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/GroupClassPermission.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/GroupClassPermission.java
@@ -20,7 +20,7 @@ import org.hibernate.envers.Audited;
 @Audited
 @AuditTable(value = "groupclasspermissions_rev", schema = "shogun_rev")
 @Cacheable
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="groupclasspermissions")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/GroupClassPermission.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/GroupClassPermission.java
@@ -1,18 +1,26 @@
 package de.terrestris.shogun.lib.model.security.permission;
 
 import de.terrestris.shogun.lib.model.Group;
-import lombok.*;
-import org.hibernate.envers.AuditTable;
-import org.hibernate.envers.Audited;
-
+import javax.persistence.Cacheable;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.envers.AuditTable;
+import org.hibernate.envers.Audited;
 
 @Entity(name = "groupclasspermissions")
 @Table(schema = "shogun")
 @Audited
 @AuditTable(value = "groupclasspermissions_rev", schema = "shogun_rev")
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -21,6 +29,7 @@ import javax.persistence.Table;
 public class GroupClassPermission extends ClassPermission {
 
     @ManyToOne(optional = false)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     private Group group;
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/GroupInstancePermission.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/GroupInstancePermission.java
@@ -20,7 +20,7 @@ import org.hibernate.envers.Audited;
 @Audited
 @AuditTable(value = "groupinstancepermissions_rev", schema = "shogun_rev")
 @Cacheable
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "groupinstancepermissions")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/GroupInstancePermission.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/GroupInstancePermission.java
@@ -1,18 +1,26 @@
 package de.terrestris.shogun.lib.model.security.permission;
 
 import de.terrestris.shogun.lib.model.Group;
-import lombok.*;
-import org.hibernate.envers.AuditTable;
-import org.hibernate.envers.Audited;
-
+import javax.persistence.Cacheable;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.envers.AuditTable;
+import org.hibernate.envers.Audited;
 
 @Entity(name = "groupinstancepermissions")
 @Table(schema = "shogun")
 @Audited
 @AuditTable(value = "groupinstancepermissions_rev", schema = "shogun_rev")
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -21,6 +29,7 @@ import javax.persistence.Table;
 public class GroupInstancePermission extends InstancePermission {
 
     @ManyToOne(optional = false)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     private Group group;
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/InstancePermission.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/InstancePermission.java
@@ -1,17 +1,21 @@
 package de.terrestris.shogun.lib.model.security.permission;
 
-import de.terrestris.shogun.lib.model.BaseEntity;
-import lombok.*;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
-import org.hibernate.envers.Audited;
+import static org.hibernate.envers.RelationTargetAuditMode.NOT_AUDITED;
 
+
+import de.terrestris.shogun.lib.model.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.FetchType;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.OneToOne;
-
-import static org.hibernate.envers.RelationTargetAuditMode.NOT_AUDITED;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.envers.Audited;
 
 @MappedSuperclass
 @Audited

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/PermissionCollection.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/PermissionCollection.java
@@ -25,7 +25,7 @@ import org.hibernate.annotations.FetchMode;
 @Entity(name = "permissions")
 @Table(schema = "shogun")
 @Cacheable
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "permissionCollectionCache")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "permissions")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -36,7 +36,7 @@ public class PermissionCollection extends BaseEntity {
     @CollectionTable(name="permission", schema = "shogun")
     @Enumerated(EnumType.STRING)
     @Fetch(FetchMode.JOIN)
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "permission")
     private Set<PermissionType> permissions = new HashSet<>();
 
     @Column(unique = true, nullable = false)

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/PermissionCollection.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/PermissionCollection.java
@@ -3,19 +3,29 @@ package de.terrestris.shogun.lib.model.security.permission;
 import de.terrestris.shogun.lib.enumeration.PermissionCollectionType;
 import de.terrestris.shogun.lib.enumeration.PermissionType;
 import de.terrestris.shogun.lib.model.BaseEntity;
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.Cacheable;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
-import javax.persistence.*;
-import java.util.HashSet;
-import java.util.Set;
-
 @Entity(name = "permissions")
 @Table(schema = "shogun")
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "permissionCollectionCache")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -26,6 +36,7 @@ public class PermissionCollection extends BaseEntity {
     @CollectionTable(name="permission", schema = "shogun")
     @Enumerated(EnumType.STRING)
     @Fetch(FetchMode.JOIN)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     private Set<PermissionType> permissions = new HashSet<>();
 
     @Column(unique = true, nullable = false)

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/UserClassPermission.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/UserClassPermission.java
@@ -1,18 +1,26 @@
 package de.terrestris.shogun.lib.model.security.permission;
 
 import de.terrestris.shogun.lib.model.User;
-import lombok.*;
-import org.hibernate.envers.AuditTable;
-import org.hibernate.envers.Audited;
-
+import javax.persistence.Cacheable;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.envers.AuditTable;
+import org.hibernate.envers.Audited;
 
 @Entity(name = "userclasspermissions")
 @Table(schema = "shogun")
 @Audited
 @AuditTable(value = "userclasspermissions_rev", schema = "shogun_rev")
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -21,6 +29,7 @@ import javax.persistence.Table;
 public class UserClassPermission extends ClassPermission {
 
     @ManyToOne(optional = false)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     private User user;
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/UserClassPermission.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/UserClassPermission.java
@@ -20,7 +20,7 @@ import org.hibernate.envers.Audited;
 @Audited
 @AuditTable(value = "userclasspermissions_rev", schema = "shogun_rev")
 @Cacheable
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "userclasspermissions")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/UserInstancePermission.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/UserInstancePermission.java
@@ -20,7 +20,7 @@ import org.hibernate.envers.Audited;
 @Audited
 @AuditTable(value = "userinstancepermissions_rev", schema = "shogun_rev")
 @Cacheable
-@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "userinstancepermissions")
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/UserInstancePermission.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/UserInstancePermission.java
@@ -1,18 +1,26 @@
 package de.terrestris.shogun.lib.model.security.permission;
 
 import de.terrestris.shogun.lib.model.User;
-import lombok.*;
-import org.hibernate.envers.AuditTable;
-import org.hibernate.envers.Audited;
-
+import javax.persistence.Cacheable;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.envers.AuditTable;
+import org.hibernate.envers.Audited;
 
 @Entity(name = "userinstancepermissions")
 @Table(schema = "shogun")
 @Audited
 @AuditTable(value = "userinstancepermissions_rev", schema = "shogun_rev")
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -21,6 +29,7 @@ import javax.persistence.Table;
 public class UserInstancePermission extends InstancePermission {
 
     @ManyToOne(optional = false)
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     private User user;
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/ApplicationRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/ApplicationRepository.java
@@ -1,15 +1,16 @@
 package de.terrestris.shogun.lib.repository;
 
 import de.terrestris.shogun.lib.model.Application;
-import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.stereotype.Repository;
-
 import java.util.Optional;
+import javax.persistence.QueryHint;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ApplicationRepository extends BaseCrudRepository<Application, Long>, JpaSpecificationExecutor<Application> {
 
+    @QueryHints(@QueryHint(name = org.hibernate.annotations.QueryHints.CACHEABLE, value = "true"))
     Optional<Application> findByName(String name);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/BaseCrudRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/BaseCrudRepository.java
@@ -1,8 +1,16 @@
 package de.terrestris.shogun.lib.repository;
 
+import java.util.List;
+import javax.persistence.QueryHint;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.data.repository.history.RevisionRepository;
 
 @NoRepositoryBean
-public interface BaseCrudRepository<T, ID> extends RevisionRepository<T, ID, Integer>, CrudRepository<T, ID> { }
+public interface BaseCrudRepository<T, ID> extends RevisionRepository<T, ID, Integer>, CrudRepository<T, ID> {
+
+    @QueryHints(@QueryHint(name = org.hibernate.annotations.QueryHints.CACHEABLE, value = "true"))
+    List<T> findAll();
+
+}

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/BaseFileRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/BaseFileRepository.java
@@ -1,13 +1,15 @@
 package de.terrestris.shogun.lib.repository;
 
-import org.springframework.data.repository.NoRepositoryBean;
-
 import java.util.Optional;
 import java.util.UUID;
+import javax.persistence.QueryHint;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.NoRepositoryBean;
 
 @NoRepositoryBean
 public interface BaseFileRepository<T, ID> extends BaseCrudRepository<T, ID> {
 
+    @QueryHints(@QueryHint(name = org.hibernate.annotations.QueryHints.CACHEABLE, value = "true"))
     Optional<T> findByFileUuid(UUID uuid);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/GroupRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/GroupRepository.java
@@ -1,14 +1,16 @@
 package de.terrestris.shogun.lib.repository;
 
 import de.terrestris.shogun.lib.model.Group;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.stereotype.Repository;
-
 import java.util.Optional;
+import javax.persistence.QueryHint;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GroupRepository extends BaseCrudRepository<Group, Long>, JpaSpecificationExecutor<Group> {
 
+    @QueryHints(@QueryHint(name = org.hibernate.annotations.QueryHints.CACHEABLE, value = "true"))
     Optional<Group> findByKeycloakId(String keycloakId);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/TopicRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/TopicRepository.java
@@ -1,14 +1,16 @@
 package de.terrestris.shogun.lib.repository;
 
 import de.terrestris.shogun.lib.model.Topic;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.stereotype.Repository;
-
 import java.util.Optional;
+import javax.persistence.QueryHint;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TopicRepository extends BaseCrudRepository<Topic, Long>, JpaSpecificationExecutor<Topic> {
 
+    @QueryHints(@QueryHint(name = org.hibernate.annotations.QueryHints.CACHEABLE, value = "true"))
     Optional<Topic> findByTitle(String title);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/UserRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/UserRepository.java
@@ -1,15 +1,16 @@
 package de.terrestris.shogun.lib.repository;
 
 import de.terrestris.shogun.lib.model.User;
-import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.stereotype.Repository;
-
 import java.util.Optional;
+import javax.persistence.QueryHint;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends BaseCrudRepository<User, Long>, JpaSpecificationExecutor<User> {
 
+    @QueryHints(@QueryHint(name = org.hibernate.annotations.QueryHints.CACHEABLE, value = "true"))
     Optional<User> findByKeycloakId(String keycloakId);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/security/permission/GroupClassPermissionRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/security/permission/GroupClassPermissionRepository.java
@@ -2,16 +2,18 @@ package de.terrestris.shogun.lib.repository.security.permission;
 
 import de.terrestris.shogun.lib.model.security.permission.GroupClassPermission;
 import de.terrestris.shogun.lib.repository.BaseCrudRepository;
+import java.util.Optional;
+import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface GroupClassPermissionRepository extends BaseCrudRepository<GroupClassPermission, Long>, JpaSpecificationExecutor<GroupClassPermission> {
 
     @Query("Select gcp from groupclasspermissions gcp where gcp.group.id = ?1 and gcp.className = ?2")
+    @QueryHints(@QueryHint(name = org.hibernate.annotations.QueryHints.CACHEABLE, value = "true"))
     Optional<GroupClassPermission> findByGroupIdAndClassName(Long groupId, String className);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/security/permission/GroupInstancePermissionRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/security/permission/GroupInstancePermissionRepository.java
@@ -2,19 +2,22 @@ package de.terrestris.shogun.lib.repository.security.permission;
 
 import de.terrestris.shogun.lib.model.security.permission.GroupInstancePermission;
 import de.terrestris.shogun.lib.repository.BaseCrudRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
-
 import java.util.List;
 import java.util.Optional;
+import javax.persistence.QueryHint;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GroupInstancePermissionRepository extends BaseCrudRepository<GroupInstancePermission, Long>, JpaSpecificationExecutor<GroupInstancePermission> {
 
     @Query("Select gip from groupinstancepermissions gip where gip.group.id = ?1 and gip.entityId = ?2")
+    @QueryHints(@QueryHint(name = org.hibernate.annotations.QueryHints.CACHEABLE, value = "true"))
     Optional<GroupInstancePermission> findByGroupIdAndEntityId(Long groupId, Long entityId);
 
+    @QueryHints(@QueryHint(name = org.hibernate.annotations.QueryHints.CACHEABLE, value = "true"))
     List<GroupInstancePermission> findByEntityId(Long entityId);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/security/permission/PermissionCollectionRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/security/permission/PermissionCollectionRepository.java
@@ -3,14 +3,16 @@ package de.terrestris.shogun.lib.repository.security.permission;
 import de.terrestris.shogun.lib.enumeration.PermissionCollectionType;
 import de.terrestris.shogun.lib.model.security.permission.PermissionCollection;
 import de.terrestris.shogun.lib.repository.BaseCrudRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.stereotype.Repository;
-
 import java.util.Optional;
+import javax.persistence.QueryHint;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PermissionCollectionRepository extends BaseCrudRepository<PermissionCollection, Long>, JpaSpecificationExecutor<PermissionCollection> {
 
+    @QueryHints(@QueryHint(name = org.hibernate.annotations.QueryHints.CACHEABLE, value = "true"))
     Optional<PermissionCollection> findByName(PermissionCollectionType name);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/security/permission/UserClassPermissionRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/security/permission/UserClassPermissionRepository.java
@@ -2,16 +2,18 @@ package de.terrestris.shogun.lib.repository.security.permission;
 
 import de.terrestris.shogun.lib.model.security.permission.UserClassPermission;
 import de.terrestris.shogun.lib.repository.BaseCrudRepository;
+import java.util.Optional;
+import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface UserClassPermissionRepository extends BaseCrudRepository<UserClassPermission, Long>, JpaSpecificationExecutor<UserClassPermission> {
 
     @Query("Select ucp from userclasspermissions ucp where ucp.user.id = ?1 and ucp.className = ?2")
+    @QueryHints(@QueryHint(name = org.hibernate.annotations.QueryHints.CACHEABLE, value = "true"))
     Optional<UserClassPermission> findByUserIdAndClassName(Long userId, String className);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/security/permission/UserInstancePermissionRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/security/permission/UserInstancePermissionRepository.java
@@ -2,19 +2,22 @@ package de.terrestris.shogun.lib.repository.security.permission;
 
 import de.terrestris.shogun.lib.model.security.permission.UserInstancePermission;
 import de.terrestris.shogun.lib.repository.BaseCrudRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
-
 import java.util.List;
 import java.util.Optional;
+import javax.persistence.QueryHint;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserInstancePermissionRepository extends BaseCrudRepository<UserInstancePermission, Long>, JpaSpecificationExecutor<UserInstancePermission> {
 
     @Query("Select uip from userinstancepermissions uip where uip.user.id = ?1 and uip.entityId = ?2")
+    @QueryHints(@QueryHint(name = org.hibernate.annotations.QueryHints.CACHEABLE, value = "true"))
     Optional<UserInstancePermission> findByUserIdAndEntityId(Long userId, Long entityId);
 
+    @QueryHints(@QueryHint(name = org.hibernate.annotations.QueryHints.CACHEABLE, value = "true"))
     List<UserInstancePermission> findByEntityId(Long entityId);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/security/access/entity/DefaultPermissionEvaluator.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/security/access/entity/DefaultPermissionEvaluator.java
@@ -4,5 +4,4 @@ import de.terrestris.shogun.lib.model.BaseEntity;
 import org.springframework.stereotype.Component;
 
 @Component
-public class DefaultPermissionEvaluator extends BaseEntityPermissionEvaluator<BaseEntity> {
-}
+public class DefaultPermissionEvaluator extends BaseEntityPermissionEvaluator<BaseEntity> { }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/CacheService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/CacheService.java
@@ -1,0 +1,30 @@
+package de.terrestris.shogun.lib.service;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceContext;
+import org.hibernate.Cache;
+import org.hibernate.SessionFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CacheService {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public void evictCache() throws Exception {
+
+        if (entityManager == null) {
+           throw new Exception("Could not get the entity manager.");
+        }
+
+        entityManager.clear();
+
+        EntityManagerFactory entityManagerFactory = entityManager.getEntityManagerFactory();
+        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
+        Cache cache = sessionFactory.getCache();
+
+        cache.evictAllRegions();
+    }
+}


### PR DESCRIPTION
This suggest to enable the second level and query cache for all entities via ehcache.

In addition a new interface `/cache/evict` is introduced to clear the current cache.

Please review @terrestris/devs.