### PR TITLE
Ensure the created timestamp is not going to be overridden (v3)

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/model/BaseEntity.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/model/BaseEntity.java
@@ -13,9 +13,10 @@ import javax.persistence.InheritanceType;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.TypeDef;
@@ -27,27 +28,28 @@ import org.hibernate.annotations.UpdateTimestamp;
 @TypeDefs({
     @TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)
 })
-@Data
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
 @EqualsAndHashCode
 public abstract class BaseEntity implements Serializable {
 
-    // TODO Don't create setter for ID?!
     @Id
     @GeneratedValue(strategy= GenerationType.SEQUENCE)
     @Column(unique = true, nullable = false)
+    @Getter
     private Long id;
 
     @CreationTimestamp
     @Column(updatable = false)
     @Temporal(TemporalType.TIMESTAMP)
+    @Getter @Setter
     private Date created;
 
     @UpdateTimestamp
     @Column
     @Temporal(TemporalType.TIMESTAMP)
+    @Getter @Setter
     private Date modified;
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/service/BaseService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/service/BaseService.java
@@ -1,9 +1,12 @@
 package de.terrestris.shoguncore.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import de.terrestris.shoguncore.model.BaseEntity;
 import de.terrestris.shoguncore.repository.BaseCrudRepository;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,10 +16,6 @@ import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Optional;
 
 public abstract class BaseService<T extends BaseCrudRepository<S, Long> & JpaSpecificationExecutor<S>, S extends BaseEntity> {
 
@@ -51,7 +50,11 @@ public abstract class BaseService<T extends BaseCrudRepository<S, Long> & JpaSpe
     public S update(Long id, S entity) throws IOException {
         Optional<S> persistedEntity = repository.findById(id);
 
-        JsonNode jsonObject = objectMapper.valueToTree(entity);
+        ObjectNode jsonObject = objectMapper.valueToTree(entity);
+
+        // Ensure the created timestamp will not be overridden.
+        jsonObject.put("created", persistedEntity.get().getCreated().toInstant().toString());
+
         S updatedEntity = objectMapper.readerForUpdating(persistedEntity.get()).readValue(jsonObject);
 
         return repository.save(updatedEntity);

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/GroupClassPermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/GroupClassPermissionService.java
@@ -83,6 +83,12 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
         // Get all groups of the user
         List<Group> groups = identityService.findAllGroupsFrom(user);
 
+        if (groups.size() > 1) {
+            LOG.warn("The given user is a member of multiple groups. If you encounter any " +
+                "errors or unexpected results, you may want to evaluate permissions via " +
+                "#findFor(BaseEntity entity, Group group, User user)");
+        }
+
         return repository.findOne(Specification.where(
             GroupClassPermissionSpecifications.hasEntity(entity)).and(
             GroupClassPermissionSpecifications.hasGroups(groups)
@@ -104,6 +110,12 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
 
         // Get all groups of the user
         List<Group> groups = identityService.findAllGroupsFrom(user);
+
+        if (groups.size() > 1) {
+            LOG.warn("The given user is a member of multiple groups. If you encounter any " +
+                "errors or unexpected results, you may want to evaluate permissions via " +
+                "#findFor(BaseEntity entity, Group group, User user)");
+        }
 
         return repository.findOne(Specification.where(
             GroupClassPermissionSpecifications.hasEntity(clazz)).and(

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/GroupInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/GroupInstancePermissionService.java
@@ -61,6 +61,12 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
         // Get all groups of the user
         List<Group> groups = identityService.findAllGroupsFrom(user);
 
+        if (groups.size() > 1) {
+            LOG.warn("The given user is a member of multiple groups. If you encounter any " +
+                "errors or unexpected results, you may want to evaluate permissions via " +
+                "#findFor(BaseEntity entity, Group group, User user)");
+        }
+
         return repository.findOne(Specification.where(
                 GroupInstancePermissionSpecifications.hasEntity(entity)).and(
                 GroupInstancePermissionSpecifications.hasGroups(groups)

--- a/shogun-lib/src/test/java/de/terrestris/shoguncore/security/access/entity/BaseEntityPermissionEvaluatorTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shoguncore/security/access/entity/BaseEntityPermissionEvaluatorTest.java
@@ -1,19 +1,26 @@
 package de.terrestris.shoguncore.security.access.entity;
 
-import de.terrestris.shoguncore.enumeration.PermissionType;
-import de.terrestris.shoguncore.model.*;
-import de.terrestris.shoguncore.model.security.Identity;
-import de.terrestris.shoguncore.model.security.permission.PermissionCollection;
-import de.terrestris.shoguncore.service.security.IdentityService;
-import org.junit.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-
-import java.util.*;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
+
+
+import de.terrestris.shoguncore.enumeration.PermissionType;
+import de.terrestris.shoguncore.model.BaseEntity;
+import de.terrestris.shoguncore.model.Group;
+import de.terrestris.shoguncore.model.User;
+import de.terrestris.shoguncore.model.security.Identity;
+import de.terrestris.shoguncore.model.security.permission.PermissionCollection;
+import de.terrestris.shoguncore.service.security.IdentityService;
+import de.terrestris.shoguncore.util.IdHelper;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 
 public abstract class BaseEntityPermissionEvaluatorTest<E extends BaseEntity> {
 
@@ -29,19 +36,19 @@ public abstract class BaseEntityPermissionEvaluatorTest<E extends BaseEntity> {
 
     protected BaseEntityPermissionEvaluatorTest(Class<E> entityClass,
             BaseEntityPermissionEvaluator<E> baseEntityPermissionEvaluator,
-            E entityToCheck) {
+            E entityToCheck) throws NoSuchFieldException {
         this.entityClass = entityClass;
         this.baseEntityPermissionEvaluator = baseEntityPermissionEvaluator;
         this.entityToCheck = entityToCheck;
 
-        this.entityToCheck.setId(123L);
+        IdHelper.setIdForEntity(this.entityToCheck, 123L);
     }
 
     @Test
-    public void hasPermission_shouldNeverGrantAnythingWithoutPermissions() {
+    public void hasPermission_shouldNeverGrantAnythingWithoutPermissions() throws NoSuchFieldException {
         final User user = new User();
         user.setUsername("Test user");
-        user.setId(1909L);
+        IdHelper.setIdForEntity(user, 1909L);
 
         Set<PermissionType> allPermissions = new HashSet<>(Arrays.asList(PermissionType.values()));
 
@@ -56,7 +63,7 @@ public abstract class BaseEntityPermissionEvaluatorTest<E extends BaseEntity> {
     public void hasPermission_shouldGrantPermissionOnSecuredObjectWithCorrectUserPermission() throws NoSuchFieldException, IllegalAccessException {
         final User user = new User();
         user.setUsername("Test user");
-        user.setId(1909L);
+        IdHelper.setIdForEntity(user, 1909L);
 
         Map<User, PermissionCollection> userPermissionsMap = new HashMap<>();
 
@@ -75,7 +82,7 @@ public abstract class BaseEntityPermissionEvaluatorTest<E extends BaseEntity> {
     public void hasPermission_shouldGrantPermissionOnSecuredObjectWithCorrectGroupPermission() throws NoSuchFieldException, IllegalAccessException {
         final User user = new User();
         user.setUsername("Test user");
-        user.setId(1909L);
+        IdHelper.setIdForEntity(user, 1909L);
 
         Group group = new Group();
         group.setName("Test group");
@@ -106,7 +113,7 @@ public abstract class BaseEntityPermissionEvaluatorTest<E extends BaseEntity> {
     public void hasPermission_shouldGrantAnyPermissionOnSecuredObjectWithUserAdminPermission() throws NoSuchFieldException, IllegalAccessException {
         final User user = new User();
         user.setUsername("Test user");
-        user.setId(1909L);
+        IdHelper.setIdForEntity(user, 1909L);
 
         Map<User, PermissionCollection> userPermissionsMap = new HashMap<>();
 
@@ -129,7 +136,7 @@ public abstract class BaseEntityPermissionEvaluatorTest<E extends BaseEntity> {
     public void hasPermission_shouldGrantAnyPermissionOnSecuredObjectWithUserGroupAdminPermission() throws NoSuchFieldException, IllegalAccessException {
         final User user = new User();
         user.setUsername("Test user");
-        user.setId(1909L);
+        IdHelper.setIdForEntity(user, 1909L);
 
         Group group = new Group();
         group.setName("Test group");

--- a/shogun-lib/src/test/java/de/terrestris/shoguncore/util/IdHelper.java
+++ b/shogun-lib/src/test/java/de/terrestris/shoguncore/util/IdHelper.java
@@ -1,0 +1,40 @@
+package de.terrestris.shoguncore.util;
+
+import static org.apache.logging.log4j.LogManager.getLogger;
+
+
+import de.terrestris.shoguncore.model.BaseEntity;
+import java.lang.reflect.Field;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import org.apache.logging.log4j.Logger;
+
+public class IdHelper {
+
+    private static final Logger logger = getLogger(IdHelper.class);
+
+    /**
+     * Helper method that uses reflection to set the (inaccessible) id field of
+     * the given {@link BaseEntity}.
+     *
+     * @param baseEntity The entity with the inaccessible id field
+     * @param id The id to set
+     * @throws NoSuchFieldException no such field exception
+     */
+    public static void setIdForEntity(BaseEntity baseEntity, Long id) throws NoSuchFieldException {
+        // use reflection to get the inaccessible final field 'id'
+        Field idField = BaseEntity.class.getDeclaredField("id");
+
+        AccessController.doPrivileged((PrivilegedAction<BaseEntity>) () -> {
+            idField.setAccessible(true);
+            try {
+                idField.set(baseEntity, id);
+            } catch (IllegalAccessException e) {
+                logger.error("Could not set ID field for persistent object", e);
+            }
+            idField.setAccessible(false);
+            return null;
+        });
+    }
+
+}


### PR DESCRIPTION
This ensures the `created` timestamp is not going to be overridden in REST PUT (update) if it's not given in the PUT body.

In addition some logger hints are added in context of the permission retrieval for users that are member of multiple groups.

Please review @terrestris/devs.

This is also candidate for the `main` once accepted.