### PR TITLE
Add git commit hash to build information

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,7 @@
                 <additionalProperties>
                   <encoding.source>${project.encoding}</encoding.source>
                   <encoding.reporting>${project.encoding}</encoding.reporting>
+                  <commithash>${git.commit.id.abbrev}</commithash>
                 </additionalProperties>
               </configuration>
             </execution>

--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/dto/ApplicationInfo.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/dto/ApplicationInfo.java
@@ -17,6 +17,8 @@ public class ApplicationInfo {
 
     private String buildTime;
 
+    private String commitHash;
+
     private Long userId;
 
     private List<String> authorities;

--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/service/ApplicationInfoService.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/service/ApplicationInfoService.java
@@ -65,6 +65,7 @@ public class ApplicationInfoService {
 
         applicationInfo.setBuildTime(props.getProperty("build.time"));
         applicationInfo.setVersion(props.getProperty("build.version"));
+        applicationInfo.setCommitHash(props.getProperty("build.commithash"));
 
         return applicationInfo;
     }


### PR DESCRIPTION
Add `commithash` property to `build-info` config to grab the commit hash info while packaging and make it accessible via `build.properties` file.

```
build.artifact=shogun-boot
build.commithash=2f454564
build.encoding.reporting=UTF-8
build.encoding.source=UTF-8
build.group=de.terrestris
build.name=SHOGun Boot
build.time=2020-12-07T12\:17\:33.402Z
build.version=6.1.1-SNAPSHOT
```

Please review @terrestris/devs 