### PR TITLE
Excludes JSONB fields from toString

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Application.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Application.java
@@ -39,6 +39,7 @@ public class Application extends BaseEntity {
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
     @Basic(fetch = FetchType.LAZY)
+    @ToString.Exclude
     private Locale i18n;
 
     @Column
@@ -47,21 +48,25 @@ public class Application extends BaseEntity {
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
     @Basic(fetch = FetchType.LAZY)
+    @ToString.Exclude
     private ApplicationClientConfig clientConfig;
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
     @Basic(fetch = FetchType.LAZY)
+    @ToString.Exclude
     private Map<String, Object> layerTree;
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
     @Basic(fetch = FetchType.LAZY)
+    @ToString.Exclude
     private Map<String, Object> layerConfig;
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
     @Basic(fetch = FetchType.LAZY)
+    @ToString.Exclude
     private Map<String, Object> toolConfig;
 }
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Layer.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Layer.java
@@ -40,16 +40,19 @@ public class Layer extends BaseEntity {
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
     @Basic(fetch = FetchType.LAZY)
+    @ToString.Exclude
     private Map<String, Object> clientConfig;
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb", nullable = false)
     @Basic(fetch = FetchType.LAZY)
+    @ToString.Exclude
     private Map<String, Object> sourceConfig;
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
     @Basic(fetch = FetchType.LAZY)
+    @ToString.Exclude
     private Map<String, Object> features;
 
     @Column(nullable = false)

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Topic.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Topic.java
@@ -67,12 +67,14 @@ public class Topic extends BaseEntity {
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb", name = "layertree")
     @Basic(fetch = FetchType.LAZY)
+    @ToString.Exclude
     private Map<String, Object> layerTree;
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb", name = "searchlayerconfigs")
     @Basic(fetch = FetchType.LAZY)
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+    @ToString.Exclude
     private Set<Map<String, Object>> searchLayerConfigs;
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/User.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/User.java
@@ -43,11 +43,13 @@ public class User extends BaseEntity {
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
     @Basic(fetch = FetchType.LAZY)
+    @ToString.Exclude
     private Map<String, Object> details = new HashMap<>();
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
     @Basic(fetch = FetchType.LAZY)
+    @ToString.Exclude
     private Map<String, Object> clientConfig = new HashMap<>();
 
 }


### PR DESCRIPTION
This excludes all properties marked with `@Type(type = "jsonb")` from the `toString` method as the json is completly written.
As the content is not limited this can massively blow up the string.