### PR TITLE
Several permission service and repository features (v3)

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/repository/security/permission/UserClassPermissionRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/repository/security/permission/UserClassPermissionRepository.java
@@ -5,11 +5,18 @@ import de.terrestris.shoguncore.model.security.permission.UserClassPermission;
 import de.terrestris.shoguncore.repository.BaseCrudRepository;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserClassPermissionRepository extends BaseCrudRepository<UserClassPermission, Long>, JpaSpecificationExecutor<UserClassPermission> {
 
     List<UserClassPermission> findAllByUser(User user);
+
+    @Modifying
+    @Query(value = "DELETE FROM userclasspermissions u WHERE u.user_id=:userId", nativeQuery = true)
+    void deleteAllByUserId(@Param("userId") Long userId);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/repository/security/permission/UserInstancePermissionRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/repository/security/permission/UserInstancePermissionRepository.java
@@ -6,6 +6,7 @@ import de.terrestris.shoguncore.model.security.permission.UserInstancePermission
 import de.terrestris.shoguncore.repository.BaseCrudRepository;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -21,4 +22,7 @@ public interface UserInstancePermissionRepository extends BaseCrudRepository<Use
         @Param("permissionCollectionType") PermissionCollectionType permissionCollectionType
     );
 
+    @Modifying
+    @Query(value = "DELETE FROM userinstancepermissions u WHERE u.user_id=:userId", nativeQuery = true)
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/GroupClassPermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/GroupClassPermissionService.java
@@ -38,7 +38,7 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
      */
     public List<GroupClassPermission> findFor(Group group) {
 
-        LOG.trace("Getting all group class permissions for group {}", group.getName());
+        LOG.trace("Getting all group class permissions for group with ID {}", group.getId());
 
         return repository.findAll(Specification.where(
             GroupClassPermissionSpecifications.hasGroup(group)
@@ -54,8 +54,8 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
      */
     public Optional<GroupClassPermission> findFor(Class<? extends BaseEntity> clazz, Group group) {
 
-        LOG.trace("Getting the group class permission for group {} and entity class {}",
-            group.getName(), clazz.getCanonicalName());
+        LOG.trace("Getting the group class permission for group with ID {} and entity class",
+            group.getId(), clazz.getCanonicalName());
 
         return repository.findOne(Specification.where(
             GroupClassPermissionSpecifications.hasEntity(clazz)).and(
@@ -73,8 +73,8 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
      */
     public Optional<GroupClassPermission> findFor(BaseEntity entity, Group group) {
 
-        LOG.trace("Getting the group class permission for group {} and entity class {}",
-                group.getName(), entity.getClass().getCanonicalName());
+        LOG.trace("Getting the group class permission for group with ID {} and " +
+                "entity class {}", group.getId(), entity.getClass().getCanonicalName());
 
         return repository.findOne(Specification.where(
                 GroupClassPermissionSpecifications.hasEntity(entity)).and(
@@ -92,8 +92,8 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
      */
     public Optional<GroupClassPermission> findFor(BaseEntity entity, User user) {
 
-        LOG.trace("Getting all group class permissions for user {} and entity {}",
-            user.getUsername(), entity);
+        LOG.trace("Getting all group class permissions for user with ID {} and " +
+                "entity with ID {}", user.getId(), entity.getId());
 
         // Get all groups of the user
         List<Group> groups = identityService.findAllGroupsFrom(user);
@@ -120,8 +120,8 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
      */
     public Optional<GroupClassPermission> findFor(Class<? extends BaseEntity> clazz, User user) {
 
-        LOG.trace("Getting all group class permissions for user {} and entity class {}",
-            user.getUsername(), clazz.getCanonicalName());
+        LOG.trace("Getting all group class permissions for user with ID {} and entity class {}",
+            user.getId(), clazz.getCanonicalName());
 
         // Get all groups of the user
         List<Group> groups = identityService.findAllGroupsFrom(user);
@@ -149,8 +149,8 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
      */
     public Optional<GroupClassPermission> findFor(BaseEntity entity, Group group, User user) {
 
-        LOG.trace("Getting all group class permissions for user {} and entity {} in the " +
-            "context of group {}", user.getUsername(), entity, group);
+        LOG.trace("Getting all group class permissions for user with ID {} and entity with ID " +
+            "{} in the context of group with ID {}", user.getId(), entity.getId(), group.getId());
 
         boolean isUserMemberInGroup = identityService.isUserMemberInGroup(user, group);
 
@@ -227,8 +227,8 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
 
         // Check if there is already an existing permission set on the entity
         if (existingPermissions.isPresent()) {
-            LOG.debug("Permission is already set for class {} and group {}: {}", clazz,
-                group, permissionCollection.get());
+            LOG.debug("Permission is already set for class {} and group with ID {}: {}", clazz,
+                group.getId(), permissionCollection.get());
 
             // Remove the existing one
             repository.delete(existingPermissions.get());

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/GroupInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/GroupInstancePermissionService.java
@@ -35,7 +35,7 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
      */
     public List<GroupInstancePermission> findFor(Group group) {
 
-        LOG.trace("Getting all group instance permissions for group {}", group.getName());
+        LOG.trace("Getting all group instance permissions for group with ID {}", group.getId());
 
         return repository.findAll(Specification.where(
             GroupInstancePermissionSpecifications.hasGroup(group))
@@ -51,8 +51,8 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
      */
     public Optional<GroupInstancePermission> findFor(BaseEntity entity, Group group) {
 
-        LOG.trace("Getting the group instance permission for group {} and entity {}",
-            group.getName(), entity);
+        LOG.trace("Getting the group instance permission for group with ID {} and entity with " +
+                "ID {}", group.getId(), entity.getId());
 
         return repository.findOne(Specification.where(
                 GroupInstancePermissionSpecifications.hasEntity(entity)).and(
@@ -70,8 +70,8 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
      */
     public Optional<GroupInstancePermission> findFor(BaseEntity entity, User user) {
 
-        LOG.trace("Getting all group permissions for user {} and entity {}",
-            user.getUsername(), entity);
+        LOG.trace("Getting all group permissions for user with ID {} and entity with ID {}",
+            user.getId(), entity.getId());
 
         // Get all groups of the user
         List<Group> groups = identityService.findAllGroupsFrom(user);
@@ -99,8 +99,9 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
      */
     public Optional<GroupInstancePermission> findFor(BaseEntity entity, Group group, User user) {
 
-        LOG.trace("Getting all group instance permissions for user {} and entity {} in the " +
-            "context of group {}", user.getUsername(), entity, group);
+        LOG.trace("Getting all group instance permissions for user with ID {} and entity " +
+            "with ID {} in the context of group with ID {}", user.getId(), entity.getId(),
+            group.getId());
 
         boolean isUserMemberInGroup = identityService.isUserMemberInGroup(user, group);
 
@@ -177,8 +178,8 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
 
         // Check if there is already an existing permission set on the entity
         if (existingPermissions.isPresent()) {
-            LOG.debug("Permission is already set for entity {} and group {}: {}",
-                persistedEntity, group, permissionCollection.get());
+            LOG.debug("Permission is already set for entity with ID {} and group with ID {}: {}",
+                persistedEntity.getId(), group.getId(), permissionCollection.get());
 
             // Remove the existing one
             repository.delete(existingPermissions.get());

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/GroupInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/GroupInstancePermissionService.java
@@ -43,6 +43,21 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
     }
 
     /**
+     * Returns all {@link GroupInstancePermission} for the given query arguments.
+     *
+     * @param entity The entity to find the permissions for.
+     * @return The permissions.
+     */
+    public List<GroupInstancePermission> findFor(BaseEntity entity) {
+
+        LOG.trace("Getting all group instance permissions for entity with ID {}", entity.getId());
+
+        return repository.findAll(Specification.where(
+            GroupInstancePermissionSpecifications.hasEntity(entity))
+        );
+    }
+
+    /**
      * Returns the {@link GroupInstancePermission} for the given query arguments.
      *
      * @param entity The entity to find the permission for.

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/UserClassPermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/UserClassPermissionService.java
@@ -34,7 +34,7 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
      */
     public List<UserClassPermission> findFor(User user) {
 
-        LOG.trace("Getting all user class permissions for user {}", user.getUsername());
+        LOG.trace("Getting all user class permissions for user with ID {}", user.getId());
 
         return repository.findAll(Specification.where(
             UserClassPermissionSpecifications.hasUser(user))
@@ -50,8 +50,8 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
      */
     public Optional<UserClassPermission> findFor(Class<? extends BaseEntity> clazz, User user) {
 
-        LOG.trace("Getting the user class permission for user {} and entity class {}",
-            user.getUsername(), clazz.getCanonicalName());
+        LOG.trace("Getting the user class permission for user with ID {} and entity class {}",
+            user.getId(), clazz.getCanonicalName());
 
         return repository.findOne(Specification.where(
             UserClassPermissionSpecifications.hasEntity(clazz)).and(
@@ -69,8 +69,8 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
      */
     public Optional<UserClassPermission> findFor(BaseEntity entity, User user) {
 
-        LOG.trace("Getting all user class permissions for user {} and entity class {}",
-                user.getUsername(), entity.getClass().getCanonicalName());
+        LOG.trace("Getting all user class permissions for user with ID {} and entity class {}",
+                user.getId(), entity.getClass().getCanonicalName());
 
         return repository.findOne(Specification.where(
                 UserClassPermissionSpecifications.hasEntity(entity)).and(
@@ -128,8 +128,8 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
 
         // Check if there is already an existing permission set on the entity
         if (existingPermissions.isPresent()) {
-            LOG.debug("Permission is already set for clazz {} and user {}: {}",
-                clazz.getCanonicalName(), user, permissionCollection.get());
+            LOG.debug("Permission is already set for clazz {} and user with ID {}: {}",
+                clazz.getCanonicalName(), user.getId(), permissionCollection.get());
 
             // Remove the existing one
             repository.delete(existingPermissions.get());

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/UserInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/service/security/permission/UserInstancePermissionService.java
@@ -35,7 +35,7 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
      */
     public List<UserInstancePermission> findFor(BaseEntity entity) {
 
-        LOG.trace("Getting all user instance permissions for entity {}", entity);
+        LOG.trace("Getting all user instance permissions for entity with ID {}", entity.getId());
 
         return repository.findAll(Specification.where(
             UserInstancePermissionSpecifications.hasEntity(entity))
@@ -50,7 +50,7 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
      */
     public List<UserInstancePermission> findFor(User user) {
 
-        LOG.trace("Getting all user instance permissions for user {}", user);
+        LOG.trace("Getting all user instance permissions for user with ID {}", user.getId());
 
         return repository.findAll(Specification.where(
             UserInstancePermissionSpecifications.hasUser(user))
@@ -66,8 +66,8 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
      */
     public Optional<UserInstancePermission> findFor(BaseEntity entity, User user) {
 
-        LOG.trace("Getting all user permissions for user {} and entity {}",
-            user.getUsername(), entity);
+        LOG.trace("Getting all user permissions for user with ID {} and entity with ID {}",
+            user.getId(), entity.getId());
 
         return repository.findOne(Specification.where(
                 UserInstancePermissionSpecifications.hasEntity(entity)).and(
@@ -84,8 +84,8 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
      */
     public List<UserInstancePermission> findFor(BaseEntity entity, PermissionCollectionType permissionCollectionType) {
 
-        LOG.trace("Getting all user permissions for entity {} and permission collection type {}",
-            entity, permissionCollectionType);
+        LOG.trace("Getting all user permissions for entity with ID {} and permission " +
+            "collection type {}", entity.getId(), permissionCollectionType);
 
         List<UserInstancePermission> result = repository
             .findByEntityAndPermissionCollectionType(entity, permissionCollectionType);
@@ -101,7 +101,7 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
      */
     public List<User> findOwner(BaseEntity entity) {
 
-        LOG.trace("Getting the owners of entity {}", entity);
+        LOG.trace("Getting the owners of entity with ID {}", entity.getId());
 
         List<UserInstancePermission> userInstancePermission =
             this.findFor(entity, PermissionCollectionType.ADMIN);
@@ -168,8 +168,8 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
 
         // Check if there is already an existing permission set on the entity
         if (existingPermissions.isPresent()) {
-            LOG.debug("Permission is already set for entity {} and user {}: {}",
-                persistedEntity, user, permissionCollection.get());
+            LOG.debug("Permission is already set for entity with ID {} and user {}: {}",
+                persistedEntity.getId(), user, permissionCollection.get());
 
             // Remove the existing one
             repository.delete(existingPermissions.get());


### PR DESCRIPTION
This applies some features to the permission services and repositories:

* Add method `deleteAllByUserId()` to delete all use instance and class permissions via the ID of the user. This performances much faster than getting the appropriate permissions first in scenarios where a lot of permissions are set.
* Add method `findFor()` for finding the group instance permissions by entity.
* Log the IDs of the handled entities only to minimize log footprint.

Please review @terrestris/devs.
