### PR TITLE
Introduce conditional controller instances for shogun-boot (v3) 

### DIFF
--- a/shogun-boot/src/main/java/de/terrestris/shogunboot/controller/ApplicationInfoController.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogunboot/controller/ApplicationInfoController.java
@@ -5,6 +5,7 @@ import de.terrestris.shogunboot.service.ApplicationInfoService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,6 +17,7 @@ import org.springframework.web.server.ResponseStatusException;
  */
 @RestController
 @RequestMapping("/info")
+@ConditionalOnExpression("${controller.info.enabled:true}")
 public class ApplicationInfoController {
 
     protected final Logger LOG = LogManager.getLogger(getClass());

--- a/shogun-boot/src/main/java/de/terrestris/shogunboot/controller/AuthController.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogunboot/controller/AuthController.java
@@ -2,6 +2,7 @@ package de.terrestris.shogunboot.controller;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/auth")
+@ConditionalOnExpression("${controller.auth.enabled:true}")
 public class AuthController {
 
     protected final Logger LOG = LogManager.getLogger(getClass());


### PR DESCRIPTION
This also makes the creation of all shogun-boot controller instances configurable:

```
controller.auth.enabled=true
controller.info.enabled=true
```

Please review @terrestris/devs.