### PR TITLE
Graphql all by ids

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/GraphQLProvider.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/GraphQLProvider.java
@@ -38,9 +38,6 @@ public class GraphQLProvider {
     protected GraphQLSchema graphQLSchema;
 
     @Autowired
-    private ApplicationContext appContext;
-
-    @Autowired
     private List<BaseGraphQLDataFetcher> dataFetchers;
 
     @Bean
@@ -110,7 +107,7 @@ public class GraphQLProvider {
     private void addBaseTypes(List<TypeRuntimeWiring.Builder> typeBuilders, BaseGraphQLDataFetcher dataFetcher) {
         String simpleClassName = dataFetcher.getGenericSimpleClassName();
 
-        String queryAllName = String.format("all%s", (English.plural(simpleClassName)));
+        String queryAllName = String.format("all%s", English.plural(simpleClassName));
         typeBuilders.add(TypeRuntimeWiring.newTypeWiring("Query")
             .dataFetcher(queryAllName, dataFetcher.findAll()));
 
@@ -122,6 +119,12 @@ public class GraphQLProvider {
             .dataFetcher(queryByIdName, dataFetcher.findOne()));
 
         log.debug("Added GraphQL query {}", queryByIdName);
+
+        String queryAllByIdsName = String.format("all%sByIds", English.plural(simpleClassName));
+        typeBuilders.add(TypeRuntimeWiring.newTypeWiring("Query")
+            .dataFetcher(queryAllByIdsName, dataFetcher.findAllByIds()));
+
+        log.debug("Added GraphQL query {}", queryAllByIdsName);
 
         String createName = String.format("create%s", simpleClassName);
         typeBuilders.add(TypeRuntimeWiring.newTypeWiring("Mutation")

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/resolver/BaseGraphQLDataFetcher.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/resolver/BaseGraphQLDataFetcher.java
@@ -9,8 +9,10 @@ import graphql.schema.DataFetcher;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.GenericTypeResolver;
@@ -40,6 +42,15 @@ public abstract class BaseGraphQLDataFetcher<E extends BaseEntity, S extends Bas
             }
 
             return persistedEntity;
+        };
+    }
+
+    public DataFetcher findAllByIds() {
+        return dataFetchingEnvironment -> {
+            List<Integer> entityIds = dataFetchingEnvironment.getArgument("ids");
+
+            return this.service.findAllById(entityIds.stream().map(Integer::longValue).collect(
+                Collectors.toList()));
         };
     }
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/BaseService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/BaseService.java
@@ -60,6 +60,12 @@ public abstract class BaseService<T extends BaseCrudRepository<S, Long> & JpaSpe
         return repository.findById(id);
     }
 
+    @PostFilter("hasRole('ROLE_ADMIN') or hasPermission(filterObject, 'READ')")
+    @Transactional(readOnly = true)
+    public List<S> findAllById(List<Long> id) {
+        return (List<S>) repository.findAllById(id);
+    }
+
     @PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#entity, 'READ')")
     @Transactional(readOnly = true)
     public Revisions<Integer, S> findRevisions(S entity) {

--- a/shogun-lib/src/main/resources/graphql/shogun.graphqls
+++ b/shogun-lib/src/main/resources/graphql/shogun.graphqls
@@ -4,21 +4,27 @@ scalar Geometry
 type Query {
     allApplications: [Application]
     applicationById(id: Int): Application
+    allApplicationsByIds(ids: [Int]): [Application]
 
     allFiles: [File]
     fileById(id: Int): File
+    allFilesByIds(ids: [Int]): [File]
 
     allGroups: [Group]
     groupById(id: Int): Group
+    allGroupsByIds(ids: [Int]): [Group]
 
     allImageFiles: [ImageFile]
     imageFileById(id: Int): ImageFile
+    allImageFilesByIds(ids: [Int]): [ImageFile]
 
     allLayers: [Layer]
     layerById(id: Int): Layer
+    allLayersByIds(ids: [Int]): [Layer]
 
     allUsers: [User]
     userById(id: Int): User
+    allUsersByIds(ids: [Int]): [User]
 }
 
 type Mutation {


### PR DESCRIPTION
**Backport of #226 to the `main` - requires #252!**

This allows generic graphQL queries in the form of `allUsersByIds(ids: $ids)` where ids is an array of ids.

Please review @terrestris/devs.