### PR TITLE
Introduce conditional controller instances (v3)

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/controller/ApplicationController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/controller/ApplicationController.java
@@ -2,10 +2,11 @@ package de.terrestris.shoguncore.controller;
 
 import de.terrestris.shoguncore.model.Application;
 import de.terrestris.shoguncore.service.ApplicationService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/applications")
-public class ApplicationController extends BaseController<ApplicationService, Application> {
-}
+@ConditionalOnExpression("${controller.applications.enabled:true}")
+public class ApplicationController extends BaseController<ApplicationService, Application> { }

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/controller/FileController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/controller/FileController.java
@@ -2,20 +2,31 @@ package de.terrestris.shoguncore.controller;
 
 import de.terrestris.shoguncore.model.File;
 import de.terrestris.shoguncore.service.FileService;
+import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
-import org.springframework.http.*;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.UUID;
-
 @RestController
 @RequestMapping("/files")
+@ConditionalOnExpression("${controller.files.enabled:true}")
 public class FileController {
 
     protected final Logger LOG = LogManager.getLogger(getClass());

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/controller/GroupController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/controller/GroupController.java
@@ -2,10 +2,11 @@ package de.terrestris.shoguncore.controller;
 
 import de.terrestris.shoguncore.model.Group;
 import de.terrestris.shoguncore.service.GroupService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/groups")
-public class GroupController extends BaseController<GroupService, Group> {
-}
+@ConditionalOnExpression("${controller.groups.enabled:true}")
+public class GroupController extends BaseController<GroupService, Group> { }

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/controller/ImageFileController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/controller/ImageFileController.java
@@ -2,10 +2,11 @@ package de.terrestris.shoguncore.controller;
 
 import de.terrestris.shoguncore.model.ImageFile;
 import de.terrestris.shoguncore.service.ImageFileService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/imagefiles")
-public class ImageFileController extends BaseController<ImageFileService, ImageFile> {
-}
+@ConditionalOnExpression("${controller.imagefiles.enabled:true}")
+public class ImageFileController extends BaseController<ImageFileService, ImageFile> { }

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/controller/LayerController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/controller/LayerController.java
@@ -2,10 +2,11 @@ package de.terrestris.shoguncore.controller;
 
 import de.terrestris.shoguncore.model.Layer;
 import de.terrestris.shoguncore.service.LayerService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/layers")
-public class LayerController extends BaseController<LayerService, Layer> {
-}
+@ConditionalOnExpression("${controller.layers.enabled:true}")
+public class LayerController extends BaseController<LayerService, Layer> { }

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/controller/RoleController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/controller/RoleController.java
@@ -2,10 +2,11 @@ package de.terrestris.shoguncore.controller;
 
 import de.terrestris.shoguncore.model.Role;
 import de.terrestris.shoguncore.service.RoleService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/roles")
-public class RoleController extends BaseController<RoleService, Role> {
-}
+@ConditionalOnExpression("${controller.roles.enabled:true}")
+public class RoleController extends BaseController<RoleService, Role> { }

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/controller/UserController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/controller/UserController.java
@@ -15,6 +15,7 @@ import java.net.URISyntaxException;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.core.env.Environment;
@@ -33,6 +34,7 @@ import org.springframework.web.servlet.view.RedirectView;
 
 @RestController
 @RequestMapping("/users")
+@ConditionalOnExpression("${controller.users.enabled:true}")
 public class UserController extends BaseController<UserService, User> {
 
     @Autowired

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/controller/security/IdentityController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/controller/security/IdentityController.java
@@ -7,17 +7,21 @@ import de.terrestris.shoguncore.model.security.Identity;
 import de.terrestris.shoguncore.service.GroupService;
 import de.terrestris.shoguncore.service.UserService;
 import de.terrestris.shoguncore.service.security.IdentityService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.i18n.LocaleContextHolder;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
-
 import java.util.List;
 import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/identities")
+@ConditionalOnExpression("${controller.identities.enabled:true}")
 public class IdentityController extends BaseController<IdentityService, Identity> {
 
     @Autowired


### PR DESCRIPTION
This makes the creation of all controller instances configurable, e.g. via the following entries in the `application.properties`:

```
controller.applications.enabled=false
controller.files.enabled=true
controller.groups.enabled=false
controller.identities.enabled=false
controller.imagefiles.enabled=true
controller.layers.enabled=true
controller.roles.enabled=false
controller.users.enabled=true
```

Once accepted, this should also be applied to the `master` branch.

Please review @terrestris/devs.
