### PR TITLE
use java.time.OffsetDateTime instead of java.util.Date

### DIFF
--- a/shogun-boot/src/main/java/de/terrestris/shogunboot/task/scheduled/UserTask.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogunboot/task/scheduled/UserTask.java
@@ -4,8 +4,9 @@ import de.terrestris.shoguncore.model.User;
 import de.terrestris.shoguncore.model.token.UserVerificationToken;
 import de.terrestris.shoguncore.repository.token.UserVerificationTokenRepository;
 import de.terrestris.shoguncore.service.UserService;
-import java.util.Calendar;
-import java.util.Date;
+
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.extern.log4j.Log4j2;
@@ -31,11 +32,8 @@ public class UserTask {
         try {
             log.trace("Collecting all pending user registrations to delete.");
 
-            final Calendar cal = Calendar.getInstance();
-            Date date = cal.getTime();
-
             List<UserVerificationToken> userVerificationTokens =
-                userVerificationTokenRepository.findByExpiryDateBefore(date);
+                userVerificationTokenRepository.findByExpiryDateBefore(OffsetDateTime.now());
 
             userVerificationTokens = userVerificationTokens.stream()
                 .filter(token -> token.getClass().isAssignableFrom(UserVerificationToken.class))

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/config/JacksonConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/config/JacksonConfig.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.ser.OffsetDateTimeSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.ZonedDateTimeSerializer;
 import com.vladmihalcea.hibernate.type.util.ObjectMapperSupplier;
 import de.terrestris.shoguncore.annotation.JsonSuperType;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -18,6 +21,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import javax.annotation.PostConstruct;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 import java.text.SimpleDateFormat;
@@ -48,12 +54,18 @@ public class JacksonConfig implements ObjectMapperSupplier {
     @PostConstruct
     public static void init() {
         if (mapper == null) {
-            mapper = new ObjectMapper().registerModule(jtsModule());
+            mapper = new ObjectMapper();
+
+            mapper.registerModule(jtsModule());
+
+            var javaTimeModule = new JavaTimeModule();
+            mapper.registerModule(javaTimeModule);
+
+            mapper.configure(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false);
 
             mapper.configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false);
             mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-            mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"));
 
             for (var entry : findAnnotatedClasses().entrySet()) {
                 mapper.addMixIn(entry.getKey(), entry.getValue());

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/graphql/scalar/DateTimeScalar.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/graphql/scalar/DateTimeScalar.java
@@ -11,7 +11,7 @@ import graphql.schema.GraphQLScalarType;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
 
-import java.util.Date;
+import java.time.OffsetDateTime;
 
 @Log4j2
 public class DateTimeScalar {
@@ -50,23 +50,23 @@ public class DateTimeScalar {
         if (dataFetcherResult instanceof String) {
             String dateTimeString = (String)dataFetcherResult;
             try {
-                return objectMapper().readValue(dateTimeString, Date.class);
+                return objectMapper().readValue(dateTimeString, OffsetDateTime.class);
             } catch (JsonProcessingException e) {
-                throw new CoercingParseValueException("Unable to parse variable value " + dataFetcherResult + " as DateTime");
+                throw new CoercingParseValueException("Unable to parse variable value " + dataFetcherResult + " as OffsetDateTime");
             }
         }
-        throw new CoercingParseValueException("Unable to parse variable value " + dataFetcherResult + " as DateTime");
+        throw new CoercingParseValueException("Unable to parse variable value " + dataFetcherResult + " as OffsetDateTime");
     }
 
     private static Object parseDateFromAstLiteral(Object dataFetcherResult) {
         if (dataFetcherResult instanceof StringValue) {
             String dateTimeString = ((StringValue) dataFetcherResult).getValue();;
             try {
-                return objectMapper().readValue(dateTimeString, Date.class);
+                return objectMapper().readValue(dateTimeString, OffsetDateTime.class);
             } catch (JsonProcessingException e) {
-                throw new CoercingParseValueException("Unable to parse value " + dataFetcherResult + " as DateTime");
+                throw new CoercingParseValueException("Unable to parse value " + dataFetcherResult + " as OffsetDateTime");
             }
         }
-        throw new CoercingParseLiteralException("Value is not DateTime");
+        throw new CoercingParseLiteralException("Value is not OffsetDateTime");
     }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/model/BaseEntity.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/model/BaseEntity.java
@@ -9,7 +9,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import java.io.Serializable;
-import java.util.Date;
+import java.time.OffsetDateTime;
 
 @Entity
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
@@ -30,14 +30,12 @@ public abstract class BaseEntity implements Serializable {
 
     @CreationTimestamp
     @Column(updatable = false)
-    @Temporal(TemporalType.TIMESTAMP)
     @Getter @Setter
-    private Date created;
+    private OffsetDateTime created;
 
     @UpdateTimestamp
     @Column
-    @Temporal(TemporalType.TIMESTAMP)
     @Getter @Setter
-    private Date modified;
+    private OffsetDateTime modified;
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/model/token/VerificationToken.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/model/token/VerificationToken.java
@@ -1,12 +1,11 @@
 package de.terrestris.shoguncore.model.token;
 
 import de.terrestris.shoguncore.model.BaseEntity;
-import java.util.Calendar;
-import java.util.Date;
+
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -27,8 +26,7 @@ public abstract class VerificationToken extends BaseEntity {
     private String token;
 
     @Column(nullable = false)
-    @Temporal(TemporalType.TIMESTAMP)
-    private Date expiryDate;
+    private OffsetDateTime expiryDate;
 
     public VerificationToken(final String token) {
         super();
@@ -44,11 +42,7 @@ public abstract class VerificationToken extends BaseEntity {
         this.expiryDate = calculateExpiryDate(expiration);
     }
 
-    private Date calculateExpiryDate(int expiryTimeInMinutes) {
-        Calendar cal = Calendar.getInstance();
-        cal.setTimeInMillis(new Date().getTime());
-        cal.add(Calendar.MINUTE, expiryTimeInMinutes);
-
-        return new Date(cal.getTime().getTime());
+    private OffsetDateTime calculateExpiryDate(int expiryTimeInMinutes) {
+        return OffsetDateTime.now().plus(expiryTimeInMinutes, ChronoUnit.MINUTES);
     }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/repository/token/UserVerificationTokenRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/repository/token/UserVerificationTokenRepository.java
@@ -3,7 +3,8 @@ package de.terrestris.shoguncore.repository.token;
 import de.terrestris.shoguncore.model.User;
 import de.terrestris.shoguncore.model.token.UserVerificationToken;
 import de.terrestris.shoguncore.repository.BaseCrudRepository;
-import java.util.Date;
+
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -16,6 +17,6 @@ public interface UserVerificationTokenRepository extends BaseCrudRepository<User
 
     List<UserVerificationToken> findAllByUser(User user);
 
-    List<UserVerificationToken> findByExpiryDateBefore(Date date);
+    List<UserVerificationToken> findByExpiryDateBefore(OffsetDateTime date);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shoguncore/service/UserService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shoguncore/service/UserService.java
@@ -21,7 +21,7 @@ import de.terrestris.shoguncore.service.security.permission.UserInstancePermissi
 import de.terrestris.shoguncore.specification.UserSpecification;
 import de.terrestris.shoguncore.specification.token.UserVerificationTokenSpecification;
 
-import java.util.Calendar;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -270,11 +270,7 @@ public class UserService extends BaseService<UserRepository, User> {
         }
 
         final User user = verificationToken.getUser();
-        final Calendar cal = Calendar.getInstance();
-        if ((verificationToken.getExpiryDate()
-            .getTime()
-            - cal.getTime()
-            .getTime()) <= 0) {
+        if (verificationToken.getExpiryDate().isBefore(OffsetDateTime.now())) {
             userVerificationTokenRepository.delete(verificationToken);
             return TOKEN_EXPIRED;
         }


### PR DESCRIPTION
This MR switches from the old `java.util.Date` to the newish `java.time.OffsetDateTime` for the better time api. See https://www.baeldung.com/migrating-to-java-8-date-time-api for more information.

This is a non intrusive change as neither the values in the database nor the serialized values change. Only the handling of the dates in the backend is much easier.

With this change the `@Temporal` annotation is not needed anymore. See https://www.baeldung.com/hibernate-date-time#mapping-javatime-types