### PR TITLE
Several permission service and repository features

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/security/permission/UserClassPermissionRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/security/permission/UserClassPermissionRepository.java
@@ -5,8 +5,10 @@ import de.terrestris.shogun.lib.repository.BaseCrudRepository;
 import java.util.Optional;
 import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -15,5 +17,9 @@ public interface UserClassPermissionRepository extends BaseCrudRepository<UserCl
     @Query("Select ucp from userclasspermissions ucp where ucp.user.id = ?1 and ucp.className = ?2")
     @QueryHints(@QueryHint(name = org.hibernate.annotations.QueryHints.CACHEABLE, value = "true"))
     Optional<UserClassPermission> findByUserIdAndClassName(Long userId, String className);
+
+    @Modifying
+    @Query(value = "DELETE FROM userclasspermissions u WHERE u.user_id=:userId", nativeQuery = true)
+    void deleteAllByUserId(@Param("userId") Long userId);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/security/permission/UserInstancePermissionRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/security/permission/UserInstancePermissionRepository.java
@@ -6,8 +6,10 @@ import java.util.List;
 import java.util.Optional;
 import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.QueryHints;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -19,5 +21,9 @@ public interface UserInstancePermissionRepository extends BaseCrudRepository<Use
 
     @QueryHints(@QueryHint(name = org.hibernate.annotations.QueryHints.CACHEABLE, value = "true"))
     List<UserInstancePermission> findByEntityId(Long entityId);
+
+    @Modifying
+    @Query(value = "DELETE FROM userinstancepermissions u WHERE u.user_id=:userId", nativeQuery = true)
+    void deleteAllByUserId(@Param("userId") Long userId);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupClassPermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupClassPermissionService.java
@@ -10,11 +10,10 @@ import de.terrestris.shogun.lib.repository.security.permission.GroupClassPermiss
 import de.terrestris.shogun.lib.repository.security.permission.PermissionCollectionRepository;
 import de.terrestris.shogun.lib.security.SecurityContextUtil;
 import de.terrestris.shogun.lib.service.BaseService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 import java.util.List;
 import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 @Service
 public class GroupClassPermissionService extends BaseService<GroupClassPermissionRepository, GroupClassPermission> {
@@ -34,8 +33,10 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
      */
     public Optional<GroupClassPermission> findFor(BaseEntity entity, Group group) {
         String className = entity.getClass().getCanonicalName();
-        LOG.trace("Getting all group class permissions for group {} and entity class {}",
-            group.getKeycloakId(), className);
+
+        LOG.trace("Getting all group class permissions for group with Keycloak ID {} and " +
+            "entity class {}", group.getKeycloakId(), className);
+
         return repository.findByGroupIdAndClassName(group.getId(), className);
     }
 
@@ -48,8 +49,10 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
      */
     public Optional<GroupClassPermission> findFor(Class<? extends BaseEntity> clazz, Group group) {
         String className = clazz.getCanonicalName();
-        LOG.trace("Getting all group class permissions for group {} and entity class {}",
-            group.getKeycloakId(), className);
+
+        LOG.trace("Getting all group class permissions for group with Keycloak ID {} and " +
+            "entity class {}", group.getKeycloakId(), className);
+
         return repository.findByGroupIdAndClassName(group.getId(), className);
     }
 
@@ -63,14 +66,17 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
      */
     public Optional<GroupClassPermission> findFor(Class<? extends BaseEntity> clazz, User user) {
         String className = clazz.getCanonicalName();
-        LOG.trace("Getting all group class permissions for user {} and entity class {}",
-            user.getKeycloakId(), className);
+
+        LOG.trace("Getting all group class permissions for user with Keycloak ID {} and " +
+            "entity class {}", user.getKeycloakId(), className);
 
         // Get all groups of the user from Keycloak
         List<Group> groups = securityContextUtil.getGroupsForUser(user);
         Optional<GroupClassPermission> gcp = Optional.empty();
         for (Group g : groups) {
-            Optional<GroupClassPermission> permissionsForGroup = repository.findByGroupIdAndClassName(g.getId(), className);
+            Optional<GroupClassPermission> permissionsForGroup = repository
+                .findByGroupIdAndClassName(g.getId(), className);
+
             if (permissionsForGroup.isPresent()) {
                 gcp = permissionsForGroup;
                 break;
@@ -105,7 +111,8 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
      * @param permissionCollectionType The permission collection type (e.g. READ, READ_WRITE)
      */
     public void setPermission(Class<? extends BaseEntity> clazz, Group group, PermissionCollectionType permissionCollectionType) {
-        Optional<PermissionCollection> permissionCollection = permissionCollectionRepository.findByName(permissionCollectionType);
+        Optional<PermissionCollection> permissionCollection = permissionCollectionRepository
+            .findByName(permissionCollectionType);
 
         if (permissionCollection.isEmpty()) {
             throw new RuntimeException("Could not find requested permission collection");
@@ -126,8 +133,8 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
 
         // Check if there is already an existing permission set on the entity
         if (existingPermission.isPresent()) {
-            LOG.debug("Permission is already set for class {} and group {}: {}", clazz,
-                group, permissionCollection);
+            LOG.debug("Permission is already set for class {} and group with " +
+                "Keycloak ID {}: {}", clazz, group.getKeycloakId(), permissionCollection);
 
             // Remove the existing one
             repository.delete(existingPermission.get());

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionService.java
@@ -10,12 +10,11 @@ import de.terrestris.shogun.lib.repository.security.permission.GroupInstancePerm
 import de.terrestris.shogun.lib.repository.security.permission.PermissionCollectionRepository;
 import de.terrestris.shogun.lib.security.SecurityContextUtil;
 import de.terrestris.shogun.lib.service.BaseService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 @Service
 public class GroupInstancePermissionService extends BaseService<GroupInstancePermissionRepository, GroupInstancePermission> {
@@ -43,9 +42,10 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
             return Optional.empty();
         }
 
-        LOG.trace("Getting all group permissions for group {} and entity {}", group.getKeycloakId(), entity);
+        LOG.trace("Getting all group permissions for group with Keycloak ID {} and " +
+            "entity with ID {}", group.getKeycloakId(), entity.getId());
 
-        return repository.findByGroupIdAndEntityId(group.getId(), entity.getId()); // TODO: !
+        return repository.findByGroupIdAndEntityId(group.getId(), entity.getId());
     }
 
 
@@ -56,7 +56,7 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
      * @return
      */
     public List<GroupInstancePermission> findFor(BaseEntity entity) {
-        LOG.trace("Getting all group permissions for entity {}", entity);
+        LOG.trace("Getting all group permissions for entity with ID {}", entity.getId());
 
         return repository.findByEntityId(entity.getId());
     }
@@ -68,12 +68,15 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
      * @return
      */
     public Optional<GroupInstancePermission> findFor(BaseEntity entity, User user) {
-        LOG.trace("Getting all group permissions for user {} and entity {}", user.getKeycloakId(), entity);
+        LOG.trace("Getting all group permissions for user with Keycloak ID {} and " +
+            "entity with ID {}", user.getKeycloakId(), entity.getId());
+
         // Get all groups of the user from Keycloak
         List<Group> groups = securityContextUtil.getGroupsForUser(user);
         Optional<GroupInstancePermission> gip = Optional.empty();
         for (Group g : groups) {
-            Optional<GroupInstancePermission> permissionsForGroup = repository.findByGroupIdAndEntityId(g.getId(), entity.getId());
+            Optional<GroupInstancePermission> permissionsForGroup = repository
+                .findByGroupIdAndEntityId(g.getId(), entity.getId());
             if (permissionsForGroup.isPresent()) {
                 gip = permissionsForGroup;
                 break;
@@ -158,8 +161,8 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
 
         // Check if there is already an existing permission set on the entity
         if (existingPermission.isPresent()) {
-            LOG.debug("Permission is already set for entity {} and group {}: {}", entity,
-                group, permissionCollection);
+            LOG.debug("Permission is already set for entity with ID {} and group with " +
+                "Keycloak ID {}: {}", entity.getId(), group.getKeycloakId(), permissionCollection);
 
             // Remove the existing one
             // TODO: deletion really needed ???
@@ -174,7 +177,8 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
 
         repository.deleteAll(groupInstancePermissions);
 
-        LOG.info("Successfully deleted all group instance permissions for entity with id {}", persistedEntity.getId());
+        LOG.info("Successfully deleted all group instance permissions for entity " +
+            "with ID {}", persistedEntity.getId());
         LOG.trace("Deleted entity: {}", persistedEntity);
     }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/PermissionCollectionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/PermissionCollectionService.java
@@ -1,10 +1,9 @@
 package de.terrestris.shogun.lib.service.security.permission;
 
-import de.terrestris.shogun.lib.repository.security.permission.PermissionCollectionRepository;
 import de.terrestris.shogun.lib.model.security.permission.PermissionCollection;
+import de.terrestris.shogun.lib.repository.security.permission.PermissionCollectionRepository;
 import de.terrestris.shogun.lib.service.BaseService;
 import org.springframework.stereotype.Service;
 
 @Service
-public class PermissionCollectionService extends BaseService<PermissionCollectionRepository, PermissionCollection> {
-}
+public class PermissionCollectionService extends BaseService<PermissionCollectionRepository, PermissionCollection> { }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/UserClassPermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/UserClassPermissionService.java
@@ -9,10 +9,9 @@ import de.terrestris.shogun.lib.repository.security.permission.PermissionCollect
 import de.terrestris.shogun.lib.repository.security.permission.UserClassPermissionRepository;
 import de.terrestris.shogun.lib.security.SecurityContextUtil;
 import de.terrestris.shogun.lib.service.BaseService;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import java.util.Optional;
 
 @Service
 public class UserClassPermissionService extends BaseService<UserClassPermissionRepository, UserClassPermission> {
@@ -31,8 +30,9 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
      */
     public Optional<UserClassPermission> findFor(Class<? extends BaseEntity> clazz, User user) {
         String className = clazz.getCanonicalName();
-        LOG.trace("Getting all user class permissions for user {} and entity class {}",
-            user.getKeycloakId(), className);
+
+        LOG.trace("Getting all user class permissions for user with Keycloak ID {} and " +
+            "entity class {}", user.getKeycloakId(), className);
 
         return repository.findByUserIdAndClassName(user.getId(), className);
     }
@@ -76,7 +76,8 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
      * @param permissionCollectionType The permissionCollectionType to set
      */
     public void setPermission(Class<? extends BaseEntity> clazz, User user, PermissionCollectionType permissionCollectionType) {
-        Optional<PermissionCollection> permissionCollection = permissionCollectionRepository.findByName(permissionCollectionType);
+        Optional<PermissionCollection> permissionCollection = permissionCollectionRepository
+            .findByName(permissionCollectionType);
 
         if (permissionCollection.isEmpty()) {
             throw new RuntimeException("Could not find requested permission collection");
@@ -97,8 +98,8 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
 
         // Check if there is already an existing permission set on the entity
         if (existingPermission.isPresent()) {
-            LOG.debug("Permission is already set for clazz {} and user {}: {}", clazz.getCanonicalName(),
-                user, permissionCollection);
+            LOG.debug("Permission is already set for clazz {} and user with " +
+                "Keycloak ID {}: {}", clazz.getCanonicalName(), user, permissionCollection);
 
             // Remove the existing one
             repository.delete(existingPermission.get());

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/UserInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/UserInstancePermissionService.java
@@ -33,7 +33,9 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
      * @return
      */
     public Optional<UserInstancePermission> findFor(BaseEntity entity, User user) {
-        LOG.trace("Getting all user permissions for user {} and entity {}", user.getKeycloakId(), entity);
+        LOG.trace("Getting all user permissions for user with Keycloak ID {} and " +
+            "entity with ID {}", user.getKeycloakId(), entity);
+
         return repository.findByUserIdAndEntityId(user.getId(), entity.getId());
     }
 
@@ -44,7 +46,7 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
      * @return
      */
     public List<UserInstancePermission> findFor(BaseEntity entity) {
-        LOG.trace("Getting all user permissions for entity {}", entity);
+        LOG.trace("Getting all user permissions for entity with ID {}", entity.getId());
 
         return repository.findByEntityId(entity.getId());
     }
@@ -76,7 +78,8 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
     }
 
     public void setPermission(BaseEntity persistedEntity, User user, PermissionCollectionType permissionCollectionType) {
-        Optional<PermissionCollection> permissionCollection = permissionCollectionRepository.findByName(permissionCollectionType);
+        Optional<PermissionCollection> permissionCollection = permissionCollectionRepository
+            .findByName(permissionCollectionType);
 
         if (permissionCollection.isEmpty()) {
             throw new RuntimeException("Could not find requested permission collection");
@@ -103,7 +106,8 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
         User user,
         PermissionCollectionType permissionCollectionType
     ) {
-        Optional<PermissionCollection> permissionCollection = permissionCollectionRepository.findByName(permissionCollectionType);
+        Optional<PermissionCollection> permissionCollection = permissionCollectionRepository
+            .findByName(permissionCollectionType);
 
         if (permissionCollection.isEmpty()) {
             throw new RuntimeException("Could not find requested permission collection");
@@ -128,8 +132,8 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
 
         // Check if there is already an existing permission set on the entity
         if (existingPermission.isPresent()) {
-            LOG.debug("Permission is already set for entity {} and user {}: {}", entity,
-                user, permissionCollection);
+            LOG.debug("Permission is already set for entity with ID {} and user with " +
+                "Keycloak ID {}: {}", entity.getId(), user.getKeycloakId(), permissionCollection);
 
             // Remove the existing one
             repository.delete(existingPermission.get());
@@ -143,7 +147,8 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
 
         repository.deleteAll(userInstancePermissions);
 
-        LOG.info("Successfully deleted all user instance permissions for entity with id {}", persistedEntity.getId());
+        LOG.info("Successfully deleted all user instance permissions for entity " +
+            "with ID {}", persistedEntity.getId());
         LOG.trace("Deleted entity: {}", persistedEntity);
     }
 }


### PR DESCRIPTION
**Backport of #233 to the `main` branch.**

This applies some features to the permission services and repositories:

* Add method deleteAllByUserId() to delete all user instance and class permissions via the ID of the user. This performances much faster than getting the appropriate permissions first in scenarios where a lot of permissions are set.
* Log the IDs of the handled entities only to minimize log footprint.

Please review @terrestris/devs.