### PR TITLE
Allow JsonSuperType annotation on multiple types that extend each other (v3)

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/annotation/JsonSuperType.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/annotation/JsonSuperType.java
@@ -10,9 +10,11 @@ import java.lang.annotation.Target;
  * The `JsonSuperType` annotation helps to identify a type that should be deserialized instead of a parent type.
  * The `type` property specifies the parent type. This annotation needs to go along with a `JsonDeserialize` pointing
  * to the own type.
+ * If the super type that should get replaced is not an interface, than `override` needs to be set to `true`.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface JsonSuperType {
     Class<? extends Serializable> type();
+    boolean override() default false;
 }


### PR DESCRIPTION
This PR is on the v3 branch.

This commit solves the problem of having multiple implementations of one of the JSONB type.

Imagine we have this project structure: `shogun-lib > project a > project b` and we extend the type `UserDetails` on project a and on project b. Then we would want to extend the UserDetails from project a in project b. But both classes would have the `JsonSuperType` annotation.

This PR will now check if multiple types deserialize to the same super type and will choose the type that is the furthest down the implementation chain. In the example that would be the `UserDetails` from project b.