### PR TITLE
Group permission retrieval (v3)

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/config/MethodSecurityConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/config/MethodSecurityConfig.java
@@ -1,53 +1,29 @@
 package de.terrestris.shoguncore.config;
 
 import de.terrestris.shoguncore.security.access.BasePermissionEvaluator;
-import de.terrestris.shoguncore.security.access.entity.BaseEntityPermissionEvaluator;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 // TODO Move to shogun-boot?!
 @Configuration
 @EnableGlobalMethodSecurity(prePostEnabled = true)
-//@ComponentScan(basePackages = { "de.terrestris.shogunboot", "de.terrestris.shoguncore" })
 public class MethodSecurityConfig extends GlobalMethodSecurityConfiguration {
 
     @Autowired
     private BasePermissionEvaluator basePermissionEvaluator;
 
-    @Autowired
-    private List<BaseEntityPermissionEvaluator> permissionEvaluators;
-
     @Override
     protected MethodSecurityExpressionHandler createExpressionHandler() {
         DefaultMethodSecurityExpressionHandler expressionHandler =
                 new DefaultMethodSecurityExpressionHandler();
-        //expressionHandler.setRoleHierarchy();
-//        BasePermissionEvaluator basePermissionEvaluator = new BasePermissionEvaluator();
-//        basePermissionEvaluator.setPermissionEvaluatorFactory(permissionEvaluatorFactory);
+
         expressionHandler.setPermissionEvaluator(basePermissionEvaluator);
 
         return expressionHandler;
     }
 
-//    @Bean
-//    public PermissionEvaluator permissionEvaluator() {
-//        Map<String, PermissionEvaluator> map = new HashMap<>();
-//
-//        // Build lookup table of PermissionEvaluator by supported target type
-//        for (BaseEntityPermissionEvaluator permissionEvaluator : permissionEvaluators) {
-//            map.put(permissionEvaluator.getTargetType(), permissionEvaluator);
-//        }
-//
-//        return new BasePermissionEvaluator(map);
-//    }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/controller/BaseController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/controller/BaseController.java
@@ -32,21 +32,6 @@ public abstract class BaseController<T extends BaseService<?, S>, S extends Base
     @Autowired
     protected UserInstancePermissionService userInstancePermissionService;
 
-//    @GetMapping("/filterjsonb")
-//    @ResponseStatus(HttpStatus.OK)
-//    public List<S> findAllBy(@RequestParam String column, @RequestParam String filter) {
-//        return service.findByFilter(column, filter);
-//    }
-//
-//    @GetMapping("/filter/{attribute}")
-//    @ResponseStatus(HttpStatus.OK)
-//    public List<S> findAllBy(
-//            @PathVariable("attribute") String attribute,
-//            @RequestParam String path,
-//            @RequestParam String value) {
-//        return service.findBy(attribute, path, value);
-//    }
-
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
     public List<S> findAll() {

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/security/access/BasePermissionEvaluator.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/security/access/BasePermissionEvaluator.java
@@ -82,30 +82,6 @@ public class BasePermissionEvaluator implements PermissionEvaluator {
         return false;
     }
 
-//    public boolean hasClassPermission(Authentication authentication, BaseEntity targetDomainObject, Object permissionObject) {
-//        LOG.trace("About to evaluate permission for authentication '{}' targetDomainObject '{}' " +
-//                "and permissionObject '{}'", authentication, targetDomainObject, permissionObject);
-//
-//        if ((authentication == null) || (targetDomainObject == null) || !(permissionObject instanceof String)) {
-//            LOG.trace("Restricting access since not all input requirements are met.");
-//            return false;
-//        }
-//
-//        User user = this.getUserFromAuthentication(authentication);
-//
-//        String accountName = user != null ? user.getUsername() : ANONYMOUS_USERNAME;
-//
-//        final PermissionType permission = PermissionType.valueOf((String) permissionObject);
-//
-//        LOG.trace("Evaluating whether user '{}' has permission '{}' on class '{}", accountName,
-//                permission, targetDomainObject.getClass().getSimpleName());
-//
-//        BaseEntityPermissionEvaluator entityPermissionEvaluator =
-//                this.getPermissionEvaluatorForClass(targetDomainObject);
-//
-//        return entityPermissionEvaluator.hasPermission(user, targetDomainObject.getClass(), permission);
-//    }
-
     /**
      * Returns the {@BaseEntityPermissionEvaluator} for the given {@BaseEntity}.
      *

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/security/access/entity/BaseEntityPermissionEvaluator.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/security/access/entity/BaseEntityPermissionEvaluator.java
@@ -46,7 +46,41 @@ public abstract class BaseEntityPermissionEvaluator<E extends BaseEntity> implem
         final String simpleClassName = entity.getClass().getSimpleName();
 
         // CHECK USER INSTANCE PERMISSIONS
-        PermissionCollection userPermissionCol = null;
+        if (this.hasPermissionByUserInstancePermission(user, entity, permission)) {
+            LOG.trace("Granting {} access by user instance permissions", permission);
+
+            return true;
+        }
+
+        // CHECK GROUP INSTANCE PERMISSIONS
+        if (this.hasPermissionByGroupInstancePermission(user, entity, permission)) {
+            LOG.trace("Granting {} access by group instance permissions", permission);
+
+            return true;
+        }
+
+        // CHECK USER CLASS PERMISSIONS
+        if (this.hasPermissionByUserClassPermission(user, entity, permission)) {
+            LOG.trace("Granting {} access by user class permissions", permission);
+
+            return true;
+        }
+
+        // CHECK GROUP CLASS PERMISSIONS
+        if (this.hasPermissionByGroupClassPermission(user, entity, permission)) {
+            LOG.trace("Granting {} access by group class permissions", permission);
+
+            return true;
+        }
+
+        LOG.trace("Restricting {} access on secured object '{}' with ID {}",
+            permission, simpleClassName, entity.getId());
+
+        return false;
+    }
+
+    public boolean hasPermissionByUserInstancePermission(User user, BaseEntity entity, PermissionType permission) {
+        PermissionCollection userPermissionCol;
         if (permission.equals(PermissionType.CREATE) && entity.getId() == null) {
             userPermissionCol = new PermissionCollection();
         } else {
@@ -56,13 +90,12 @@ public abstract class BaseEntityPermissionEvaluator<E extends BaseEntity> implem
 
         // Grant access if user explicitly has the requested permission or
         // if the user has the ADMIN permission
-        if (userInstancePermissions.contains(permission) || userInstancePermissions.contains(PermissionType.ADMIN)) {
-            LOG.trace("Granting " + permission + " access by user instance permissions");
-            return true;
-        }
+        return userInstancePermissions.contains(permission) ||
+            userInstancePermissions.contains(PermissionType.ADMIN);
+    }
 
-        // CHECK GROUP INSTANCE PERMISSIONS
-        PermissionCollection groupPermissionsCol = null;
+    public boolean hasPermissionByGroupInstancePermission(User user, BaseEntity entity, PermissionType permission) {
+        PermissionCollection groupPermissionsCol;
         if (permission.equals(PermissionType.CREATE) && entity.getId() == null) {
             groupPermissionsCol = new PermissionCollection();
         } else {
@@ -72,36 +105,27 @@ public abstract class BaseEntityPermissionEvaluator<E extends BaseEntity> implem
 
         // Grant access if group explicitly has the requested permission or
         // if the group has the ADMIN permission
-        if (groupInstancePermissions.contains(permission) || groupInstancePermissions.contains(PermissionType.ADMIN)) {
-            LOG.trace("Granting " + permission + " access by group instance permissions");
-            return true;
-        }
+        return groupInstancePermissions.contains(permission) ||
+            groupInstancePermissions.contains(PermissionType.ADMIN);
+    }
 
-        // CHECK USER CLASS PERMISSIONS
+    public boolean hasPermissionByUserClassPermission(User user, BaseEntity entity, PermissionType permission) {
         PermissionCollection userClassPermissionCol = userClassPermissionService.findPermissionCollectionFor(entity, user);
         final Set<PermissionType> userClassPermissions = userClassPermissionCol.getPermissions();
 
         // Grant access if user explicitly has the requested permission or
         // if the group has the ADMIN permission
-        if (userClassPermissions.contains(permission) || userClassPermissions.contains(PermissionType.ADMIN)) {
-            LOG.trace("Granting " + permission + " access by user class permissions");
-            return true;
-        }
+        return userClassPermissions.contains(permission) ||
+            userClassPermissions.contains(PermissionType.ADMIN);
+    }
 
-        // CHECK GROUP CLASS PERMISSIONS
+    public boolean hasPermissionByGroupClassPermission(User user, BaseEntity entity, PermissionType permission) {
         PermissionCollection groupClassPermissionsCol = groupClassPermissionService.findPermissionCollectionFor(entity, user);
         final Set<PermissionType> groupClassPermissions = groupClassPermissionsCol.getPermissions();
 
         // Grant access if group explicitly has the requested permission or
         // if the group has the ADMIN permission
-        if (groupClassPermissions.contains(permission) || groupClassPermissions.contains(PermissionType.ADMIN)) {
-            LOG.trace("Granting " + permission + " access by group instance permissions");
-            return true;
-        }
-
-        LOG.trace("Restricting " + permission + " access on secured object '"
-                + simpleClassName + "' with ID " + entity.getId());
-
-        return false;
+        return groupClassPermissions.contains(permission) ||
+            groupClassPermissions.contains(PermissionType.ADMIN);
     }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/security/access/entity/BaseEntityPermissionEvaluator.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/security/access/entity/BaseEntityPermissionEvaluator.java
@@ -9,12 +9,11 @@ import de.terrestris.shoguncore.service.security.permission.GroupClassPermission
 import de.terrestris.shoguncore.service.security.permission.GroupInstancePermissionService;
 import de.terrestris.shoguncore.service.security.permission.UserClassPermissionService;
 import de.terrestris.shoguncore.service.security.permission.UserInstancePermissionService;
+import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.GenericTypeResolver;
-
-import java.util.Set;
 
 //@Component
 public abstract class BaseEntityPermissionEvaluator<E extends BaseEntity> implements EntityPermissionEvaluator<E> {

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/GroupClassPermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/GroupClassPermissionService.java
@@ -30,30 +30,13 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
     @Autowired
     IdentityService identityService;
 
-    public Optional<GroupClassPermission> findFor(BaseEntity entity, Group group) {
-
-        LOG.trace("Getting all group class permissions for group {} and entity class {}",
-                group.getName(), entity.getClass().getCanonicalName());
-
-        return repository.findOne(Specification.where(
-                GroupClassPermissionSpecifications.hasEntity(entity)).and(
-                GroupClassPermissionSpecifications.hasGroup(group)
-        ));
-    }
-
-    public Optional<GroupClassPermission> findFor(BaseEntity entity, User user) {
-
-        LOG.trace("Getting all group class permissions for user {} and entity {}", user.getUsername(), entity);
-
-        // Get all groups of the user
-        List<Group> groups = identityService.findAllGroupsFrom(user);
-
-        return repository.findOne(Specification.where(
-            GroupClassPermissionSpecifications.hasEntity(entity)).and(
-            GroupClassPermissionSpecifications.hasGroups(groups)
-        ));
-    }
-
+    /**
+     * Returns the {@link GroupClassPermission} for the given query arguments.
+     *
+     * @param clazz The class to find the permission for.
+     * @param group The group to find the permission for.
+     * @return The (optional) permission.
+     */
     public Optional<GroupClassPermission> findFor(Class<? extends BaseEntity> clazz, Group group) {
 
         LOG.trace("Getting all group class permissions for group {} and entity class {}",
@@ -65,6 +48,55 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
         ));
     }
 
+    /**
+     * Returns the {@link GroupClassPermission} for the given query arguments. Hereby
+     * the class of the given entity will be considered.
+     *
+     * @param entity The entity to find the permission for.
+     * @param group The group to find the permission for.
+     * @return The (optional) permission.
+     */
+    public Optional<GroupClassPermission> findFor(BaseEntity entity, Group group) {
+
+        LOG.trace("Getting all group class permissions for group {} and entity class {}",
+                group.getName(), entity.getClass().getCanonicalName());
+
+        return repository.findOne(Specification.where(
+                GroupClassPermissionSpecifications.hasEntity(entity)).and(
+                GroupClassPermissionSpecifications.hasGroup(group)
+        ));
+    }
+
+    /**
+     * Returns the {@link GroupClassPermission} for the given query arguments. Hereby
+     * the class of the given entity and all groups of the given user will be considered.
+     *
+     * @param entity The entity to find the permission for.
+     * @param user The user to find the permission for.
+     * @return The (optional) permission.
+     */
+    public Optional<GroupClassPermission> findFor(BaseEntity entity, User user) {
+
+        LOG.trace("Getting all group class permissions for user {} and entity {}",
+            user.getUsername(), entity);
+
+        // Get all groups of the user
+        List<Group> groups = identityService.findAllGroupsFrom(user);
+
+        return repository.findOne(Specification.where(
+            GroupClassPermissionSpecifications.hasEntity(entity)).and(
+            GroupClassPermissionSpecifications.hasGroups(groups)
+        ));
+    }
+
+    /**
+     * Returns the {@link GroupClassPermission} for the given query arguments. Hereby
+     * all groups of the given user will be considered.
+     *
+     * @param clazz The class to find the permission for.
+     * @param user The user to find the permission for.
+     * @return The (optional) permission.
+     */
     public Optional<GroupClassPermission> findFor(Class<? extends BaseEntity> clazz, User user) {
 
         LOG.trace("Getting all group class permissions for user {} and entity class {}",
@@ -79,6 +111,15 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
         ));
     }
 
+    /**
+     * Returns the {@link GroupClassPermission} for the given query arguments. Hereby
+     * it will be considered if the user is currently a member of the given group.
+     *
+     * @param entity The entity to find the permission for.
+     * @param group The group to find the permission for.
+     * @param user The user to find the permission for.
+     * @return The (optional) permission.
+     */
     public Optional<GroupClassPermission> findFor(BaseEntity entity, Group group, User user) {
 
         LOG.trace("Getting all group class permissions for user {} and entity {} in the " +
@@ -98,24 +139,55 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
         ));
     }
 
+    /**
+     * Returns the {@link PermissionCollection} for the given query arguments.
+     *
+     * @param entity The entity to find the collection for.
+     * @param group The group to find the collection for.
+     * @return The collection (may be empty).
+     */
     public PermissionCollection findPermissionCollectionFor(BaseEntity entity, Group group) {
         Optional<GroupClassPermission> groupClassPermission = this.findFor(entity, group);
 
         return getPermissionCollection(groupClassPermission);
     }
 
+    /**
+     * Returns the {@link PermissionCollection} for the given query arguments. Hereby
+     * all groups of the given user will be considered.
+     *
+     * @param entity The entity to find the collection for.
+     * @param user The user to find the collection for.
+     * @return The collection (may be empty).
+     */
     public PermissionCollection findPermissionCollectionFor(BaseEntity entity, User user) {
         Optional<GroupClassPermission> groupClassPermission = this.findFor(entity, user);
 
         return getPermissionCollection(groupClassPermission);
     }
 
+    /**
+     * Returns the {@link PermissionCollection} for the given query arguments. Hereby
+     * it will be considered if the user is currently a member of the given group.
+     *
+     * @param entity The entity to find the collection for.
+     * @param group The group to find the collection for.
+     * @param user The user to find the collection for.
+     * @return The collection (may be empty).
+     */
     public PermissionCollection findPermissionCollectionFor(BaseEntity entity, Group group, User user) {
         Optional<GroupClassPermission> groupClassPermission = this.findFor(entity, group, user);
 
         return getPermissionCollection(groupClassPermission);
     }
 
+    /**
+     * Sets the given {@link PermissionCollectionType} for the given class and group.
+     *
+     * @param clazz The class to set the permission for.
+     * @param group The group to set the permission for.
+     * @param permissionCollectionType The permission to set.
+     */
     public void setPermission(Class<? extends BaseEntity> clazz, Group group, PermissionCollectionType permissionCollectionType) {
         Optional<PermissionCollection> permissionCollection = permissionCollectionRepository.findOne(
             PermissionCollectionSpecification.findByName(permissionCollectionType));
@@ -145,6 +217,14 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
         repository.save(groupClassPermission);
     }
 
+    /**
+     * Helper function to get the {@link PermissionCollection} from a given
+     * class permission. If no collection is available, it returns an empty
+     * list.
+     *
+     * @param classPermission The classPermission to get the permissions from.
+     * @return The collection (may be empty).
+     */
     private PermissionCollection getPermissionCollection(Optional<GroupClassPermission> classPermission) {
         if (classPermission.isPresent()) {
             return classPermission.get().getPermissions();

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/GroupInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/GroupInstancePermissionService.java
@@ -27,9 +27,17 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
     @Autowired
     protected PermissionCollectionRepository permissionCollectionRepository;
 
+    /**
+     * Returns the {@link GroupInstancePermission} for the given query arguments.
+     *
+     * @param entity The entity to find the permission for.
+     * @param group The group to find the permission for.
+     * @return The (optional) permission.
+     */
     public Optional<GroupInstancePermission> findFor(BaseEntity entity, Group group) {
 
-        LOG.trace("Getting all group permissions for group {} and entity {}", group.getName(), entity);
+        LOG.trace("Getting all group permissions for group {} and entity {}",
+            group.getName(), entity);
 
         return repository.findOne(Specification.where(
                 GroupInstancePermissionSpecifications.hasEntity(entity)).and(
@@ -37,9 +45,18 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
         ));
     }
 
+    /**
+     * Returns the {@link GroupInstancePermission} for the given query arguments. Hereby
+     * all groups of the given user will be considered.
+     *
+     * @param entity The entity to find the permission for.
+     * @param user The user to find the permission for.
+     * @return The (optional) permission.
+     */
     public Optional<GroupInstancePermission> findFor(BaseEntity entity, User user) {
 
-        LOG.trace("Getting all group permissions for user {} and entity {}", user.getUsername(), entity);
+        LOG.trace("Getting all group permissions for user {} and entity {}",
+            user.getUsername(), entity);
 
         // Get all groups of the user
         List<Group> groups = identityService.findAllGroupsFrom(user);
@@ -50,6 +67,15 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
         ));
     }
 
+    /**
+     * Returns the {@link GroupInstancePermission} for the given query arguments. Hereby
+     * it will be considered if the user is currently a member of the given group.
+     *
+     * @param entity The entity to find the permission for.
+     * @param group The group to find the permission for.
+     * @param user The user to find the permission for.
+     * @return The (optional) permission.
+     */
     public Optional<GroupInstancePermission> findFor(BaseEntity entity, Group group, User user) {
 
         LOG.trace("Getting all group instance permissions for user {} and entity {} in the " +
@@ -69,24 +95,55 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
         ));
     }
 
+    /**
+     * Returns the {@link PermissionCollection} for the given query arguments.
+     *
+     * @param entity The entity to find the collection for.
+     * @param group The group to find the collection for.
+     * @return The collection (may be empty).
+     */
     public PermissionCollection findPermissionCollectionFor(BaseEntity entity, Group group) {
         Optional<GroupInstancePermission> groupInstancePermission = this.findFor(entity, group);
 
         return getPermissionCollection(groupInstancePermission);
     }
 
+    /**
+     * Returns the {@link PermissionCollection} for the given query arguments. Hereby
+     * all groups of the given user will be considered.
+     *
+     * @param entity The entity to find the collection for.
+     * @param user The user to find the collection for.
+     * @return The collection (may be empty).
+     */
     public PermissionCollection findPermissionCollectionFor(BaseEntity entity, User user) {
         Optional<GroupInstancePermission> groupInstancePermission = this.findFor(entity, user);
 
         return getPermissionCollection(groupInstancePermission);
     }
 
+    /**
+     * Returns the {@link PermissionCollection} for the given query arguments. Hereby
+     * it will be considered if the user is currently a member of the given group.
+     *
+     * @param entity The entity to find the collection for.
+     * @param group The group to find the collection for.
+     * @param user The user to find the collection for.
+     * @return The collection (may be empty).
+     */
     public PermissionCollection findPermissionCollectionFor(BaseEntity entity, Group group, User user) {
         Optional<GroupInstancePermission> groupInstancePermission = this.findFor(entity, group, user);
 
         return getPermissionCollection(groupInstancePermission);
     }
 
+    /**
+     * Sets the given {@link PermissionCollectionType} for the given class and group.
+     *
+     * @param persistedEntity The entity to set the permission for.
+     * @param group The group to set the permission for.
+     * @param permissionCollectionType The permission to set.
+     */
     public void setPermission(BaseEntity persistedEntity, Group group, PermissionCollectionType permissionCollectionType) {
         Optional<PermissionCollection> permissionCollection = permissionCollectionRepository.findOne(
             PermissionCollectionSpecification.findByName(permissionCollectionType));
@@ -99,8 +156,8 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
 
         // Check if there is already an existing permission set on the entity
         if (existingPermissions.isPresent()) {
-            LOG.debug("Permission is already set for entity {} and group {}: {}", persistedEntity,
-                group, permissionCollection.get());
+            LOG.debug("Permission is already set for entity {} and group {}: {}",
+                persistedEntity, group, permissionCollection.get());
 
             // Remove the existing one
             repository.delete(existingPermissions.get());
@@ -116,6 +173,14 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
         repository.save(groupInstancePermission);
     }
 
+    /**
+     * Helper function to get the {@link PermissionCollection} from a given
+     * class permission. If no collection is available, it returns an empty
+     * list.
+     *
+     * @param classPermission The classPermission to get the permissions from.
+     * @return The collection (may be empty).
+     */
     private PermissionCollection getPermissionCollection(Optional<GroupInstancePermission> classPermission) {
         if (classPermission.isPresent()) {
             return classPermission.get().getPermissions();

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/PermissionCollectionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/PermissionCollectionService.java
@@ -6,5 +6,4 @@ import de.terrestris.shoguncore.service.BaseService;
 import org.springframework.stereotype.Service;
 
 @Service
-public class PermissionCollectionService extends BaseService<PermissionCollectionRepository, PermissionCollection> {
-}
+public class PermissionCollectionService extends BaseService<PermissionCollectionRepository, PermissionCollection> { }

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/UserClassPermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/UserClassPermissionService.java
@@ -5,18 +5,16 @@ import de.terrestris.shoguncore.model.BaseEntity;
 import de.terrestris.shoguncore.model.User;
 import de.terrestris.shoguncore.model.security.permission.PermissionCollection;
 import de.terrestris.shoguncore.model.security.permission.UserClassPermission;
-import de.terrestris.shoguncore.model.security.permission.UserInstancePermission;
 import de.terrestris.shoguncore.repository.security.permission.PermissionCollectionRepository;
 import de.terrestris.shoguncore.repository.security.permission.UserClassPermissionRepository;
 import de.terrestris.shoguncore.security.SecurityContextUtil;
 import de.terrestris.shoguncore.service.BaseService;
 import de.terrestris.shoguncore.specification.security.permission.PermissionCollectionSpecification;
 import de.terrestris.shoguncore.specification.security.permission.UserClassPermissionSpecifications;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
-
-import java.util.Optional;
 
 @Service
 public class UserClassPermissionService extends BaseService<UserClassPermissionRepository, UserClassPermission> {
@@ -52,11 +50,7 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
     public PermissionCollection findPermissionCollectionFor(BaseEntity entity, User user) {
         Optional<UserClassPermission> userClassPermission = this.findFor(entity, user);
 
-        if (userClassPermission.isPresent()) {
-            return userClassPermission.get().getPermissions();
-        }
-
-        return new PermissionCollection();
+        return getPermissionCollection(userClassPermission);
     }
 
     public void setPermission(Class<? extends BaseEntity> clazz, PermissionCollectionType permissionCollectionType) {
@@ -96,5 +90,13 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
         userClassPermission.setPermissions(permissionCollection.get());
 
         repository.save(userClassPermission);
+    }
+
+    private PermissionCollection getPermissionCollection(Optional<UserClassPermission> classPermission) {
+        if (classPermission.isPresent()) {
+            return classPermission.get().getPermissions();
+        }
+
+        return new PermissionCollection();
     }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/UserClassPermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/UserClassPermissionService.java
@@ -25,17 +25,13 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
     @Autowired
     protected PermissionCollectionRepository permissionCollectionRepository;
 
-    public Optional<UserClassPermission> findFor(BaseEntity entity, User user) {
-
-        LOG.trace("Getting all user class permissions for user {} and entity class {}",
-                user.getUsername(), entity.getClass().getCanonicalName());
-
-        return repository.findOne(Specification.where(
-                UserClassPermissionSpecifications.hasEntity(entity)).and(
-                UserClassPermissionSpecifications.hasUser(user)
-        ));
-    }
-
+    /**
+     * Returns the {@link UserClassPermission} for the given query arguments.
+     *
+     * @param clazz The class to find the permission for.
+     * @param user The user to find the permission for.
+     * @return The (optional) permission.
+     */
     public Optional<UserClassPermission> findFor(Class<? extends BaseEntity> clazz, User user) {
 
         LOG.trace("Getting all user class permissions for user {} and entity class {}",
@@ -47,12 +43,46 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
         ));
     }
 
+    /**
+     * Returns the {@link UserClassPermission} for the given query arguments. Hereby
+     * the class of the given entity will be considered.
+     *
+     * @param entity The entity to find the permission for.
+     * @param user The user to find the permission for.
+     * @return The (optional) permission.
+     */
+    public Optional<UserClassPermission> findFor(BaseEntity entity, User user) {
+
+        LOG.trace("Getting all user class permissions for user {} and entity class {}",
+                user.getUsername(), entity.getClass().getCanonicalName());
+
+        return repository.findOne(Specification.where(
+                UserClassPermissionSpecifications.hasEntity(entity)).and(
+                UserClassPermissionSpecifications.hasUser(user)
+        ));
+    }
+
+    /**
+     * Returns the {@link PermissionCollection} for the given query arguments. Hereby
+     * the class of the given entity and and all groups of the given user will be considered.
+     *
+     * @param entity The entity to find the collection for.
+     * @param user The user to find the collection for.
+     * @return The collection (may be empty).
+     */
     public PermissionCollection findPermissionCollectionFor(BaseEntity entity, User user) {
         Optional<UserClassPermission> userClassPermission = this.findFor(entity, user);
 
         return getPermissionCollection(userClassPermission);
     }
 
+    /**
+     * Sets the given {@link PermissionCollectionType} for the given class and the currently
+     * logged in user.
+     *
+     * @param clazz The class to set the permission for.
+     * @param permissionCollectionType The permission to set.
+     */
     public void setPermission(Class<? extends BaseEntity> clazz, PermissionCollectionType permissionCollectionType) {
         Optional<User> activeUser = securityContextUtil.getUserBySession();
 
@@ -63,6 +93,13 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
         setPermission(clazz, activeUser.get(), permissionCollectionType);
     }
 
+    /**
+     * Sets the given {@link PermissionCollectionType} for the given class and user.
+     *
+     * @param clazz The class to find set the permission for.
+     * @param user The user to find set the permission for.
+     * @param permissionCollectionType The permission to set.
+     */
     public void setPermission(Class<? extends BaseEntity> clazz, User user, PermissionCollectionType permissionCollectionType) {
         Optional<PermissionCollection> permissionCollection = permissionCollectionRepository.findOne(
             PermissionCollectionSpecification.findByName(permissionCollectionType));
@@ -75,8 +112,8 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
 
         // Check if there is already an existing permission set on the entity
         if (existingPermissions.isPresent()) {
-            LOG.debug("Permission is already set for clazz {} and user {}: {}", clazz.getCanonicalName(),
-                user, permissionCollection.get());
+            LOG.debug("Permission is already set for clazz {} and user {}: {}",
+                clazz.getCanonicalName(), user, permissionCollection.get());
 
             // Remove the existing one
             repository.delete(existingPermissions.get());
@@ -92,6 +129,14 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
         repository.save(userClassPermission);
     }
 
+    /**
+     * Helper function to get the {@link PermissionCollection} from a given
+     * class permission. If no collection is available, it returns an empty
+     * list.
+     *
+     * @param classPermission The classPermission to get the permissions from.
+     * @return The collection (may be empty).
+     */
     private PermissionCollection getPermissionCollection(Optional<UserClassPermission> classPermission) {
         if (classPermission.isPresent()) {
             return classPermission.get().getPermissions();

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/UserInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/UserInstancePermissionService.java
@@ -3,7 +3,6 @@ package de.terrestris.shoguncore.service.security.permission;
 import de.terrestris.shoguncore.enumeration.PermissionCollectionType;
 import de.terrestris.shoguncore.model.BaseEntity;
 import de.terrestris.shoguncore.model.User;
-import de.terrestris.shoguncore.model.security.permission.GroupInstancePermission;
 import de.terrestris.shoguncore.model.security.permission.PermissionCollection;
 import de.terrestris.shoguncore.model.security.permission.UserInstancePermission;
 import de.terrestris.shoguncore.repository.security.permission.PermissionCollectionRepository;
@@ -12,12 +11,10 @@ import de.terrestris.shoguncore.security.SecurityContextUtil;
 import de.terrestris.shoguncore.service.BaseService;
 import de.terrestris.shoguncore.specification.security.permission.PermissionCollectionSpecification;
 import de.terrestris.shoguncore.specification.security.permission.UserInstancePermissionSpecifications;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.Optional;
 
 @Service
 public class UserInstancePermissionService extends BaseService<UserInstancePermissionRepository, UserInstancePermission> {
@@ -41,11 +38,7 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
     public PermissionCollection findPermissionCollectionFor(BaseEntity entity, User user) {
         Optional<UserInstancePermission> userInstancePermission = this.findFor(entity, user);
 
-        if (userInstancePermission.isPresent()) {
-            return userInstancePermission.get().getPermissions();
-        }
-
-        return new PermissionCollection();
+        return getPermissionCollection(userInstancePermission);
     }
 
     public void setPermission(BaseEntity persistedEntity, PermissionCollectionType permissionCollectionType) {
@@ -85,5 +78,13 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
         userInstancePermission.setPermissions(permissionCollection.get());
 
         repository.save(userInstancePermission);
+    }
+
+    private PermissionCollection getPermissionCollection(Optional<UserInstancePermission> classPermission) {
+        if (classPermission.isPresent()) {
+            return classPermission.get().getPermissions();
+        }
+
+        return new PermissionCollection();
     }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/UserInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/UserInstancePermissionService.java
@@ -25,9 +25,17 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
     @Autowired
     protected PermissionCollectionRepository permissionCollectionRepository;
 
+    /**
+     * Returns the {@link UserInstancePermission} for the given query arguments.
+     *
+     * @param entity The entity to find the permission for.
+     * @param user The user to find the permission for.
+     * @return The (optional) permission.
+     */
     public Optional<UserInstancePermission> findFor(BaseEntity entity, User user) {
 
-        LOG.trace("Getting all user permissions for user {} and entity {}", user.getUsername(), entity);
+        LOG.trace("Getting all user permissions for user {} and entity {}",
+            user.getUsername(), entity);
 
         return repository.findOne(Specification.where(
                 UserInstancePermissionSpecifications.hasEntity(entity)).and(
@@ -35,12 +43,26 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
         ));
     }
 
+    /**
+     * Returns the {@link PermissionCollection} for the given query arguments.
+     *
+     * @param entity The entity to find the collection for.
+     * @param user The user to find the collection for.
+     * @return The collection (may be empty).
+     */
     public PermissionCollection findPermissionCollectionFor(BaseEntity entity, User user) {
         Optional<UserInstancePermission> userInstancePermission = this.findFor(entity, user);
 
         return getPermissionCollection(userInstancePermission);
     }
 
+    /**
+     * Sets the given {@link PermissionCollectionType} for the given entity and the currently
+     * logged in user.
+     *
+     * @param persistedEntity The entity to set the permission for.
+     * @param permissionCollectionType The permission to set.
+     */
     public void setPermission(BaseEntity persistedEntity, PermissionCollectionType permissionCollectionType) {
         Optional<User> activeUser = securityContextUtil.getUserBySession();
 
@@ -51,6 +73,13 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
         setPermission(persistedEntity, activeUser.get(), permissionCollectionType);
     }
 
+    /**
+     * Sets the given {@link PermissionCollectionType} for the given entity and user.
+     *
+     * @param persistedEntity The entity to set the permission for.
+     * @param user The user to set the permission for.
+     * @param permissionCollectionType The permission to set.
+     */
     public void setPermission(BaseEntity persistedEntity, User user, PermissionCollectionType permissionCollectionType) {
         Optional<PermissionCollection> permissionCollection = permissionCollectionRepository.findOne(
             PermissionCollectionSpecification.findByName(permissionCollectionType));
@@ -63,8 +92,8 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
 
         // Check if there is already an existing permission set on the entity
         if (existingPermissions.isPresent()) {
-            LOG.debug("Permission is already set for entity {} and user {}: {}", persistedEntity,
-                user, permissionCollection.get());
+            LOG.debug("Permission is already set for entity {} and user {}: {}",
+                persistedEntity, user, permissionCollection.get());
 
             // Remove the existing one
             repository.delete(existingPermissions.get());
@@ -80,6 +109,14 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
         repository.save(userInstancePermission);
     }
 
+    /**
+     * Helper function to get the {@link PermissionCollection} from a given
+     * class permission. If no collection is available, it returns an empty
+     * list.
+     *
+     * @param classPermission The classPermission to get the permissions from.
+     * @return The collection (may be empty).
+     */
     private PermissionCollection getPermissionCollection(Optional<UserInstancePermission> classPermission) {
         if (classPermission.isPresent()) {
             return classPermission.get().getPermissions();


### PR DESCRIPTION
This suggests to apply some minor changes, especially for easier handling of group permissions in child projects by:

* Refactoring the `BasePermissionEvaluator` and `BaseEntityPermissionEvaluator` to become easier reusable and extendable.
* Adding the method `findFor(BaseEntity entity, Group group, User user)` to both the `GroupInstancePermission`- and `GroupClassPermissionService` for taking the group membership of a user into account while getting the appropriate permissions of a user.

Assorted changes might be applied to the `main` as soon as accepted here.

Please review @terrestris/devs.


