### PR TITLE
JacksonMapper: Extend config from ObjectMapper to initialize objectMapper used for Hibernate and GraphQL correctly

### DIFF
--- a/shogun-boot/pom.xml
+++ b/shogun-boot/pom.xml
@@ -119,6 +119,11 @@
       <groupId>org.keycloak</groupId>
       <artifactId>keycloak-spring-boot-starter</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/shogun-boot/src/test/java/JacksonConfigTest.java
+++ b/shogun-boot/src/test/java/JacksonConfigTest.java
@@ -1,0 +1,59 @@
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.terrestris.shogun.boot.config.ApplicationConfig;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.LineString;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = ApplicationConfig.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+public class JacksonConfigTest {
+
+    @Value("${shogun.srid}")
+    private int srid;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    public void assertThatObjectMapperHasJtsModuleRegistered() {
+        var registeredModules = objectMapper.getRegisteredModuleIds();
+        boolean hasJtsModuleRegistered = false;
+        for (Object module : registeredModules) {
+            if (StringUtils.equalsIgnoreCase((CharSequence) module, "com.bedatadriven.jackson.datatype.jts.JtsModule")) {
+                hasJtsModuleRegistered = true;
+            }
+        }
+        Assertions.assertTrue(hasJtsModuleRegistered, "JTS Module is not registrered in ObjectMapper");
+    }
+
+    @Test
+    public void assertThatObjectMapperHasCorrectlyConfiguredJtsModule() throws JsonProcessingException {
+        String LINESTRING_25832 = "{" +
+            "\"type\": \"LineString\"," +
+            "\"coordinates\": [" +
+                "[" +
+                    "711957.369742162," +
+                    "5637657.304058334" +
+                "]," +
+                "[" +
+                    "711979.3599907478," +
+                    "5637629.050147795" +
+                "]," +
+                "[" +
+                    "712000.5099907471," +
+                    "5637596.860147787" +
+                "]" +
+            "]" +
+        "}";
+        LineString parsedLineString = objectMapper.readValue(LINESTRING_25832, LineString.class);
+        Assertions.assertEquals(parsedLineString.getSRID(), srid, "Coordinate reference system of parsed " +
+            "geometry does not match the one configured in JTS Module");
+    }
+
+}

--- a/shogun-boot/src/test/java/de/terrestris/shogun/boot/config/JacksonConfigTest.java
+++ b/shogun-boot/src/test/java/de/terrestris/shogun/boot/config/JacksonConfigTest.java
@@ -1,22 +1,32 @@
+package de.terrestris.shogun.boot.config;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.terrestris.shogun.boot.config.ApplicationConfig;
+import de.terrestris.shogun.boot.runner.ApplicationInitializer;
 import org.apache.commons.lang3.StringUtils;
+import org.junit.AfterClass;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.LineString;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest(classes = ApplicationConfig.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(classes = { ApplicationConfig.class, JdbcConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 public class JacksonConfigTest {
+
+    // Replace ApplicationInitializer by functionless mock
+    @MockBean
+    private ApplicationInitializer applicationInitializer;
 
     @Value("${shogun.srid}")
     private int srid;
 
+    // The objectmapper created during boot procedure
     @Autowired
     ObjectMapper objectMapper;
 

--- a/shogun-boot/src/test/java/de/terrestris/shogun/boot/config/JdbcConfiguration.java
+++ b/shogun-boot/src/test/java/de/terrestris/shogun/boot/config/JdbcConfiguration.java
@@ -1,0 +1,103 @@
+package de.terrestris.shogun.boot.config;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.AfterClass;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.core.env.Environment;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.JpaVendorAdapter;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Configuration(proxyBeanMethods = false)
+@PropertySource("jdbc.properties")
+@EnableTransactionManagement
+public class JdbcConfiguration {
+
+    @Autowired
+    private Environment env;
+
+    private PostgreSQLContainer postgreSQLContainer;
+
+    private static final Set<HikariDataSource> datasourcesForCleanup = new HashSet();
+
+    @Bean
+    public PostgreSQLContainer postgreSQLContainer() {
+        if (postgreSQLContainer != null) {
+            return postgreSQLContainer;
+        }
+        DockerImageName postgis = DockerImageName.parse("docker.terrestris.de/postgis/postgis:11-3.0").asCompatibleSubstituteFor("postgres");
+        postgreSQLContainer = new PostgreSQLContainer(postgis);
+        postgreSQLContainer.start();
+        return postgreSQLContainer;
+    }
+
+    @Bean
+    public DataSource dataSource(final JdbcDatabaseContainer databaseContainer) {
+        HikariConfig hikariConfig = new HikariConfig();
+        String jdbcUrl = String.format("%s&currentSchema=shogun", databaseContainer.getJdbcUrl());
+        hikariConfig.setJdbcUrl(jdbcUrl);
+        hikariConfig.setUsername(databaseContainer.getUsername());
+        hikariConfig.setPassword(databaseContainer.getPassword());
+        hikariConfig.setDriverClassName(databaseContainer.getDriverClassName());
+
+        final HikariDataSource dataSource = new HikariDataSource(hikariConfig);
+        datasourcesForCleanup.add(dataSource);
+
+        return dataSource;
+    }
+
+    @Bean
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
+        LocalContainerEntityManagerFactoryBean result = new LocalContainerEntityManagerFactoryBean();
+
+        result.setDataSource(dataSource(postgreSQLContainer()));
+        result.setPackagesToScan(env.getProperty("shogun.model.packages"));
+        result.setJpaVendorAdapter(jpaVendorAdapter());
+
+        Map<String, Object> jpaProperties = new HashMap<>();
+        jpaProperties.put("hibernate.hbm2ddl.auto", env.getProperty("hibernate.hbm2ddl.auto"));
+        jpaProperties.put("hibernate.dialect", env.getProperty("hibernate.dialect"));
+        jpaProperties.put("hibernate.show_sql", env.getProperty("hibernate.show_sql"));
+        jpaProperties.put("hibernate.format_sql", env.getProperty("hibernate.format_sql"));
+        jpaProperties.put("hibernate.default_schema", env.getProperty("hibernate.default_schema"));
+        jpaProperties.put("hibernate.integration.envers.enabled", false);
+
+        result.setJpaPropertyMap(jpaProperties);
+
+        return result;
+    }
+
+    @Bean
+    public JpaVendorAdapter jpaVendorAdapter() {
+        return new HibernateJpaVendorAdapter();
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager() {
+        JpaTransactionManager transactionManager = new JpaTransactionManager();
+        transactionManager.setEntityManagerFactory(entityManagerFactory().getObject());
+        return transactionManager;
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        datasourcesForCleanup.forEach(HikariDataSource::close);
+    }
+
+}

--- a/shogun-boot/src/test/resources/application-test.yml
+++ b/shogun-boot/src/test/resources/application-test.yml
@@ -1,0 +1,19 @@
+shogun:
+  srid: 25832
+
+spring:
+  flyway:
+    schemas: shogun, public
+    defaultSchema: shogun
+    disabled: true
+  jpa:
+    show-sql: false
+    properties:
+      hibernate:
+        generate_statistics: false
+        cache:
+          use_second_level_cache: false
+          use_query_cache: false
+        integration:
+          envers:
+            enabled: false

--- a/shogun-boot/src/test/resources/application-test.yml
+++ b/shogun-boot/src/test/resources/application-test.yml
@@ -5,15 +5,5 @@ spring:
   flyway:
     schemas: shogun, public
     defaultSchema: shogun
-    disabled: true
-  jpa:
-    show-sql: false
-    properties:
-      hibernate:
-        generate_statistics: false
-        cache:
-          use_second_level_cache: false
-          use_query_cache: false
-        integration:
-          envers:
-            enabled: false
+  session:
+    store-type: none

--- a/shogun-boot/src/test/resources/jdbc.properties
+++ b/shogun-boot/src/test/resources/jdbc.properties
@@ -4,4 +4,3 @@ hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 hibernate.hbm2ddl.auto=update
 hibernate.show_sql=false
 hibernate.format_sql=false
-hibernate.default_schema=shogun

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/GraphQLProvider.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/GraphQLProvider.java
@@ -10,25 +10,21 @@ import graphql.scalars.ExtendedScalars;
 import graphql.schema.DataFetcher;
 import graphql.schema.GraphQLScalarType;
 import graphql.schema.GraphQLSchema;
-import graphql.schema.idl.RuntimeWiring;
-import graphql.schema.idl.SchemaGenerator;
-import graphql.schema.idl.SchemaParser;
-import graphql.schema.idl.TypeDefinitionRegistry;
-import graphql.schema.idl.TypeRuntimeWiring;
+import graphql.schema.idl.*;
+import lombok.extern.log4j.Log4j2;
+import org.atteo.evo.inflector.English;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.PostConstruct;
-import lombok.extern.log4j.Log4j2;
-import org.atteo.evo.inflector.English;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
-import org.springframework.stereotype.Component;
 
 @Log4j2
 @Component
@@ -90,8 +86,8 @@ public class GraphQLProvider {
     protected List<GraphQLScalarType> gatherScalars() {
         List<GraphQLScalarType> scalars = new ArrayList<>();
         scalars.add(ExtendedScalars.Json);
-        scalars.add(GeometryScalar.GEOMETRY);
-        scalars.add(DateTimeScalar.DATE_TIME);
+        scalars.add(new GeometryScalar());
+        scalars.add(new DateTimeScalar());
         return scalars;
     }
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/scalar/DateTimeScalar.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/scalar/DateTimeScalar.java
@@ -2,70 +2,68 @@ package de.terrestris.shogun.lib.graphql.scalar;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.terrestris.shogun.lib.config.JacksonConfig;
 import graphql.language.StringValue;
 import graphql.schema.Coercing;
 import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.GraphQLScalarType;
-import java.util.Date;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
 
 @Log4j2
-public class DateTimeScalar {
-    protected static ObjectMapper _objectMapper;
-    protected static ObjectMapper objectMapper() {
-        if (_objectMapper == null) {
-            _objectMapper = (new JacksonConfig()).objectMapper();
-        }
-        return _objectMapper;
+@Component
+public class DateTimeScalar extends GraphQLScalarType {
+
+    private static ObjectMapper om;
+
+    @Autowired
+    public void setObjectMapper(ObjectMapper objectMapper){
+        DateTimeScalar.om = objectMapper;
     }
 
-    public static final GraphQLScalarType DATE_TIME = new GraphQLScalarType("DateTime", "A custom scalar that handles date formats", new Coercing() {
-        @Override
-        public Object serialize(Object dataFetcherResult) {
-            return serializeDate(dataFetcherResult);
-        }
-
-        @SneakyThrows
-        @Override
-        public Object parseValue(Object input) {
-            return parseDateFromVariable(input);
-        }
-
-        @SneakyThrows
-        @Override
-        public Object parseLiteral(Object input) {
-            return parseDateFromAstLiteral(input);
-        }
-    });
-
-    private static Object serializeDate(Object dataFetcherResult) {
-        return objectMapper().convertValue(dataFetcherResult, String.class);
+    public DateTimeScalar() {
+        this("DateTime", "A custom scalar that handles date formats");
     }
 
-    private static Object parseDateFromVariable(Object dataFetcherResult) {
-        if (dataFetcherResult instanceof String) {
-            String dateTimeString = (String)dataFetcherResult;
-            try {
-                return objectMapper().readValue(dateTimeString, Date.class);
-            } catch (JsonProcessingException e) {
+    public DateTimeScalar(String name, String description) {
+        super(name, description, new Coercing() {
+            @Override
+            public Object serialize(Object dataFetcherResult) {
+                return om.convertValue(dataFetcherResult, String.class);
+            }
+
+            @SneakyThrows
+            @Override
+            public Object parseValue(Object dataFetcherResult) {
+                if (dataFetcherResult instanceof String) {
+                    String dateTimeString = (String)dataFetcherResult;
+                    try {
+                        return om.readValue(dateTimeString, Date.class);
+                    } catch (JsonProcessingException e) {
+                        throw new CoercingParseValueException("Unable to parse variable value " + dataFetcherResult + " as DateTime");
+                    }
+                }
                 throw new CoercingParseValueException("Unable to parse variable value " + dataFetcherResult + " as DateTime");
             }
-        }
-        throw new CoercingParseValueException("Unable to parse variable value " + dataFetcherResult + " as DateTime");
+
+            @SneakyThrows
+            @Override
+            public Object parseLiteral(Object dataFetcherResult) {
+                if (dataFetcherResult instanceof StringValue) {
+                    String dateTimeString = ((StringValue) dataFetcherResult).getValue();;
+                    try {
+                        return om.readValue(dateTimeString, Date.class);
+                    } catch (JsonProcessingException e) {
+                        throw new CoercingParseValueException("Unable to parse value " + dataFetcherResult + " as DateTime");
+                    }
+                }
+                throw new CoercingParseLiteralException("Value is not DateTime");
+            }
+        });
     }
 
-    private static Object parseDateFromAstLiteral(Object dataFetcherResult) {
-        if (dataFetcherResult instanceof StringValue) {
-            String dateTimeString = ((StringValue) dataFetcherResult).getValue();;
-            try {
-                return objectMapper().readValue(dateTimeString, Date.class);
-            } catch (JsonProcessingException e) {
-                throw new CoercingParseValueException("Unable to parse value " + dataFetcherResult + " as DateTime");
-            }
-        }
-        throw new CoercingParseLiteralException("Value is not DateTime");
-    }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/scalar/GeometryScalar.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/scalar/GeometryScalar.java
@@ -1,93 +1,84 @@
 package de.terrestris.shogun.lib.graphql.scalar;
 
-import com.bedatadriven.jackson.datatype.jts.JtsModule;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import de.terrestris.shogun.lib.config.JacksonConfig;
 import graphql.language.StringValue;
-import graphql.schema.Coercing;
-import graphql.schema.CoercingParseLiteralException;
-import graphql.schema.CoercingParseValueException;
-import graphql.schema.CoercingSerializeException;
-import graphql.schema.GraphQLScalarType;
-import java.util.HashMap;
+import graphql.schema.*;
 import lombok.extern.log4j.Log4j2;
 import org.locationtech.jts.geom.Geometry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+
+import java.util.HashMap;
 
 @Log4j2
-public class GeometryScalar {
+@Component
+public class GeometryScalar extends GraphQLScalarType {
 
-    protected static ObjectMapper _objectMapper;
+    private static ObjectMapper om;
 
-    protected static ObjectMapper objectMapper() {
-        if (_objectMapper == null) {
-            _objectMapper = (new JacksonConfig()).objectMapper();
-        }
-        return _objectMapper;
+    @Autowired
+    public void setObjectMapper(ObjectMapper objectMapper){
+        GeometryScalar.om = objectMapper;
     }
 
-    public static final GraphQLScalarType GEOMETRY = new GraphQLScalarType("Geometry", "A custom scalar that handles geometries", new Coercing() {
-
-        @Override
-        public Object serialize(Object dataFetcherResult) {
-            return serializeGeometry(dataFetcherResult);
-        }
-
-        @Override
-        public Object parseValue(Object input) {
-            return parseGeometryFromVariable(input);
-        }
-
-        @Override
-        public Object parseLiteral(Object input) {
-            return parseGeometryFromAstLiteral(input);
-        }
-    });
-
-    private static boolean isAGeometry(Object possibleGeometryValue) {
-        return possibleGeometryValue instanceof Geometry;
+    public GeometryScalar() {
+        this("Geometry", "A custom scalar that handles geometries");
     }
 
-    private static Object serializeGeometry(Object dataFetcherResult) {
-        if (isAGeometry(dataFetcherResult)) {
-            Geometry geometry = (Geometry) dataFetcherResult;
-            try {
-                return objectMapper().readValue(objectMapper().writeValueAsString(geometry), HashMap.class);
-            } catch (JsonProcessingException e) {
-                log.error("JSON Processing error while writing geometry for GraphQL");
-                log.trace("Full stack trace: ", e);
-                throw new CoercingSerializeException(e.getMessage());
+    public GeometryScalar(String name, String description) {
+        super(name, description, new Coercing() {
+
+            @Override
+            public Object serialize(Object dataFetcherResult) {
+                if (isAGeometry(dataFetcherResult)) {
+                    Geometry geometry = (Geometry) dataFetcherResult;
+                    try {
+                        return om.readValue(om.writeValueAsString(geometry), HashMap.class);
+                    } catch (JsonProcessingException e) {
+                        log.error("JSON Processing error while writing geometry for GraphQL");
+                        log.trace("Full stack trace: ", e);
+                        throw new CoercingSerializeException(e.getMessage());
+                    }
+                } else {
+                    throw new CoercingSerializeException("Unable to serialize " + dataFetcherResult + " as a geometry");
+                }
             }
-        } else {
-            throw new CoercingSerializeException("Unable to serialize " + dataFetcherResult + " as a geometry");
-        }
-    }
 
-    private static Object parseGeometryFromVariable(Object input) {
-        if (input instanceof String) {
-            String geometryString = (String)input;
-            try {
-                return objectMapper().readValue(geometryString, HashMap.class);
-            } catch (JsonProcessingException e) {
+            @Override
+            public Object parseValue(Object input) {
+                if (input instanceof String) {
+                    String geometryString = (String)input;
+                    try {
+                        return om.readValue(geometryString, HashMap.class);
+                    } catch (JsonProcessingException e) {
+                        throw new CoercingParseValueException("Unable to parse variable value " + input + " as a geometry");
+                    }
+                }
                 throw new CoercingParseValueException("Unable to parse variable value " + input + " as a geometry");
             }
-        }
-        throw new CoercingParseValueException("Unable to parse variable value " + input + " as a geometry");
+
+            @Override
+            public Object parseLiteral(Object input) {
+                if (input instanceof StringValue) {
+                    String geometryString = ((StringValue) input).getValue();;
+                    try {
+                        return om.readValue(geometryString, HashMap.class);
+                    } catch (JsonProcessingException e) {
+                        throw new CoercingParseValueException("Unable to parse value " + input + " as a geometry");
+                    }
+                }
+                throw new CoercingParseLiteralException(
+                    "Value is not an geometry"
+                );
+            }
+        });
     }
 
-    private static Object parseGeometryFromAstLiteral(Object input) {
-        if (input instanceof StringValue) {
-            String geometryString = ((StringValue) input).getValue();;
-            ObjectMapper mapper = new ObjectMapper();
-            mapper.registerModule(new JtsModule());
-            try {
-                return mapper.readValue(geometryString, HashMap.class);
-            } catch (JsonProcessingException e) {
-                throw new CoercingParseValueException("Unable to parse value " + input + " as a geometry");
-            }
-        }
-        throw new CoercingParseLiteralException(
-            "Value is not an geometry"
-        );
+    static boolean isAGeometry(Object possibleGeometryValue) {
+        return possibleGeometryValue instanceof Geometry;
     }
 }


### PR DESCRIPTION
During startup of a SHOGun boot application, two `objectMapper` instances are created currently: The one for hibernate and the one of Spring (used in GraphQL).
However, since `hibernate.types.jackson.object.mapper` is set in `hibernate.properties` the `objectMapper` created in JacksonConfig is used *before* the one of Spring is created. Therefore, the passed values for `shogun.srid` and `shogun.coordinatePrecisionScale` are not yet available which leads to a erroneous configured mapper for geometries (SRID:0).
By this PR, `JacksonConfig` extends `ObjectMapper` and uses its methods directly and fixes the broken initialization procedure. In addition, `readValue` needed to be overwritten in order to guarantee that search for `JsonSuperType` annotation already has been done.

Plz review @terrestris/devs 

 