### PR TITLE
Introduce conditional controller instances

### DIFF
--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/controller/ApplicationInfoController.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/controller/ApplicationInfoController.java
@@ -5,6 +5,7 @@ import de.terrestris.shogun.boot.service.ApplicationInfoService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,6 +17,7 @@ import org.springframework.web.server.ResponseStatusException;
  */
 @RestController
 @RequestMapping("/info")
+@ConditionalOnExpression("${controller.info.enabled:true}")
 public class ApplicationInfoController {
 
     protected final Logger LOG = LogManager.getLogger(getClass());

--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/controller/AuthController.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/controller/AuthController.java
@@ -2,6 +2,7 @@ package de.terrestris.shogun.boot.controller;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/auth")
+@ConditionalOnExpression("${controller.auth.enabled:true}")
 public class AuthController {
 
     protected final Logger LOG = LogManager.getLogger(getClass());

--- a/shogun-config/src/main/resources/application-base.yml
+++ b/shogun-config/src/main/resources/application-base.yml
@@ -94,6 +94,26 @@ keycloakauth:
   master-realm: master
   admin-client: admin-cli
 
+controller:
+  applications:
+    enabled: true
+  auth:
+    enabled: true
+  cache:
+    enabled: true
+  files:
+    enabled: true
+  groups:
+    enabled: true
+  imagefiles:
+    enabled: true
+  info:
+    enabled: true
+  layers:
+    enabled: true
+  users:
+    enabled: true
+
 upload:
   file:
     supportedContentTypes:

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/ApplicationController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/ApplicationController.java
@@ -2,10 +2,11 @@ package de.terrestris.shogun.lib.controller;
 
 import de.terrestris.shogun.lib.model.Application;
 import de.terrestris.shogun.lib.service.ApplicationService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/applications")
-public class ApplicationController extends BaseController<ApplicationService, Application> {
-}
+@ConditionalOnExpression("${controller.applications.enabled:true}")
+public class ApplicationController extends BaseController<ApplicationService, Application> { }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/CacheController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/CacheController.java
@@ -3,6 +3,7 @@ package de.terrestris.shogun.lib.controller;
 import de.terrestris.shogun.lib.service.CacheService;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.HttpStatus;
@@ -15,6 +16,7 @@ import org.springframework.web.server.ResponseStatusException;
 @Log4j2
 @RestController
 @RequestMapping("/cache")
+@ConditionalOnExpression("${controller.cache.enabled:true}")
 public class CacheController {
 
     @Autowired

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/FileController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/FileController.java
@@ -2,13 +2,11 @@ package de.terrestris.shogun.lib.controller;
 
 import de.terrestris.shogun.lib.model.File;
 import de.terrestris.shogun.lib.service.FileService;
-import org.springframework.context.i18n.LocaleContextHolder;
-import org.springframework.http.HttpStatus;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/files")
+@ConditionalOnExpression("${controller.files.enabled:true}")
 public class FileController extends BaseFileController<FileService, File> { }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/GroupController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/GroupController.java
@@ -4,18 +4,23 @@ import de.terrestris.shogun.lib.model.Group;
 import de.terrestris.shogun.lib.model.User;
 import de.terrestris.shogun.lib.service.GroupService;
 import de.terrestris.shogun.lib.service.UserService;
-import org.keycloak.representations.idm.GroupRepresentation;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.i18n.LocaleContextHolder;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
-
 import java.util.List;
 import java.util.Optional;
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/groups")
+@ConditionalOnExpression("${controller.groups.enabled:true}")
 public class GroupController extends BaseController<GroupService, Group> {
 
     @Autowired

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/ImageFileController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/ImageFileController.java
@@ -2,17 +2,26 @@ package de.terrestris.shogun.lib.controller;
 
 import de.terrestris.shogun.lib.model.ImageFile;
 import de.terrestris.shogun.lib.service.ImageFileService;
-import org.springframework.context.i18n.LocaleContextHolder;
-import org.springframework.http.*;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.server.ResponseStatusException;
-
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/imagefiles")
+@ConditionalOnExpression("${controller.imagefiles.enabled:true}")
 public class ImageFileController extends BaseFileController<ImageFileService, ImageFile> {
 
     @GetMapping("/{fileUuid}/thumbnail")

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/LayerController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/LayerController.java
@@ -2,9 +2,11 @@ package de.terrestris.shogun.lib.controller;
 
 import de.terrestris.shogun.lib.model.Layer;
 import de.terrestris.shogun.lib.service.LayerService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/layers")
+@ConditionalOnExpression("${controller.layers.enabled:true}")
 public class LayerController extends BaseController<LayerService, Layer> { }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/UserController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/UserController.java
@@ -2,9 +2,11 @@ package de.terrestris.shogun.lib.controller;
 
 import de.terrestris.shogun.lib.model.User;
 import de.terrestris.shogun.lib.service.UserService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/users")
+@ConditionalOnExpression("${controller.users.enabled:true}")
 public class UserController extends BaseController<UserService, User> { }


### PR DESCRIPTION
**Backport of #180 and #185 to the `main` branch.**

This makes the creation of all controller instances configurable, e.g. via the following entries in the `application.properties`:

```
controller:
  applications:
    enabled: true
  cache:
    enabled: true
  files:
    enabled: true
  groups:
    enabled: true
  imagefiles:
    enabled: true
  layers:
    enabled: true
  users:
    enabled: true
```

Please review @terrestris/devs.
