### PR TITLE
Use an Annotation to mark graph ql queries.

### DIFF
--- a/shogun-lib/pom.xml
+++ b/shogun-lib/pom.xml
@@ -231,6 +231,11 @@
       <artifactId>HikariCP</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.reflections</groupId>
+          <artifactId>reflections</artifactId>
+          <version>0.9.12</version>
+      </dependency>
   </dependencies>
 
 </project>

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/GraphQLDataFetchers.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/GraphQLDataFetchers.java
@@ -26,68 +26,80 @@ public class GraphQLDataFetchers {
     ImageFileService imageFileService;
 
     // Application
+    @GraphQLQuery(name = "applicationById")
     public DataFetcher getApplicationById() {
         return dataFetchingEnvironment -> {
             Long applicationId = ((Integer) dataFetchingEnvironment.getArgument("id")).longValue();
             return this.applicationService.findOne(applicationId);
         };
     }
+    @GraphQLQuery(name = "allApplications")
     public DataFetcher getAllApplications() {
         return dataFetchingEnvironment -> this.applicationService.findAll();
     }
 
     // Layer
+    @GraphQLQuery(name = "layerById")
     public DataFetcher getLayerById() {
         return dataFetchingEnvironment -> {
             Long layerId = ((Integer) dataFetchingEnvironment.getArgument("id")).longValue();
             return this.layerService.findOne(layerId);
         };
     }
+    @GraphQLQuery(name = "allLayers")
     public DataFetcher getAllLayers() {
         return dataFetchingEnvironment -> this.layerService.findAll();
     }
 
     // User
+    @GraphQLQuery(name = "userById")
     public DataFetcher getUserById() {
         return dataFetchingEnvironment -> {
             Long userId = ((Integer) dataFetchingEnvironment.getArgument("id")).longValue();
             return this.userService.findOne(userId);
         };
     }
+    @GraphQLQuery(name = "allUsers")
     public DataFetcher getAllUsers() {
         return dataFetchingEnvironment -> this.userService.findAll();
     }
 
     // File
+    @GraphQLQuery(name = "fileByUuid")
     public DataFetcher getFileByUuid() {
         return dataFetchingEnvironment -> {
             UUID uuid = dataFetchingEnvironment.getArgument("uuid");
             return this.fileService.findOne(uuid);
         };
     }
+    @GraphQLQuery(name = "fileById")
     public DataFetcher getFileById() {
         return dataFetchingEnvironment -> {
             Long id = ((Integer) dataFetchingEnvironment.getArgument("id")).longValue();
             return this.fileService.findOne(id);
         };
     }
+    @GraphQLQuery(name = "allFiles")
     public DataFetcher getAllFiles() {
         return dataFetchingEnvironment -> this.fileService.findAll();
     }
 
     // ImageFile
+    @GraphQLQuery(name = "getImageFileByUuid")
     public DataFetcher getImageFileByUuid() {
         return dataFetchingEnvironment -> {
             UUID uuid = dataFetchingEnvironment.getArgument("uuid");
             return this.imageFileService.findOne(uuid);
         };
     }
+    @GraphQLQuery(name = "imageFileById")
     public DataFetcher getImageFileById() {
         return dataFetchingEnvironment -> {
             Long id = ((Integer) dataFetchingEnvironment.getArgument("id")).longValue();
             return this.imageFileService.findOne(id);
         };
     }
+    @GraphQLQuery(name = "allImageFiles")
     public DataFetcher getAllImageFiles() {
         return dataFetchingEnvironment -> this.imageFileService.findAll();
     }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/GraphQLDataFetchers.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/GraphQLDataFetchers.java
@@ -85,7 +85,7 @@ public class GraphQLDataFetchers {
     }
 
     // ImageFile
-    @GraphQLQuery(name = "getImageFileByUuid")
+    @GraphQLQuery(name = "imageFileByUuid")
     public DataFetcher getImageFileByUuid() {
         return dataFetchingEnvironment -> {
             UUID uuid = dataFetchingEnvironment.getArgument("uuid");

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/GraphQLQuery.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/GraphQLQuery.java
@@ -1,0 +1,9 @@
+package de.terrestris.shogun.lib.graphql;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface GraphQLQuery {
+    public String name() default "";
+}

--- a/shogun-lib/src/main/resources/graphql/shogun.graphqls
+++ b/shogun-lib/src/main/resources/graphql/shogun.graphqls
@@ -11,6 +11,7 @@ type Query {
     fileById(id: Int): File
     fileByUuid(uuid: String): File
     allFiles: [File]
+    getImageFileByUuid(uuid: String): File
     imageFileById(id: Int): ImageFile
     allImageFiles: [ImageFile]
 }

--- a/shogun-lib/src/main/resources/graphql/shogun.graphqls
+++ b/shogun-lib/src/main/resources/graphql/shogun.graphqls
@@ -11,7 +11,7 @@ type Query {
     fileById(id: Int): File
     fileByUuid(uuid: String): File
     allFiles: [File]
-    getImageFileByUuid(uuid: String): File
+    imageFileByUuid(uuid: String): File
     imageFileById(id: Int): ImageFile
     allImageFiles: [ImageFile]
 }


### PR DESCRIPTION
This introduces an annotation `@GraphQLQuery` that annotates a method that returns a `DataFetcher` for a graph ql query. The GraphQLProvider will search for all methods with this annotation automatically on application start up.

Usage:
```
    @GraphQLQuery(name = "allUsers")
    public DataFetcher getAllUsers() {
        return dataFetchingEnvironment -> this.userService.findAll();
    }
```

It can be used without the name parameter in which case the method name is used.

It has to be checked that the GraphQLProvider will correctly search for the annotation if used from a child project.