### PR TITLE
Introduces updatePartial interface

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/BaseController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/BaseController.java
@@ -507,6 +507,10 @@ public abstract class BaseController<T extends BaseService<?, S>, S extends Base
                     ),
                     ade
             );
+        } catch (NumberFormatException nfe) {
+            LOG.error("Can't parse 'id' field ({}) from values ({}). It has to be an Integer.",
+                values, entityId, nfe.getMessage());
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
         } catch (ResponseStatusException rse) {
             throw rse;
         } catch (Exception e) {

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/BaseService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/BaseService.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public abstract class BaseService<T extends BaseCrudRepository<S, Long> & JpaSpecificationExecutor<S>, S extends BaseEntity> {
@@ -92,6 +93,17 @@ public abstract class BaseService<T extends BaseCrudRepository<S, Long> & JpaSpe
         Optional<S> persistedEntity = repository.findById(id);
 
         JsonNode jsonObject = objectMapper.valueToTree(entity);
+        S updatedEntity = objectMapper.readerForUpdating(persistedEntity.get()).readValue(jsonObject);
+
+        return repository.save(updatedEntity);
+    }
+
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#entity, 'UPDATE')")
+    @Transactional(isolation = Isolation.SERIALIZABLE)
+    public S updatePartial(Long id, Map<String, Object> values) throws IOException {
+        Optional<S> persistedEntity = repository.findById(id);
+
+        JsonNode jsonObject = objectMapper.valueToTree(values);
         S updatedEntity = objectMapper.readerForUpdating(persistedEntity.get()).readValue(jsonObject);
 
         return repository.save(updatedEntity);


### PR DESCRIPTION
This introduces controller and service methods to partially update entities.

The passed values object has to include the `id` which has to be equal to the one from the PATCH url.

Values which can't be associated with the entity will be ignored:

## Examples
#### Valid :heavy_check_mark: 
Send [HTTP PATCH](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PATCH) request to: `http://localhost:9090/shogun-boot/applications/21`
**_200 OK_**
```
{
  "id": 21,
  "name": "My new App"
}
```

#### Valid :heavy_check_mark: 
Send [HTTP PATCH](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PATCH) request to: `http://localhost:9090/shogun-boot/applications/21`
**_200 OK_**
```
{
  "id": 21,
  "name": "My new App",
  "opacity": 0.234
}
```

#### Invalid :x:  
Send [HTTP PATCH](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PATCH) request to: `http://localhost:9090/shogun-boot/applications/21`
**_400 Bad Request_**
```
{
  "id": 22,
  "name": "My new App"
}
```

#### Invalid :x:  
Send [HTTP PATCH](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PATCH) request to: `http://localhost:9090/shogun-boot/applications/21`
**_400 Bad Request_**
```
{
  "name": "My new App"
}
```


Closes #169 