### PR TITLE
implement permission check by target entity id

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/security/access/entity/EntityPermissionEvaluator.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/security/access/entity/EntityPermissionEvaluator.java
@@ -8,4 +8,6 @@ public interface EntityPermissionEvaluator<E> {
     Class<E> getEntityClassName();
 
     boolean hasPermission(User user, E entity, PermissionType permission);
+
+    boolean hasPermission(User user, Long entityId, String targetDomainType, PermissionType permission);
 }


### PR DESCRIPTION
This implements a new method 

```java
boolean hasPermission(User user, Long entityId, String targetDomainType, PermissionType permission);
```
in the EntityPermissionEvaluator which can be used to evaluate permissions based on the target entity id rather than providing the full entity.

Example usage:
```java
@PreAuthorize("hasPermission(filterObjectId, 'de.terrestris.shogun.model.User', 'READ')")
```
@terrestris/devs Please review
