### PR TITLE
Partly fix mvn site and friends

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,11 +65,12 @@
 
     <!-- Plugins -->
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+    <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+    <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     <jacoco-plugin.version>0.8.6</jacoco-plugin.version>
-    <project-info-reports-plugin.version>3.1.1</project-info-reports-plugin.version>
-    <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
+    <maven-project-info-reports-plugin.version>3.1.1</maven-project-info-reports-plugin.version>
     <jib-maven-pluign.version>2.7.1</jib-maven-pluign.version>
 
     <!-- Javax -->
@@ -230,6 +231,11 @@
             </container>
           </configuration>
         </plugin>
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>${maven-site-plugin.version}</version>
+          <extensions>true</extensions>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -262,7 +268,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-project-info-reports-plugin</artifactId>
-            <version>${project-info-reports-plugin.version}</version>
+            <version>${maven-project-info-reports-plugin.version}</version>
             <reportSets>
               <reportSet>
                 <reports>

--- a/shogun-boot/pom.xml
+++ b/shogun-boot/pom.xml
@@ -125,8 +125,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-site-plugin</artifactId>
-        <!-- TODO Version -->
-        <version>3.9.1</version>
+        <version>${maven-site-plugin.version}</version>
         <extensions>true</extensions>
       </plugin>
       <plugin>

--- a/shogun-gs-interceptor/pom.xml
+++ b/shogun-gs-interceptor/pom.xml
@@ -123,7 +123,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.9.1</version>
+        <version>${maven-site-plugin.version}</version>
         <extensions>true</extensions>
       </plugin>
       <plugin>


### PR DESCRIPTION
This PR suggests …

* …to add a new property `maven-site-plugin.version` for accessing the version of the maven site plugin
* …to additionally add the site plugin to the parent pom under `plugins`

These changes make `mvn site` work (currently broken on master). When the `reporting` profile is active (`mvn -P reporting test site`, e.g.), several information from the project info lugin will be included (That was previousl already included).

Nonetheless several things aren't work as expected win the genrated report, these should be tackled some other day.

Please review.


