### PR TITLE
implement setPermission for a list of entities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 
     <!-- Database -->
     <hibernate.version>5.4.24.Final</hibernate.version>
-    <hibernate-extra-types.version>2.10.1</hibernate-extra-types.version>
+    <hibernate-extra-types.version>2.10.0</hibernate-extra-types.version>
     <postgres.version>42.2.18</postgres.version>
     <ehcache.version>3.9.0</ehcache.version>
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupClassPermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupClassPermissionService.java
@@ -111,19 +111,7 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
             throw new RuntimeException("Could not find requested permission collection");
         }
 
-        Optional<GroupClassPermission> existingPermissions = findFor(clazz, group);
-
-        // Check if there is already an existing permission set on the entity
-        if (existingPermissions.isPresent()) {
-            LOG.debug("Permission is already set for class {} and group {}: {}", clazz,
-                group, permissionCollection.get());
-
-            // Remove the existing one
-            // TODO: deletion really needed ???
-            repository.delete(existingPermissions.get());
-
-            LOG.debug("Removed the permission");
-        }
+        clearExistingPermission(group, permissionCollection.get(), clazz);
 
         GroupClassPermission groupClassPermission = new GroupClassPermission();
         groupClassPermission.setGroup(group);
@@ -131,5 +119,20 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
         groupClassPermission.setPermissions(permissionCollection.get());
 
         repository.save(groupClassPermission);
+    }
+
+    private void clearExistingPermission(Group group, PermissionCollection permissionCollection, Class<? extends BaseEntity> clazz) {
+        Optional<GroupClassPermission> existingPermission = findFor(clazz, group);
+
+        // Check if there is already an existing permission set on the entity
+        if (existingPermission.isPresent()) {
+            LOG.debug("Permission is already set for class {} and group {}: {}", clazz,
+                group, permissionCollection);
+
+            // Remove the existing one
+            repository.delete(existingPermission.get());
+
+            LOG.debug("Removed the permission");
+        }
     }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionService.java
@@ -128,7 +128,7 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
      * @param group The SHOGun group
      * @param permissionCollectionType The permission collection type (e.g. READ, READ_WRITE)
      */
-    public void setPermissionBulk(
+    public void setPermission(
         List<? extends BaseEntity> persistedEntityList,
         Group group,
         PermissionCollectionType permissionCollectionType

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionService.java
@@ -112,7 +112,7 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
             throw new RuntimeException("Could not find requested permission collection");
         }
 
-        checkForExistingPermissions(group, permissionCollection.get(), persistedEntity);
+        clearExistingPermission(group, permissionCollection.get(), persistedEntity);
 
         GroupInstancePermission groupInstancePermission = new GroupInstancePermission();
         groupInstancePermission.setGroup(group);
@@ -123,7 +123,7 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
     }
 
     /**
-     * Set Permission for SHOGun group (bulk)
+     * Set Permission for SHOGun group for multiple entities at once
      * @param persistedEntityList A collection of entities to set permission for
      * @param group The SHOGun group
      * @param permissionCollectionType The permission collection type (e.g. READ, READ_WRITE)
@@ -142,7 +142,7 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
         List<GroupInstancePermission> groupInstancePermissionsToSave = new ArrayList<>();
 
         persistedEntityList.forEach(e -> {
-            checkForExistingPermissions(group, permissionCollection.get(), e);
+            clearExistingPermission(group, permissionCollection.get(), e);
             GroupInstancePermission groupInstancePermission = new GroupInstancePermission();
             groupInstancePermission.setGroup(group);
             groupInstancePermission.setEntityId(e.getId());
@@ -153,17 +153,17 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
         repository.saveAll(groupInstancePermissionsToSave);
     }
 
-    private void checkForExistingPermissions(Group group, PermissionCollection permissionCollection, BaseEntity e) {
-        Optional<GroupInstancePermission> existingPermissions = findFor(e, group);
+    private void clearExistingPermission(Group group, PermissionCollection permissionCollection, BaseEntity entity) {
+        Optional<GroupInstancePermission> existingPermission = findFor(entity, group);
 
         // Check if there is already an existing permission set on the entity
-        if (existingPermissions.isPresent()) {
-            LOG.debug("Permission is already set for entity {} and group {}: {}", e,
+        if (existingPermission.isPresent()) {
+            LOG.debug("Permission is already set for entity {} and group {}: {}", entity,
                 group, permissionCollection);
 
             // Remove the existing one
             // TODO: deletion really needed ???
-            repository.delete(existingPermissions.get());
+            repository.delete(existingPermission.get());
 
             LOG.debug("Removed the permission");
         }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionService.java
@@ -13,6 +13,7 @@ import de.terrestris.shogun.lib.service.BaseService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -111,19 +112,7 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
             throw new RuntimeException("Could not find requested permission collection");
         }
 
-        Optional<GroupInstancePermission> existingPermissions = findFor(persistedEntity, group);
-
-        // Check if there is already an existing permission set on the entity
-        if (existingPermissions.isPresent()) {
-            LOG.debug("Permission is already set for entity {} and group {}: {}", persistedEntity,
-                group, permissionCollection.get());
-
-            // Remove the existing one
-            // TODO: deletion really needed ???
-            repository.delete(existingPermissions.get());
-
-            LOG.debug("Removed the permission");
-        }
+        checkForExistingPermissions(group, permissionCollection.get(), persistedEntity);
 
         GroupInstancePermission groupInstancePermission = new GroupInstancePermission();
         groupInstancePermission.setGroup(group);
@@ -131,6 +120,53 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
         groupInstancePermission.setPermissions(permissionCollection.get());
 
         repository.save(groupInstancePermission);
+    }
+
+    /**
+     * Set Permission for SHOGun group (bulk)
+     * @param persistedEntityList A collection of entities to set permission for
+     * @param group The SHOGun group
+     * @param permissionCollectionType The permission collection type (e.g. READ, READ_WRITE)
+     */
+    public void setPermissionBulk(
+        List<? extends BaseEntity> persistedEntityList,
+        Group group,
+        PermissionCollectionType permissionCollectionType
+    ) {
+        Optional<PermissionCollection> permissionCollection = permissionCollectionRepository.findByName(permissionCollectionType);
+
+        if (permissionCollection.isEmpty()) {
+            throw new RuntimeException("Could not find requested permission collection");
+        }
+
+        List<GroupInstancePermission> groupInstancePermissionsToSave = new ArrayList<>();
+
+        persistedEntityList.forEach(e -> {
+            checkForExistingPermissions(group, permissionCollection.get(), e);
+            GroupInstancePermission groupInstancePermission = new GroupInstancePermission();
+            groupInstancePermission.setGroup(group);
+            groupInstancePermission.setEntityId(e.getId());
+            groupInstancePermission.setPermissions(permissionCollection.get());
+            groupInstancePermissionsToSave.add(groupInstancePermission);
+        });
+
+        repository.saveAll(groupInstancePermissionsToSave);
+    }
+
+    private void checkForExistingPermissions(Group group, PermissionCollection permissionCollection, BaseEntity e) {
+        Optional<GroupInstancePermission> existingPermissions = findFor(e, group);
+
+        // Check if there is already an existing permission set on the entity
+        if (existingPermissions.isPresent()) {
+            LOG.debug("Permission is already set for entity {} and group {}: {}", e,
+                group, permissionCollection);
+
+            // Remove the existing one
+            // TODO: deletion really needed ???
+            repository.delete(existingPermissions.get());
+
+            LOG.debug("Removed the permission");
+        }
     }
 
     public void deleteAllForEntity(BaseEntity persistedEntity) {

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/UserClassPermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/UserClassPermissionService.java
@@ -82,18 +82,7 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
             throw new RuntimeException("Could not find requested permission collection");
         }
 
-        Optional<UserClassPermission> existingPermissions = findFor(clazz, user);
-
-        // Check if there is already an existing permission set on the entity
-        if (existingPermissions.isPresent()) {
-            LOG.debug("Permission is already set for clazz {} and user {}: {}", clazz.getCanonicalName(),
-                user, permissionCollection.get());
-
-            // Remove the existing one
-            repository.delete(existingPermissions.get());
-
-            LOG.debug("Removed the permission");
-        }
+        clearExistingPermission(user, permissionCollection.get(), clazz);
 
         UserClassPermission userClassPermission = new UserClassPermission();
         userClassPermission.setUser(user);
@@ -101,5 +90,20 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
         userClassPermission.setPermissions(permissionCollection.get());
 
         repository.save(userClassPermission);
+    }
+
+    private void clearExistingPermission(User user, PermissionCollection permissionCollection, Class<? extends BaseEntity> clazz) {
+        Optional<UserClassPermission> existingPermission = findFor(clazz, user);
+
+        // Check if there is already an existing permission set on the entity
+        if (existingPermission.isPresent()) {
+            LOG.debug("Permission is already set for clazz {} and user {}: {}", clazz.getCanonicalName(),
+                user, permissionCollection);
+
+            // Remove the existing one
+            repository.delete(existingPermission.get());
+
+            LOG.debug("Removed the permission");
+        }
     }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/UserInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/UserInstancePermissionService.java
@@ -98,7 +98,7 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
      * @param user The user
      * @param permissionCollectionType The permission collection type (e.g. READ, READ_WRITE)
      */
-    public void setPermissionBulk(
+    public void setPermission(
         List<? extends BaseEntity> persistedEntityList,
         User user,
         PermissionCollectionType permissionCollectionType


### PR DESCRIPTION
Resolves #184:

- introduces
   -  `setPermission(List<BaseEntity> entityList, Group group, PermissionCollectionType pct)` and
   - `setPermission(List<BaseEntity> entityList, User user, PermissionCollectionType pct)` 
- this can be used to set a permission for a collection of entities at once
- makes use of `repository.saveAll()` and should speed up permission creation considerably
- existing duplicate permissions are still checked and removed if present
- didn't do any detailed performance testing, but the import mentioned in #184 now only takes a few minutes (including permissions)

Example usage:


```java
@Autowired
protected GroupInstancePermissionService groupInstancePermissionService;

@Autowired
protected LayerRepository layerRepository;

Group group = ...
List<Layer> layers = layerRepository.findAll();

groupInstancePermissionService.setPermission(layers, group, PermissionCollectionType.ADMIN);
```

@terrestris/devs Please review