### PR TITLE
Skip jib execution on mvn release:perform

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -37,6 +37,6 @@ pushd "$SCRIPTDIR"/..
 mvn release:clean
 mvn release:prepare --batch-mode -DreleaseVersion="$RELEASE_VERSION" -DdevelopmentVersion="$DEVELOPMENT_VERSION" -DtagNameFormat=v@{project.version} -Darguments="-DskipTests"
 # Deployment will be handled by GitHub actions
-mvn release:perform --batch-mode -Darguments="-Dmaven.deploy.skip=true"
+mvn release:perform --batch-mode -Darguments="-Dmaven.deploy.skip=true -Djib.skip=true"
 
 popd


### PR DESCRIPTION
All deploy actions will be performed during the execution of the GitHub actions.

Please review @terrestris/devs.