### PR TITLE
Init jackson ID resolver (v3)

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/resolver/BaseEntityIdResolver.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/resolver/BaseEntityIdResolver.java
@@ -1,0 +1,60 @@
+package de.terrestris.shoguncore.resolver;
+
+import com.fasterxml.jackson.annotation.ObjectIdGenerator.IdKey;
+import com.fasterxml.jackson.annotation.ObjectIdResolver;
+import com.fasterxml.jackson.annotation.SimpleObjectIdResolver;
+import com.sun.jdi.InvalidTypeException;
+import de.terrestris.shoguncore.model.BaseEntity;
+import de.terrestris.shoguncore.service.BaseService;
+import de.terrestris.shoguncore.util.ApplicationContextProvider;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Optional;
+import javassist.NotFoundException;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+
+@Log4j2
+public abstract class BaseEntityIdResolver<E extends BaseEntity, S extends BaseService> extends SimpleObjectIdResolver {
+
+    @Autowired
+    protected S service;
+
+    @Override
+    public E resolveId(IdKey idKey) {
+        try {
+            if (idKey.key instanceof Long) {
+                final Long id = (Long) idKey.key;
+                Optional<E> entity = service.findOne(id);
+
+                if (entity.isPresent()) {
+                    return entity.get();
+                } else {
+                    throw new NotFoundException("Could not find entity with ID " + id);
+                }
+            } else {
+                throw new InvalidTypeException("ID is not of type Long.");
+            }
+        } catch (Exception e) {
+            log.error("Could not resolve object: {}", e.getMessage());
+            log.trace("Full stack trace: ", e);
+            return null;
+        }
+    }
+
+    @Override
+    public ObjectIdResolver newForDeserialization(Object context) {
+        try {
+            BaseEntityIdResolver instance = getClass().getDeclaredConstructor().newInstance();
+            ApplicationContext applicationContext = ApplicationContextProvider.getContext();
+            applicationContext.getAutowireCapableBeanFactory().autowireBean(instance);
+
+            return instance;
+        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+            log.error("Error instantiating a BaseEntityIdResolver: " + e.getMessage());
+            log.trace("Full stack trace: ", e);
+        }
+        return null;
+    }
+
+}

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/util/ApplicationContextProvider.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/util/ApplicationContextProvider.java
@@ -1,0 +1,21 @@
+package de.terrestris.shoguncore.util;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApplicationContextProvider implements ApplicationContextAware {
+
+    private static ApplicationContext applicationContext;
+
+    public static ApplicationContext getContext() {
+        return applicationContext;
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+}


### PR DESCRIPTION
Cherry picks the `BaseEntityIdResolver` introduced in #56 from the current `master` branch.