### PR TITLE
History enhancements and graphQL integration

### DIFF
--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/AuditConfig.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/AuditConfig.java
@@ -1,0 +1,23 @@
+package de.terrestris.shogun.boot.config;
+
+import org.hibernate.envers.AuditReader;
+import org.hibernate.envers.AuditReaderFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManagerFactory;
+
+@Configuration
+public class AuditConfig {
+
+    private final EntityManagerFactory entityManagerFactory;
+
+    AuditConfig(EntityManagerFactory entityManagerFactory) {
+        this.entityManagerFactory = entityManagerFactory;
+    }
+
+    @Bean
+    AuditReader auditReader() {
+        return AuditReaderFactory.get(entityManagerFactory.createEntityManager());
+    }
+}

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/config/AuditConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/config/AuditConfig.java
@@ -1,4 +1,4 @@
-package de.terrestris.shogun.boot.config;
+package de.terrestris.shogun.lib.config;
 
 import org.hibernate.envers.AuditReader;
 import org.hibernate.envers.AuditReaderFactory;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/config/JacksonConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/config/JacksonConfig.java
@@ -8,9 +8,6 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.vladmihalcea.hibernate.type.util.ObjectMapperSupplier;
 import de.terrestris.shogun.lib.annotation.JsonSuperType;
-import java.util.HashMap;
-import java.util.Map;
-import javax.annotation.PostConstruct;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.PrecisionModel;
 import org.reflections.Reflections;
@@ -21,6 +18,10 @@ import org.reflections.util.ConfigurationBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
+import java.util.HashMap;
+import java.util.Map;
 
 @Configuration
 public class JacksonConfig implements ObjectMapperSupplier {

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/BaseController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/BaseController.java
@@ -282,7 +282,7 @@ public abstract class BaseController<T extends BaseService<?, S>, S extends Base
             getGenericClassName(), entityId, timeStamp);
 
         try {
-            Optional<S> entity = service.findOneByDate(entityId, timeStamp);
+            Optional<S> entity = service.findOneByTime(entityId, timeStamp);
 
             if (entity.isPresent()) {
                 S persistedEntity = entity.get();

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/BaseController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/BaseController.java
@@ -10,11 +10,13 @@ import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.core.GenericTypeResolver;
 import org.springframework.data.history.Revision;
 import org.springframework.data.history.Revisions;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -256,6 +258,70 @@ public abstract class BaseController<T extends BaseService<?, S>, S extends Base
         } catch (Exception e) {
             LOG.error("Error while requesting entity of type {} with ID {}: \n {}",
                 getGenericClassName(), entityId, e.getMessage());
+            LOG.trace("Full stack trace: ", e);
+
+            throw new ResponseStatusException(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                messageSource.getMessage(
+                    "BaseController.INTERNAL_SERVER_ERROR",
+                    null,
+                    LocaleContextHolder.getLocale()
+                ),
+                e
+            );
+        }
+    }
+
+    @GetMapping({"/{id}/forTime/{timeStamp}"})
+    @ResponseStatus(HttpStatus.OK)
+    public S findOneByTime(
+        @PathVariable("id") Long entityId, @PathVariable("timeStamp")
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime timeStamp
+    ) {
+        LOG.trace("Requested to return entity of type {} with ID {} for date {}",
+            getGenericClassName(), entityId, timeStamp);
+
+        try {
+            Optional<S> entity = service.findOneByDate(entityId, timeStamp);
+
+            if (entity.isPresent()) {
+                S persistedEntity = entity.get();
+
+                LOG.trace("Successfully got entity of type {} with ID {}",
+                    getGenericClassName(), entityId);
+
+                return persistedEntity;
+            } else {
+                LOG.error("Could not find entity of type {} with ID {} for time {}",
+                    getGenericClassName(), entityId, timeStamp);
+
+                throw new ResponseStatusException(
+                    HttpStatus.NOT_FOUND,
+                    messageSource.getMessage(
+                        "BaseController.NOT_FOUND",
+                        null,
+                        LocaleContextHolder.getLocale()
+                    )
+                );
+            }
+        } catch (AccessDeniedException ade) {
+            LOG.warn("Access to entity of type {} with ID {} is denied",
+                getGenericClassName(), entityId);
+
+            throw new ResponseStatusException(
+                HttpStatus.NOT_FOUND,
+                messageSource.getMessage(
+                    "BaseController.NOT_FOUND",
+                    null,
+                    LocaleContextHolder.getLocale()
+                ),
+                ade
+            );
+        } catch (ResponseStatusException rse) {
+            throw rse;
+        } catch (Exception e) {
+            LOG.error("Error while requesting entity of type {} with ID {} for time {}: \n {}",
+                getGenericClassName(), entityId, timeStamp, e.getMessage());
             LOG.trace("Full stack trace: ", e);
 
             throw new ResponseStatusException(

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/GraphQLProvider.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/GraphQLProvider.java
@@ -104,6 +104,7 @@ public class GraphQLProvider {
 
     private void addBaseTypes(List<TypeRuntimeWiring.Builder> typeBuilders, BaseGraphQLDataFetcher dataFetcher) {
         String simpleClassName = dataFetcher.getGenericSimpleClassName();
+        String entityName = Character.toLowerCase(simpleClassName.charAt(0)) + simpleClassName.substring(1);
 
         String queryAllName = String.format("all%s", English.plural(simpleClassName));
         typeBuilders.add(TypeRuntimeWiring.newTypeWiring("Query")
@@ -112,11 +113,25 @@ public class GraphQLProvider {
         log.debug("Added GraphQL query {}", queryAllName);
 
         String queryByIdName = String.format("%sById",
-            Character.toLowerCase(simpleClassName.charAt(0)) + simpleClassName.substring(1));
+            entityName);
         typeBuilders.add(TypeRuntimeWiring.newTypeWiring("Query")
             .dataFetcher(queryByIdName, dataFetcher.findOne()));
 
         log.debug("Added GraphQL query {}", queryByIdName);
+
+        String queryByRevisionName = String.format("%sByIdAndRevision",
+            entityName);
+        typeBuilders.add(TypeRuntimeWiring.newTypeWiring("Query")
+            .dataFetcher(queryByRevisionName, dataFetcher.findOneRevision()));
+
+        log.debug("Added GraphQL query {}", queryByRevisionName);
+
+        String queryByTimeName = String.format("%sByIdAndTime",
+            entityName);
+        typeBuilders.add(TypeRuntimeWiring.newTypeWiring("Query")
+            .dataFetcher(queryByTimeName, dataFetcher.findOneForTime()));
+
+        log.debug("Added GraphQL query {}", queryByTimeName);
 
         String queryAllByIdsName = String.format("all%sByIds", English.plural(simpleClassName));
         typeBuilders.add(TypeRuntimeWiring.newTypeWiring("Query")

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/GraphQLProvider.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/GraphQLProvider.java
@@ -2,6 +2,7 @@ package de.terrestris.shogun.lib.graphql;
 
 import com.google.common.io.Resources;
 import de.terrestris.shogun.lib.annotation.GraphQLQuery;
+import de.terrestris.shogun.lib.graphql.resolver.BaseEntityTypeResolver;
 import de.terrestris.shogun.lib.graphql.resolver.BaseGraphQLDataFetcher;
 import de.terrestris.shogun.lib.graphql.scalar.DateTimeScalar;
 import de.terrestris.shogun.lib.graphql.scalar.GeometryScalar;
@@ -109,52 +110,46 @@ public class GraphQLProvider {
         String queryAllName = String.format("all%s", English.plural(simpleClassName));
         typeBuilders.add(TypeRuntimeWiring.newTypeWiring("Query")
             .dataFetcher(queryAllName, dataFetcher.findAll()));
-
         log.debug("Added GraphQL query {}", queryAllName);
 
-        String queryByIdName = String.format("%sById",
-            entityName);
+        String queryRevisionsName = String.format("%sRevisionsById", entityName);
+        typeBuilders.add(TypeRuntimeWiring.newTypeWiring("Query")
+            .dataFetcher(queryRevisionsName, dataFetcher.findRevisions()));
+        log.debug("Added GraphQL query {}", queryRevisionsName);
+
+        String queryByIdName = String.format("%sById", entityName);
         typeBuilders.add(TypeRuntimeWiring.newTypeWiring("Query")
             .dataFetcher(queryByIdName, dataFetcher.findOne()));
-
         log.debug("Added GraphQL query {}", queryByIdName);
 
-        String queryByRevisionName = String.format("%sByIdAndRevision",
-            entityName);
+        String queryByRevisionName = String.format("%sByIdAndRevision", entityName);
         typeBuilders.add(TypeRuntimeWiring.newTypeWiring("Query")
-            .dataFetcher(queryByRevisionName, dataFetcher.findOneRevision()));
-
+            .dataFetcher(queryByRevisionName, dataFetcher.findRevision()));
         log.debug("Added GraphQL query {}", queryByRevisionName);
 
-        String queryByTimeName = String.format("%sByIdAndTime",
-            entityName);
+        String queryByTimeName = String.format("%sByIdAndTime", entityName);
         typeBuilders.add(TypeRuntimeWiring.newTypeWiring("Query")
             .dataFetcher(queryByTimeName, dataFetcher.findOneForTime()));
-
         log.debug("Added GraphQL query {}", queryByTimeName);
 
         String queryAllByIdsName = String.format("all%sByIds", English.plural(simpleClassName));
         typeBuilders.add(TypeRuntimeWiring.newTypeWiring("Query")
             .dataFetcher(queryAllByIdsName, dataFetcher.findAllByIds()));
-
         log.debug("Added GraphQL query {}", queryAllByIdsName);
 
         String createName = String.format("create%s", simpleClassName);
         typeBuilders.add(TypeRuntimeWiring.newTypeWiring("Mutation")
             .dataFetcher(createName, dataFetcher.create()));
-
         log.debug("Added GraphQL mutation {}", createName);
 
         String updateName = String.format("update%s", simpleClassName);
         typeBuilders.add(TypeRuntimeWiring.newTypeWiring("Mutation")
             .dataFetcher(updateName, dataFetcher.update()));
-
         log.debug("Added GraphQL mutation {}", updateName);
 
         String deleteName = String.format("delete%s", simpleClassName);
         typeBuilders.add(TypeRuntimeWiring.newTypeWiring("Mutation")
             .dataFetcher(deleteName, dataFetcher.delete()));
-
         log.debug("Added GraphQL mutation {}", deleteName);
     }
 
@@ -187,6 +182,8 @@ public class GraphQLProvider {
         for (TypeRuntimeWiring.Builder type : types) {
             runtimeWiring = runtimeWiring.type(type);
         }
+        // TODO: can this be automated?
+        runtimeWiring.type("BaseEntity", typeWiring -> typeWiring.typeResolver(new BaseEntityTypeResolver()));
         return runtimeWiring.build();
     }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/GraphQLProvider.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/GraphQLProvider.java
@@ -166,11 +166,11 @@ public class GraphQLProvider {
         RuntimeWiring.Builder runtimeWiring = RuntimeWiring.newRuntimeWiring();
         List<GraphQLScalarType> scalars = this.gatherScalars();
         List<TypeRuntimeWiring.Builder> types = gatherTypes();
-        for (int i = 0; i < scalars.size(); i++) {
-            runtimeWiring = runtimeWiring.scalar(scalars.get(i));
+        for (GraphQLScalarType scalar : scalars) {
+            runtimeWiring = runtimeWiring.scalar(scalar);
         }
-        for (int i = 0; i < types.size(); i++) {
-            runtimeWiring = runtimeWiring.type(types.get(i));
+        for (TypeRuntimeWiring.Builder type : types) {
+            runtimeWiring = runtimeWiring.type(type);
         }
         return runtimeWiring.build();
     }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/resolver/BaseEntityTypeResolver.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/resolver/BaseEntityTypeResolver.java
@@ -1,6 +1,5 @@
 package de.terrestris.shogun.lib.graphql.resolver;
 
-import de.terrestris.shogun.lib.model.*;
 import graphql.TypeResolutionEnvironment;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.TypeResolver;
@@ -12,22 +11,8 @@ public class BaseEntityTypeResolver implements TypeResolver {
     @Override
     public GraphQLObjectType getType(TypeResolutionEnvironment env) {
         Object javaObject = env.getObject();
-        if (javaObject instanceof Application) {
-            return env.getSchema().getObjectType("Application");
-        } else if (javaObject instanceof User) {
-            return env.getSchema().getObjectType("User");
-        } else if (javaObject instanceof ImageFile) {
-            return env.getSchema().getObjectType("ImageFile");
-        } else if (javaObject instanceof File) {
-            return env.getSchema().getObjectType("File");
-        } else if (javaObject instanceof Group) {
-            return env.getSchema().getObjectType("Group");
-        } else if (javaObject instanceof Layer) {
-            return env.getSchema().getObjectType("Layer");
-        } else {
-            log.warn("Getting object type from class name {}", javaObject.getClass().getSimpleName());
-            return env.getSchema().getObjectType(javaObject.getClass().getSimpleName());
-        }
+        log.trace("Getting object type from class name {}", javaObject.getClass().getSimpleName());
+        return env.getSchema().getObjectType(javaObject.getClass().getSimpleName());
     }
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/resolver/BaseEntityTypeResolver.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/resolver/BaseEntityTypeResolver.java
@@ -1,0 +1,33 @@
+package de.terrestris.shogun.lib.graphql.resolver;
+
+import de.terrestris.shogun.lib.model.*;
+import graphql.TypeResolutionEnvironment;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.TypeResolver;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+public class BaseEntityTypeResolver implements TypeResolver {
+
+    @Override
+    public GraphQLObjectType getType(TypeResolutionEnvironment env) {
+        Object javaObject = env.getObject();
+        if (javaObject instanceof Application) {
+            return env.getSchema().getObjectType("Application");
+        } else if (javaObject instanceof User) {
+            return env.getSchema().getObjectType("User");
+        } else if (javaObject instanceof ImageFile) {
+            return env.getSchema().getObjectType("ImageFile");
+        } else if (javaObject instanceof File) {
+            return env.getSchema().getObjectType("File");
+        } else if (javaObject instanceof Group) {
+            return env.getSchema().getObjectType("Group");
+        } else if (javaObject instanceof Layer) {
+            return env.getSchema().getObjectType("Layer");
+        } else {
+            log.warn("Getting object type from class name {}", javaObject.getClass().getSimpleName());
+            return env.getSchema().getObjectType(javaObject.getClass().getSimpleName());
+        }
+    }
+
+}

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/resolver/BaseGraphQLDataFetcher.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/resolver/BaseGraphQLDataFetcher.java
@@ -55,7 +55,7 @@ public abstract class BaseGraphQLDataFetcher<E extends BaseEntity, S extends Bas
             Integer entityId = dataFetchingEnvironment.getArgument("id");
             OffsetDateTime time = dataFetchingEnvironment.getArgument("time");
 
-            Optional<E> persistedEntity = this.service.findOneByDate(entityId.longValue(), time);
+            Optional<E> persistedEntity = this.service.findOneByTime(entityId.longValue(), time);
 
             if (persistedEntity.isEmpty()) {
                 throw new EntityNotAvailableException(String.format("Entity with ID %s is not " +

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/resolver/BaseGraphQLDataFetcher.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/resolver/BaseGraphQLDataFetcher.java
@@ -31,7 +31,7 @@ public abstract class BaseGraphQLDataFetcher<E extends BaseEntity, S extends Bas
     @Autowired
     protected S service;
 
-    public DataFetcher<List<? extends BaseEntity>> findAll() {
+    public DataFetcher<List<E>> findAll() {
         return dataFetchingEnvironment -> this.service.findAll();
     }
 
@@ -66,7 +66,7 @@ public abstract class BaseGraphQLDataFetcher<E extends BaseEntity, S extends Bas
         };
     }
 
-    public DataFetcher<Revisions<Integer, ? extends BaseEntity>> findRevisions() {
+    public DataFetcher<Revisions<Integer, E>> findRevisions() {
         return dataFetchingEnvironment -> {
             Integer entityId = dataFetchingEnvironment.getArgument("id");
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/scalar/DateTimeScalar.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/scalar/DateTimeScalar.java
@@ -1,6 +1,5 @@
 package de.terrestris.shogun.lib.graphql.scalar;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import graphql.language.StringValue;
 import graphql.schema.Coercing;
@@ -9,9 +8,11 @@ import graphql.schema.CoercingParseValueException;
 import graphql.schema.GraphQLScalarType;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
-import java.time.OffsetDateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
 
 @Log4j2
 @Component
@@ -39,10 +40,10 @@ public class DateTimeScalar extends GraphQLScalarType {
             @Override
             public Object parseValue(Object dataFetcherResult) {
                 if (dataFetcherResult instanceof String) {
-                    String dateTimeString = (String)dataFetcherResult;
+                    String dateTimeString = (String) dataFetcherResult;
                     try {
-                        return om.readValue(dateTimeString, OffsetDateTime.class);
-                    } catch (JsonProcessingException e) {
+                        return OffsetDateTime.parse(dateTimeString);
+                    } catch (DateTimeParseException e) {
                         throw new CoercingParseValueException("Unable to parse variable value " + dataFetcherResult + " as OffsetDateTime");
                     }
                 }
@@ -55,8 +56,8 @@ public class DateTimeScalar extends GraphQLScalarType {
                 if (dataFetcherResult instanceof StringValue) {
                     String dateTimeString = ((StringValue) dataFetcherResult).getValue();;
                     try {
-                        return om.readValue(dateTimeString, OffsetDateTime.class);
-                    } catch (JsonProcessingException e) {
+                        return OffsetDateTime.parse(dateTimeString);
+                    } catch (DateTimeParseException e) {
                         throw new CoercingParseValueException("Unable to parse value " + dataFetcherResult + " as OffsetDateTime");
                     }
                 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/BaseService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/BaseService.java
@@ -148,7 +148,7 @@ public abstract class BaseService<T extends BaseCrudRepository<S, Long> & JpaSpe
      */
     @PostAuthorize("hasRole('ROLE_ADMIN') or hasPermission(returnObject.orElse(null), 'READ')")
     @Transactional(readOnly = true)
-    public Optional<S> findOneByDate(
+    public Optional<S> findOneByTime(
         Long id,
         OffsetDateTime time
     ) {

--- a/shogun-lib/src/main/resources/graphql/shogun.graphqls
+++ b/shogun-lib/src/main/resources/graphql/shogun.graphqls
@@ -5,26 +5,44 @@ scalar DateTime
 type Query {
     allApplications: [Application]
     applicationById(id: Int): Application
+    applicationByIdAndTime(id: Int, time: DateTime): Application
+    applicationByIdAndRevision(id: Int, rev: Int): Revision
+    applicationRevisionsById(id: Int): Revisions
     allApplicationsByIds(ids: [Int]): [Application]
 
     allFiles: [File]
     fileById(id: Int): File
+    fileByIdAndTime(id: Int, time: DateTime): File
+    fileByIdAndRevision(id: Int, rev: Int): Revision
+    fileRevisionsById(id: Int): Revisions
     allFilesByIds(ids: [Int]): [File]
 
     allGroups: [Group]
     groupById(id: Int): Group
+    groupByIdAndTime(id: Int, time: DateTime): Group
+    groupByIdAndRevision(id: Int, rev: Int): Revision
+    groupRevisionsById(id: Int): Revisions
     allGroupsByIds(ids: [Int]): [Group]
 
     allImageFiles: [ImageFile]
     imageFileById(id: Int): ImageFile
+    imageFileByIdAndTime(id: Int, time: DateTime): ImageFile
+    imageFileByIdAndRevision(id: Int, rev: Int): Revision
+    imageFileRevisionsById(id: Int): Revisions
     allImageFilesByIds(ids: [Int]): [ImageFile]
 
     allLayers: [Layer]
     layerById(id: Int): Layer
+    layerByIdAndTime(id: Int, time: DateTime): Layer
+    layerByIdAndRevision(id: Int, rev: Int): Revision
+    layerRevisionsById(id: Int): Revisions
     allLayersByIds(ids: [Int]): [Layer]
 
     allUsers: [User]
     userById(id: Int): User
+    userByIdAndTime(id: Int, time: DateTime): User
+    userByIdAndRevision(id: Int, rev: Int): Revision
+    userRevisionsById(id: Int): Revisions
     allUsersByIds(ids: [Int]): [User]
 }
 
@@ -46,7 +64,43 @@ type Mutation {
     deleteUser(id: Int): Boolean
 }
 
-type Application {
+interface BaseEntity {
+  id: Int
+  created: DateTime
+  modified: DateTime
+}
+
+type Revisions {
+    content: [Revision]
+}
+
+type Revision {
+    metadata: RevisionMetadata
+    entity: BaseEntity
+}
+
+type RevisionMetadata {
+    revisionType: String
+    delegate: RevisionDelegate
+    revisionNumber: RevisionFieldInfo
+    revisionDate: RevisionFieldInfo
+    revisionInstant: RevisionFieldInfo
+    requiredRevisionNumber: Int
+    requiredRevisionInstant: DateTime
+}
+
+type RevisionDelegate {
+    id: Int
+    timestamp: Long
+    revisionDate: DateTime
+}
+
+type RevisionFieldInfo {
+    empty: Boolean
+    present: Boolean
+}
+
+type Application implements BaseEntity {
     id: Int
     created: DateTime
     modified: DateTime
@@ -69,7 +123,7 @@ input MutateApplication {
     toolConfig: JSON
 }
 
-type File {
+type File implements BaseEntity {
     id: Int
     created: DateTime
     modified: DateTime
@@ -87,7 +141,7 @@ type GroupRepresentation {
     subGroups: [GroupRepresentation]
 }
 
-type Group {
+type Group implements BaseEntity {
     id: Int
     created: DateTime
     modified: DateTime
@@ -99,7 +153,7 @@ input MutateGroup {
     keycloakId: ID
 }
 
-type ImageFile {
+type ImageFile implements BaseEntity {
     id: Int
     created: DateTime
     modified: DateTime
@@ -111,7 +165,7 @@ type ImageFile {
     height: Int
 }
 
-type Layer {
+type Layer implements BaseEntity {
     id: Int
     created: DateTime
     modified: DateTime
@@ -141,7 +195,7 @@ type UserRepresentation {
     groups: [String]
 }
 
-type User {
+type User implements BaseEntity {
     id: Int
     created: DateTime
     modified: DateTime

--- a/shogun-lib/src/main/resources/graphql/shogun.graphqls
+++ b/shogun-lib/src/main/resources/graphql/shogun.graphqls
@@ -77,6 +77,10 @@ type Revisions {
 type Revision {
     metadata: RevisionMetadata
     entity: BaseEntity
+    revisionNumber: RevisionFieldInfo
+    revisionInstant: RevisionFieldInfo
+    requiredRevisionNumber: Int
+    requiredRevisionInstant: DateTime
 }
 
 type RevisionMetadata {


### PR DESCRIPTION
### Features:

Introduces several improvements to auditing queries available in shogun:

- adds `findOneByTime` service method & controller which returns the entity revision for a specific time
   - if no revision at that time exists it will provide the next oldest revision
- GraphQL: adds methods provided through spring-data-envers (e.g. findRevisions, findRevision) and findOneByTime to GraphQL 
- introduces `BaseEntity` graphql interface and adds envers types

To use `findRevisions` via graphql any custom entity schemas now have to implement `BaseEntity`, e.g.:

```graphql
type MyCustomEntity implements BaseEntity {
    id: Int
    created: DateTime
    modified: DateTime
    [...]
}
```

### Bugfixes:

- fixes OffsetDateTime parsing in graphQL queries

### Examples:

userByIdAndTime graphql query:

```graphql
query {
  userByIdAndTime(id: 16284, time: "2021-02-20T15:54:25.236Z") {
    id
    created
    keycloakId
    details
  }
}
```

userRevisionsById graphql query:

-  requires inline fragments (https://graphql.org/learn/queries/#inline-fragments) to get properties of `User` that are not already in `BaseEntity`

```graphql
query {
  userRevisionsById(id: 16284) {
    content {
      entity {
        created
        id
      	... on User {
          keycloakId
        }
      }
      metadata {
        revisionType
        requiredRevisionNumber
        requiredRevisionInstant
      }
    }
  }
}
```

@terrestris/devs Please review
