### PR TITLE
Revert "Bump hibernate-types-52 from 2.10.0 to 2.10.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 
     <!-- Database -->
     <hibernate.version>5.4.24.Final</hibernate.version>
-    <hibernate-extra-types.version>2.10.1</hibernate-extra-types.version>
+    <hibernate-extra-types.version>2.10.0</hibernate-extra-types.version>
     <postgres.version>42.2.18</postgres.version>
     <ehcache.version>3.9.0</ehcache.version>
 


### PR DESCRIPTION
This raises an error on compiling the application. See the failing test on https://github.com/terrestris/shogun/pull/207 for more details

Reverts terrestris/shogun#193