### PR TITLE
update to springfox 3

### DIFF
--- a/.github/workflows/startup.yml
+++ b/.github/workflows/startup.yml
@@ -52,4 +52,3 @@ jobs:
       - name: Maven output
         if: always()
         run: cat mvn.out.txt
-        working-directory: ./shogun-boot

--- a/.github/workflows/startup.yml
+++ b/.github/workflows/startup.yml
@@ -21,9 +21,15 @@ jobs:
         with:
           java-version: 11
 
+      - name: Cache the Maven packages to speed up build
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven
+
       - name: Run mvn install
         run: mvn install
-        working-directory: ./shogun-boot
 
       - name: Clone shogun-docker
         run: git clone https://github.com/terrestris/shogun-docker
@@ -34,7 +40,6 @@ jobs:
           
       - name: Start spring-boot
         run: mvn spring-boot:run > mvn.out.txt &
-        working-directory: ./shogun-boot
         
       - name: Check if application has started
         run: ./scripts/wait.sh

--- a/.github/workflows/startup.yml
+++ b/.github/workflows/startup.yml
@@ -21,13 +21,6 @@ jobs:
         with:
           java-version: 11
 
-      - name: Cache the Maven packages to speed up build
-        uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven
-
       - name: Run mvn install
         run: mvn install
         working-directory: ./shogun-boot

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@
 
 ## Swagger
 
-The swagger generated API documentation is available after the startup at [http://localhost:8080/shogun-boot/swagger-ui.html](http://localhost:8080/shogun-boot/swagger-ui.html)
+The swagger generated API documentation is available after the startup at [http://localhost:8080/shogun-boot/swagger-ui/index.html](http://localhost:8080/shogun-boot/swagger-ui/index.html)
 
 ## Keycloak
 

--- a/pom.xml
+++ b/pom.xml
@@ -610,11 +610,6 @@
         <artifactId>flyway-core</artifactId>
         <version>${flyway.version}</version>
       </dependency>
-<!--      <dependency>-->
-<!--        <groupId>io.swagger.core.v3</groupId>-->
-<!--        <artifactId>swagger-annotations</artifactId>-->
-<!--        <version>${swagger-core-version}</version>-->
-<!--      </dependency>-->
 
       <dependency>
         <groupId>javax.annotation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,11 @@
       <id>nexus.terrestris.de</id>
       <url>https://nexus.terrestris.de/repository/public/</url>
     </repository>
+    <repository>
+      <id>jcenter-snapshots</id>
+      <name>jcenter</name>
+      <url>https://jcenter.bintray.com/</url>
+    </repository>
   </repositories>
 
   <pluginRepositories>
@@ -114,7 +119,7 @@
     <jaxb.version>2.3.1</jaxb.version>
 
     <!-- Doc -->
-    <springfox.version>2.9.2</springfox.version>
+    <springfox.version>3.0.0</springfox.version>
 
     <!-- Swagger/REST -->
     <swagger.version>2.1.1</swagger.version>
@@ -364,6 +369,11 @@
         <artifactId>spring-boot-starter-security</artifactId>
         <version>${spring-boot.version}</version>
       </dependency>
+      <dependency>
+        <groupId>io.springfox</groupId>
+        <artifactId>springfox-boot-starter</artifactId>
+        <version>${springfox.version}</version>
+      </dependency>
 
       <!-- Spring -->
       <dependency>
@@ -565,11 +575,6 @@
       </dependency>
       <dependency>
         <groupId>io.springfox</groupId>
-        <artifactId>springfox-swagger2</artifactId>
-        <version>${springfox.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.springfox</groupId>
         <artifactId>springfox-swagger-ui</artifactId>
         <version>${springfox.version}</version>
       </dependency>
@@ -605,11 +610,11 @@
         <artifactId>flyway-core</artifactId>
         <version>${flyway.version}</version>
       </dependency>
-      <dependency>
-        <groupId>io.swagger.core.v3</groupId>
-        <artifactId>swagger-annotations</artifactId>
-        <version>${swagger-core-version}</version>
-      </dependency>
+<!--      <dependency>-->
+<!--        <groupId>io.swagger.core.v3</groupId>-->
+<!--        <artifactId>swagger-annotations</artifactId>-->
+<!--        <version>${swagger-core-version}</version>-->
+<!--      </dependency>-->
 
       <dependency>
         <groupId>javax.annotation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,9 @@
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>
           <version>${spring-boot.version}</version>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
           <executions>
             <execution>
               <id>build-info</id>

--- a/shogun-boot/pom.xml
+++ b/shogun-boot/pom.xml
@@ -53,6 +53,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.springfox</groupId>
+      <artifactId>springfox-boot-starter</artifactId>
+    </dependency>
 
     <!-- Spring -->
     <dependency>
@@ -95,7 +99,7 @@
     <!-- Swagger -->
     <dependency>
       <groupId>io.springfox</groupId>
-      <artifactId>springfox-swagger2</artifactId>
+      <artifactId>springfox-boot-starter</artifactId>
     </dependency>
     <dependency>
       <groupId>io.springfox</groupId>

--- a/shogun-boot/pom.xml
+++ b/shogun-boot/pom.xml
@@ -53,10 +53,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.springfox</groupId>
-      <artifactId>springfox-boot-starter</artifactId>
-    </dependency>
 
     <!-- Spring -->
     <dependency>
@@ -100,10 +96,6 @@
     <dependency>
       <groupId>io.springfox</groupId>
       <artifactId>springfox-boot-starter</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.springfox</groupId>
-      <artifactId>springfox-swagger-ui</artifactId>
     </dependency>
 
     <!-- GeoServer Manager-->

--- a/shogun-boot/pom.xml
+++ b/shogun-boot/pom.xml
@@ -127,6 +127,10 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <fork>true</fork>
+          <skip>false</skip>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.hibernate.orm.tooling</groupId>

--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootSwaggerConfig.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootSwaggerConfig.java
@@ -1,6 +1,5 @@
 package de.terrestris.shogun.boot.config;
 
-import com.google.common.base.Predicate;
 import de.terrestris.shogun.config.SwaggerConfig;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
@@ -8,6 +7,7 @@ import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.service.ApiInfo;
 
 import java.util.Collections;
+import java.util.function.Predicate;
 
 @Configuration
 @EnableAutoConfiguration
@@ -15,7 +15,7 @@ public class BootSwaggerConfig extends SwaggerConfig {
 
     @Override
     protected ApiInfo apiInfo() {
-        ApiInfo apiInfo = new ApiInfo(
+        return new ApiInfo(
             "SHOGun Boot REST-API",
             description,
             version,
@@ -25,8 +25,6 @@ public class BootSwaggerConfig extends SwaggerConfig {
             licenseUrl,
             Collections.emptyList()
         );
-
-        return apiInfo;
     }
 
     @Override

--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootWebSecurityConfig.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootWebSecurityConfig.java
@@ -14,7 +14,7 @@ public class BootWebSecurityConfig extends WebSecurityConfig {
     RequestMatcher csrfRequestMatcher = httpServletRequest -> {
         String refererHeader = httpServletRequest.getHeader("Referer");
 
-        return refererHeader != null && refererHeader.endsWith("swagger-ui.html");
+        return refererHeader != null && refererHeader.endsWith("swagger-ui/index.html");
     };
 
     @Override
@@ -27,7 +27,7 @@ public class BootWebSecurityConfig extends WebSecurityConfig {
                     "/info/**",
                     "/index.html",
                     // Enable anonymous access to swagger docs
-                    "/swagger-ui.html",
+                    "/swagger-ui/index.html",
                     "/webjars/springfox-swagger-ui/**",
                     "/swagger-resources/**",
                     "/v2/api-docs"

--- a/shogun-boot/src/main/resources/public/index.html
+++ b/shogun-boot/src/main/resources/public/index.html
@@ -8,7 +8,7 @@
 <body>
     <h1>Hallo SHOGun-Boot</h1>
     <ul>
-        <li><a href="swagger-ui.html">Swagger (requires login)</a></li>
+        <li><a href="swagger-ui/index.html">Swagger (requires login)</a></li>
         <li><a href="graphiql">Graphi QL (requires login)</a></li>
         <li><a href="websocket.html">WebSocket (requires login)</a></li>
     </ul>

--- a/shogun-config/pom.xml
+++ b/shogun-config/pom.xml
@@ -8,7 +8,6 @@
     <version>7.0.1-SNAPSHOT</version>
   </parent>
 
-  <groupId>de.terrestris</groupId>
   <artifactId>shogun-config</artifactId>
   <name>SHOGun Config</name>
   <packaging>jar</packaging>
@@ -33,7 +32,7 @@
     <!-- Swagger -->
     <dependency>
       <groupId>io.springfox</groupId>
-      <artifactId>springfox-swagger2</artifactId>
+      <artifactId>springfox-boot-starter</artifactId>
     </dependency>
 
     <dependency>

--- a/shogun-config/src/main/java/de/terrestris/shogun/config/SwaggerConfig.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/config/SwaggerConfig.java
@@ -1,6 +1,5 @@
 package de.terrestris.shogun.config;
 
-import com.google.common.base.Predicate;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,13 +9,11 @@ import springfox.documentation.service.*;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.function.Predicate;
 
 @Configuration
-@EnableSwagger2
 @EnableAutoConfiguration
 public abstract class SwaggerConfig {
 
@@ -36,14 +33,14 @@ public abstract class SwaggerConfig {
             .paths(PathSelectors.any())
             .build()
             .apiInfo(apiInfo())
-            .securityContexts(Arrays.asList(actuatorSecurityContext()))
-            .securitySchemes(Arrays.asList(basicAuthScheme()));
+            .securityContexts(Collections.singletonList(actuatorSecurityContext()))
+            .securitySchemes(Collections.singletonList(basicAuthScheme()));
     }
 
     private SecurityContext actuatorSecurityContext() {
         return SecurityContext.builder()
-            .securityReferences(Arrays.asList(basicAuthReference()))
-            .forPaths(setSecurityContextPaths())
+            .securityReferences(Collections.singletonList(basicAuthReference()))
+            .forPaths(setSecurityContextPaths()::test)
             .build();
     }
 
@@ -56,7 +53,7 @@ public abstract class SwaggerConfig {
     }
 
     protected ApiInfo apiInfo() {
-        ApiInfo apiInfo = new ApiInfo(
+        return new ApiInfo(
             title,
             description,
             version,
@@ -66,8 +63,6 @@ public abstract class SwaggerConfig {
             licenseUrl,
             Collections.emptyList()
         );
-
-        return apiInfo;
     }
 
     /**

--- a/shogun-gs-interceptor/pom.xml
+++ b/shogun-gs-interceptor/pom.xml
@@ -86,7 +86,7 @@
     <!-- Swagger -->
     <dependency>
       <groupId>io.springfox</groupId>
-      <artifactId>springfox-swagger2</artifactId>
+      <artifactId>springfox-boot-starter</artifactId>
     </dependency>
     <dependency>
       <groupId>io.springfox</groupId>

--- a/shogun-gs-interceptor/pom.xml
+++ b/shogun-gs-interceptor/pom.xml
@@ -88,10 +88,6 @@
       <groupId>io.springfox</groupId>
       <artifactId>springfox-boot-starter</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.springfox</groupId>
-      <artifactId>springfox-swagger-ui</artifactId>
-    </dependency>
 
     <!-- GeoServer Manager-->
     <dependency>

--- a/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/config/InterceptorSwaggerConfig.java
+++ b/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/config/InterceptorSwaggerConfig.java
@@ -1,6 +1,5 @@
 package de.terrestris.shogun.interceptor.config;
 
-import com.google.common.base.Predicate;
 import de.terrestris.shogun.config.SwaggerConfig;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
@@ -8,6 +7,7 @@ import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.service.ApiInfo;
 
 import java.util.Collections;
+import java.util.function.Predicate;
 
 @Configuration
 @EnableAutoConfiguration
@@ -15,7 +15,7 @@ public class InterceptorSwaggerConfig extends SwaggerConfig {
 
     @Override
     protected ApiInfo apiInfo() {
-        ApiInfo apiInfo = new ApiInfo(
+        return new ApiInfo(
             "SHOGun GeoServer Interceptor REST-API",
             description,
             version,
@@ -25,8 +25,6 @@ public class InterceptorSwaggerConfig extends SwaggerConfig {
             licenseUrl,
             Collections.emptyList()
         );
-
-        return apiInfo;
     }
 
     @Override

--- a/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/config/InterceptorWebSecurityConfig.java
+++ b/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/config/InterceptorWebSecurityConfig.java
@@ -21,7 +21,7 @@ public class InterceptorWebSecurityConfig extends WebSecurityConfig {
             .authorizeRequests()
             .antMatchers(
                 // Allow access to swagger interface
-                "/swagger-ui.html",
+                "/swagger-ui/index.html",
                 "/swagger-resources/**",
                 "/webjars/**",
                 "/v2/**",


### PR DESCRIPTION
- updates to springfox 3 (https://github.com/springfox/springfox/releases/tag/3.0.0)
- use `springfox-boot-starter` and removes explicit springfox dependencies
- replace guava Predicates with java 8 Predicates (`java.util.function.Predicate`)

### BREAKING CHANGES

- `swagger-ui.html` endpoint changed to `swagger-ui/` (or `swagger-ui/index.html`)
- `guava` dependency removed, any Guava functional primitives have to be replaced by Java API
   - imports have to be adjusted from `com.google.common.base.Predicate` to `java.util.function.Predicate` 
- for more info see: https://springfox.github.io/springfox/docs/current/#migrating-from-existing-2-x-version

@terrestris/devs Please review

~~Please note that the Github Actions check "Startup Shogun" is failing due to cache issues~~

Cache was not the issue, the problem was that `mvn install` and `mvn spring-boot:run` were executed from the `./shogun-boot` directory, which did not build the other modules. In this case the changes to module `shogun-config` were missing.

@simonseyock I changed the startup script to fix this and made those steps run from the root directory. Maybe you can have a look at this. Seems to work though...

