### PR TITLE
Bump version of jts geometry serializer dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <swagger-codegen-maven-plugin.version>2.4.16</swagger-codegen-maven-plugin.version>
 
     <!-- JSON/Dataformats -->
-    <jackson-datatype-jts.version>0.12-2.5-1</jackson-datatype-jts.version>
+    <jackson-datatype-jts.version>1.0-2.7</jackson-datatype-jts.version>
 
     <!-- Logging -->
     <log4j.version>2.13.3</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,6 @@
 
     <!-- GeoServer/Geodata -->
     <geoserver-manager.version>1.7.0</geoserver-manager.version>
-    <jts.version>1.17.1</jts.version>
   </properties>
 
   <build>
@@ -617,12 +616,6 @@
         <groupId>com.graphhopper.external</groupId>
         <artifactId>jackson-datatype-jts</artifactId>
         <version>${jackson-datatype-jts.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.locationtech.jts</groupId>
-            <artifactId>jts</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>
@@ -641,12 +634,6 @@
         <groupId>com.sun.mail</groupId>
         <artifactId>javax.mail</artifactId>
         <version>${com.sun.mail.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.locationtech.jts</groupId>
-        <artifactId>jts-core</artifactId>
-        <version>${jts.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/shogun-lib/pom.xml
+++ b/shogun-lib/pom.xml
@@ -176,11 +176,6 @@
       <artifactId>javax.mail</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.locationtech.jts</groupId>
-      <artifactId>jts-core</artifactId>
-    </dependency>
-
     <!-- Testing -->
     <dependency>
       <groupId>org.springframework</groupId>


### PR DESCRIPTION
As stated [here](https://github.com/graphhopper/jackson-datatype-jts), jackson-datatype-jts 1.0-2.7 should be used in combination with jackson-databind 2.9.9 and JTS 1.16.0

Since usage of JTS >=1.17 leads to errors in serialization (`e.g. java.lang.NoSuchMethodError: 'org.locationtech.jts.geom.LineString org.locationtech.jts.geom.Polygon.getExteriorRing()'`), I suggest to use JTS 1.16.0 as a transitive dependency of  jackson-datatype-jts 1.0-2.7

Plz review @terrestris/devs 