### PR TITLE
Add findFor(user/group) methods

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/GroupClassPermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/GroupClassPermissionService.java
@@ -31,6 +31,21 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
     IdentityService identityService;
 
     /**
+     * Returns all {@link GroupClassPermission} for the given query arguments.
+     *
+     * @param group The group to find the permissions for.
+     * @return The permissions.
+     */
+    public List<GroupClassPermission> findFor(Group group) {
+
+        LOG.trace("Getting all group class permissions for group {}", group.getName());
+
+        return repository.findAll(Specification.where(
+            GroupClassPermissionSpecifications.hasGroup(group)
+        ));
+    }
+
+    /**
      * Returns the {@link GroupClassPermission} for the given query arguments.
      *
      * @param clazz The class to find the permission for.
@@ -39,7 +54,7 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
      */
     public Optional<GroupClassPermission> findFor(Class<? extends BaseEntity> clazz, Group group) {
 
-        LOG.trace("Getting all group class permissions for group {} and entity class {}",
+        LOG.trace("Getting the group class permission for group {} and entity class {}",
             group.getName(), clazz.getCanonicalName());
 
         return repository.findOne(Specification.where(
@@ -58,7 +73,7 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
      */
     public Optional<GroupClassPermission> findFor(BaseEntity entity, Group group) {
 
-        LOG.trace("Getting all group class permissions for group {} and entity class {}",
+        LOG.trace("Getting the group class permission for group {} and entity class {}",
                 group.getName(), entity.getClass().getCanonicalName());
 
         return repository.findOne(Specification.where(

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/GroupInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/GroupInstancePermissionService.java
@@ -28,6 +28,21 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
     protected PermissionCollectionRepository permissionCollectionRepository;
 
     /**
+     * Returns all {@link GroupInstancePermission} for the given query arguments.
+     *
+     * @param group The group to find the permissions for.
+     * @return The permissions.
+     */
+    public List<GroupInstancePermission> findFor(Group group) {
+
+        LOG.trace("Getting all group instance permissions for group {}", group.getName());
+
+        return repository.findAll(Specification.where(
+            GroupInstancePermissionSpecifications.hasGroup(group))
+        );
+    }
+
+    /**
      * Returns the {@link GroupInstancePermission} for the given query arguments.
      *
      * @param entity The entity to find the permission for.
@@ -36,7 +51,7 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
      */
     public Optional<GroupInstancePermission> findFor(BaseEntity entity, Group group) {
 
-        LOG.trace("Getting all group permissions for group {} and entity {}",
+        LOG.trace("Getting the group instance permission for group {} and entity {}",
             group.getName(), entity);
 
         return repository.findOne(Specification.where(

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/UserClassPermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/UserClassPermissionService.java
@@ -11,6 +11,7 @@ import de.terrestris.shoguncore.security.SecurityContextUtil;
 import de.terrestris.shoguncore.service.BaseService;
 import de.terrestris.shoguncore.specification.security.permission.PermissionCollectionSpecification;
 import de.terrestris.shoguncore.specification.security.permission.UserClassPermissionSpecifications;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.domain.Specification;
@@ -26,6 +27,21 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
     protected PermissionCollectionRepository permissionCollectionRepository;
 
     /**
+     * Returns all {@link UserClassPermission} for the given query arguments.
+     *
+     * @param user The user to find the permissions for.
+     * @return The permissions.
+     */
+    public List<UserClassPermission> findFor(User user) {
+
+        LOG.trace("Getting all user class permissions for user {}", user.getUsername());
+
+        return repository.findAll(Specification.where(
+            UserClassPermissionSpecifications.hasUser(user))
+        );
+    }
+
+    /**
      * Returns the {@link UserClassPermission} for the given query arguments.
      *
      * @param clazz The class to find the permission for.
@@ -34,7 +50,7 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
      */
     public Optional<UserClassPermission> findFor(Class<? extends BaseEntity> clazz, User user) {
 
-        LOG.trace("Getting all user class permissions for user {} and entity class {}",
+        LOG.trace("Getting the user class permission for user {} and entity class {}",
             user.getUsername(), clazz.getCanonicalName());
 
         return repository.findOne(Specification.where(

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/UserInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/UserInstancePermissionService.java
@@ -28,6 +28,36 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
     protected PermissionCollectionRepository permissionCollectionRepository;
 
     /**
+     * Returns all {@link UserInstancePermission} for the given query arguments.
+     *
+     * entity The entity to find the permission for.
+     * @return The permissions
+     */
+    public List<UserInstancePermission> findFor(BaseEntity entity) {
+
+        LOG.trace("Getting all user instance permissions for entity {}", entity);
+
+        return repository.findAll(Specification.where(
+            UserInstancePermissionSpecifications.hasEntity(entity))
+        );
+    }
+
+    /**
+     * Returns all {@link UserInstancePermission} for the given query arguments.
+     *
+     * @param user The user to find the permission for.
+     * @return The permissions
+     */
+    public List<UserInstancePermission> findFor(User user) {
+
+        LOG.trace("Getting all user instance permissions for user {}", user);
+
+        return repository.findAll(Specification.where(
+            UserInstancePermissionSpecifications.hasUser(user))
+        );
+    }
+
+    /**
      * Returns the {@link UserInstancePermission} for the given query arguments.
      *
      * @param entity The entity to find the permission for.


### PR DESCRIPTION
This suggests to add some methods to the permission service methods to find all appropriate permissions by the owning user or group.

Please review @terrestris/devs.