### PR TITLE
Ensure the created timestamp is not going to be overriden

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/BaseService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/BaseService.java
@@ -2,6 +2,7 @@ package de.terrestris.shogun.lib.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import de.terrestris.shogun.lib.enumeration.PermissionCollectionType;
 import de.terrestris.shogun.lib.model.BaseEntity;
 import de.terrestris.shogun.lib.repository.BaseCrudRepository;
@@ -92,7 +93,11 @@ public abstract class BaseService<T extends BaseCrudRepository<S, Long> & JpaSpe
     public S update(Long id, S entity) throws IOException {
         Optional<S> persistedEntity = repository.findById(id);
 
-        JsonNode jsonObject = objectMapper.valueToTree(entity);
+        ObjectNode jsonObject = objectMapper.valueToTree(entity);
+
+        // Ensure the created timestamp will not be overridden.
+        jsonObject.put("created", persistedEntity.get().getCreated().toInstant().toString());
+
         S updatedEntity = objectMapper.readerForUpdating(persistedEntity.get()).readValue(jsonObject);
 
         return repository.save(updatedEntity);


### PR DESCRIPTION
**Backport of #213 to the `main` branch.**

This ensures the created timestamp is not going to be overridden in REST PUT (update) if it's not given in the PUT body.

Please review @terrestris/devs.