### PR TITLE
Create github action to test if application starts up

### DIFF
--- a/.github/workflows/startup.yml
+++ b/.github/workflows/startup.yml
@@ -1,0 +1,57 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Startup Shogun
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Cache the Maven packages to speed up build
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven
+
+      - name: Run mvn install
+        run: mvn install
+        working-directory: ./shogun-boot
+
+      - name: Clone shogun-docker
+        run: git clone https://github.com/terrestris/shogun-docker
+
+      - name: Start containers
+        run: docker-compose up -d
+        working-directory: ./shogun-docker
+          
+      - name: Start spring-boot
+        run: mvn spring-boot:run > mvn.out.txt &
+        working-directory: ./shogun-boot
+        
+      - name: Check if application has started
+        run: ./scripts/wait.sh
+        
+      - name: Docker logs
+        if: ${{ failure() }}
+        run: docker-compose logs
+        working-directory: ./shogun-docker
+        
+      - name: Maven output
+        if: ${{ failure() }}
+        run: cat mvn.out.txt
+        working-directory: ./shogun-boot

--- a/.github/workflows/startup.yml
+++ b/.github/workflows/startup.yml
@@ -47,11 +47,11 @@ jobs:
         run: ./scripts/wait.sh
         
       - name: Docker logs
-        if: ${{ failure() }}
+        if: always()
         run: docker-compose logs
         working-directory: ./shogun-docker
         
       - name: Maven output
-        if: ${{ failure() }}
+        if: always()
         run: cat mvn.out.txt
         working-directory: ./shogun-boot

--- a/scripts/wait.sh
+++ b/scripts/wait.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+URL="http://localhost:8080/shogun-boot/"
+TIMEOUT=120
+seconds=0
+
+echo 'Waiting up to' $TIMEOUT 'seconds for HTTP 200 from' $URL 
+until [ "$seconds" -gt "$TIMEOUT" ] || $(curl --output /dev/null --silent --max-time $TIMEOUT --head --fail $URL); do
+  sleep 5
+  seconds=$((seconds+5))
+done
+
+if [ "$seconds" -lt "$TIMEOUT" ]; then
+  echo 'OK'
+else
+  echo "ERROR: Timed out wating for HTTP 200 from" $URL >&2
+  exit 1
+fi


### PR DESCRIPTION
This adds a github action that simply tests if the application starts up to catch the most severe errors.

Here is how a successful run looks like: https://github.com/simonseyock/shogun/runs/1571654866?check_suite_focus=true
and here is a not successful one: https://github.com/simonseyock/shogun/runs/1571697016?check_suite_focus=true

Note that the docker-compose logs and maven output are only displayed at the end and if the run was not successful. The latter could be changed so it is shown always, but still at the end.