### PR TITLE
Introduce getGroupsForUser() returning groups of user in SecurityContext 

### DIFF
--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/service/ApplicationInfoService.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/service/ApplicationInfoService.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +24,7 @@ public class ApplicationInfoService {
     protected final Logger LOG = LogManager.getLogger(getClass());
 
     @Autowired
-    private SecurityContextUtil securityContextUtil;
+    protected SecurityContextUtil securityContextUtil;
 
     /**
      * Returns general application information such as the version.
@@ -61,7 +60,7 @@ public class ApplicationInfoService {
                 applicationInfo.setAuthorities(simpleAuthList);
             }
         } else {
-            List<String> grantedAuthorities = new ArrayList();
+            List<String> grantedAuthorities = new ArrayList<>();
             grantedAuthorities.add("ROLE_ANONYMOUS");
 
             applicationInfo.setAuthorities(grantedAuthorities);


### PR DESCRIPTION
This PR introduces a new method `getGroupsForUser()` to the `SecurityContextUtil` that returns the groups of the user that is actually logged in. In contrast to the existing one, it uses the `otherClaims` map of the `IdToken` / `AccessToken` in `KeycloakPrincipal` (Keycloak plugin https://github.com/terrestris/keycloak-oidc-group-uuid-mapper required and activated for the client in specific realm).
As fallback, the already existing method for the user if claims are not provided.

Plz review @terrestris/devs 