### PR TITLE
Readd mockito in version 3.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
     <!-- Testing -->
     <testcontainers.version>1.15.2</testcontainers.version>
     <junit.jupiter.version>5.7.1</junit.jupiter.version>
+    <mockito.version>3.8.0</mockito.version>
   </properties>
 
   <build>
@@ -484,6 +485,12 @@
         <groupId>org.springframework</groupId>
         <artifactId>spring-test</artifactId>
         <version>${spring-framework.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Follow up of #307 as the provided version by spring-boot-dependencies (3.3.x) misses the class for mocking static methods.

Please review @terrestris/devs.