### PR TITLE
Add missing migrations

### DIFF
--- a/shogun-boot/src/main/resources/db/migration/V0.5.0__Add_missing_permission_READ_UPDATE_DELETE.sql
+++ b/shogun-boot/src/main/resources/db/migration/V0.5.0__Add_missing_permission_READ_UPDATE_DELETE.sql
@@ -1,3 +1,5 @@
+SET search_path TO shogun, public;
+
 INSERT INTO permissions (id, created, modified, name)
 SELECT
     nextval('hibernate_sequence'),

--- a/shogun-boot/src/main/resources/db/migration/V0.5.0__Add_missing_permission_READ_UPDATE_DELETE.sql
+++ b/shogun-boot/src/main/resources/db/migration/V0.5.0__Add_missing_permission_READ_UPDATE_DELETE.sql
@@ -1,0 +1,60 @@
+INSERT INTO permissions (id, created, modified, name)
+SELECT
+    nextval('hibernate_sequence'),
+    NOW()::timestamp,
+    NOW()::timestamp,
+    'READ_UPDATE_DELETE'
+WHERE
+  NOT EXISTS (
+    SELECT
+      *
+    FROM
+      permissions
+    WHERE
+      name = 'READ_UPDATE_DELETE'
+  );
+
+INSERT INTO permission (permissions_id, permissions)
+SELECT
+  currval('hibernate_sequence'),
+  'READ'
+WHERE
+  NOT EXISTS (
+    SELECT
+      *
+    FROM
+      permission
+    WHERE
+      permissions_id = currval('hibernate_sequence') AND
+      permissions = 'READ'
+  );
+
+INSERT INTO permission (permissions_id, permissions)
+SELECT
+  currval('hibernate_sequence'),
+  'UPDATE'
+WHERE
+  NOT EXISTS (
+    SELECT
+      *
+    FROM
+      permission
+    WHERE
+      permissions_id = currval('hibernate_sequence') AND
+      permissions = 'UPDATE'
+  );
+
+INSERT INTO permission (permissions_id, permissions)
+SELECT
+  currval('hibernate_sequence'),
+  'DELETE'
+WHERE
+  NOT EXISTS (
+    SELECT
+      *
+    FROM
+      permission
+    WHERE
+      permissions_id = currval('hibernate_sequence') AND
+      permissions = 'DELETE'
+  );

--- a/shogun-boot/src/main/resources/db/migration/V0.6.0__Remove_topic.sql
+++ b/shogun-boot/src/main/resources/db/migration/V0.6.0__Remove_topic.sql
@@ -1,0 +1,7 @@
+SET search_path TO shogun_rev, public;
+
+DROP TABLE IF EXISTS shogun_rev.topics_rev;
+
+SET search_path TO shogun, public;
+
+DROP TABLE IF EXISTS shogun.topics;

--- a/shogun-boot/src/test/java/de/terrestris/shogun/boot/flyway/FlywayMigrations.java
+++ b/shogun-boot/src/test/java/de/terrestris/shogun/boot/flyway/FlywayMigrations.java
@@ -1,0 +1,28 @@
+package de.terrestris.shogun.boot.flyway;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
+
+
+import java.io.File;
+import org.junit.Test;
+
+public class FlywayMigrations {
+
+    @Test
+    public void validateFilenames() {
+        File migrationFolder = new File("src/main/resources/db/migration");
+        File[] migrationFiles = migrationFolder.listFiles();
+
+        for (File migrationFile : migrationFiles) {
+            if (migrationFile.isFile()) {
+                String migrationFilename = migrationFile.getName();
+
+                assertThat(
+                    migrationFilename,
+                    matchesPattern("^V0\\.\\d+\\.\\d+(\\_\\_)[^_][\\w]+[^_]\\.(sql|java|sh)$")
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
:rotating_light: **Attention** :rotating_light:

This adds two missing migrations that were made necessary due to #247 and #258.

**Important:** 

This will very likely break the startup of _any_ existing project as the flyway migration order might be out of sync. Please note discussion in #263 for a potential solution and also the test included in this PR to enforce the correct namings.

Please review @terrestris/devs.