### PR TITLE
Allows saving of files to filesystem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
 
     <!-- Utils -->
     <commons.io.version>2.8.0</commons.io.version>
+    <tika.core.version>1.26</tika.core.version>
     <reflections.version>0.9.12</reflections.version>
     <evo-inflector.version>1.2.2</evo-inflector.version>
 
@@ -417,6 +418,13 @@
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>${commons.io.version}</version>
+      </dependency>
+
+      <!-- Apache Tika -->
+      <dependency>
+        <groupId>org.apache.tika</groupId>
+        <artifactId>tika-core</artifactId>
+        <version>${tika.core.version}</version>
       </dependency>
 
       <!-- Jackson -->

--- a/shogun-boot/src/main/resources/db/migration/V0.8.0__FilePath.sql
+++ b/shogun-boot/src/main/resources/db/migration/V0.8.0__FilePath.sql
@@ -1,0 +1,2 @@
+ALTER TABLE shogun.files ADD COLUMN IF NOT EXISTS path text;
+ALTER TABLE shogun.imagefiles ADD COLUMN IF NOT EXISTS path text;

--- a/shogun-config/src/main/java/de/terrestris/shogun/properties/UploadProperties.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/properties/UploadProperties.java
@@ -20,7 +20,6 @@ import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.stereotype.Component;
 
 @Data
 @Configuration
@@ -32,5 +31,9 @@ public class UploadProperties {
 
     @NestedConfigurationProperty
     private ImageFileUploadProperties image;
+
+    private String path;
+
+    private String maxSize;
 
 }

--- a/shogun-config/src/main/java/de/terrestris/shogun/properties/UploadProperties.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/properties/UploadProperties.java
@@ -32,7 +32,7 @@ public class UploadProperties {
     @NestedConfigurationProperty
     private ImageFileUploadProperties image;
 
-    private String path;
+    private String basePath;
 
     private String maxSize;
 

--- a/shogun-config/src/main/resources/application-base.yml
+++ b/shogun-config/src/main/resources/application-base.yml
@@ -134,3 +134,5 @@ upload:
       - image/png
       - image/svg+xml
       - image/tiff
+  path: /data
+  maxSize: 500M

--- a/shogun-config/src/main/resources/application-base.yml
+++ b/shogun-config/src/main/resources/application-base.yml
@@ -134,5 +134,5 @@ upload:
       - image/png
       - image/svg+xml
       - image/tiff
-  path: /data
+  basePath: /data
   maxSize: 500M

--- a/shogun-lib/pom.xml
+++ b/shogun-lib/pom.xml
@@ -241,6 +241,12 @@
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-core</artifactId>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/BaseFileController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/BaseFileController.java
@@ -123,6 +123,8 @@ public abstract class BaseFileController<T extends BaseFileService<?, S>, S exte
                     LOG.trace("… load file from disk");
                     byte[] fileByteArray = FileUtils.readFileToByteArray(dataFile);
                     return new ResponseEntity<>(fileByteArray, responseHeaders, HttpStatus.OK);
+                } else {
+                    LOG.error("Could not load File {} from disk", file.getId());
                 }
             }
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/BaseFileController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/BaseFileController.java
@@ -18,8 +18,6 @@ package de.terrestris.shogun.lib.controller;
 
 import de.terrestris.shogun.lib.model.File;
 import de.terrestris.shogun.lib.service.BaseFileService;
-import de.terrestris.shogun.lib.util.FileUtil;
-import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,7 +39,7 @@ public abstract class BaseFileController<T extends BaseFileService<?, S>, S exte
 
     protected final Logger LOG = LogManager.getLogger(getClass());
 
-    @Value("${upload.path}")
+    @Value("${upload.basePath}")
     protected String uploadBasePath;
 
     @Autowired

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/BaseFileController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/BaseFileController.java
@@ -107,21 +107,10 @@ public abstract class BaseFileController<T extends BaseFileService<?, S>, S exte
                 responseHeaders.setContentType(MediaType.parseMediaType(file.getFileType()));
                 responseHeaders.setContentDisposition(ContentDisposition.parse(
                     String.format("inline; filename=\"%s\"", file.getFileName())));
-
                 LOG.trace("Successfully got file with UUID {}", fileUuid);
-                if (file.getPath() == null) {
-                    LOG.trace("… load file from database");
-                    return new ResponseEntity<>(file.getFile(), responseHeaders, HttpStatus.OK);
-                }
 
-                java.io.File dataFile = new java.io.File(uploadBasePath + "/" + file.getPath());
-                if (dataFile.exists()) {
-                    LOG.trace("… load file from disk");
-                    byte[] fileByteArray = FileUtils.readFileToByteArray(dataFile);
-                    return new ResponseEntity<>(fileByteArray, responseHeaders, HttpStatus.OK);
-                } else {
-                    LOG.error("Could not load File {} from disk", file.getId());
-                }
+                byte[] fileData = service.getFileData(file);
+                return new ResponseEntity<>(fileData, responseHeaders, HttpStatus.OK);
             }
 
             LOG.error("Could not find entity of type {} with UUID {}", getGenericClassName(), fileUuid);

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/BaseFileController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/BaseFileController.java
@@ -212,7 +212,7 @@ public abstract class BaseFileController<T extends BaseFileService<?, S>, S exte
     @PostMapping(value = "/uploadToFileSystem", consumes = "multipart/form-data")
     @ResponseStatus(HttpStatus.CREATED)
     public S addToFileSystem(MultipartFile uploadedFile) {
-        LOG.debug("Requested to upload a multipart-file");
+        LOG.debug("Requested to upload a multipart-file and to save it to the file system");
 
         try {
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/BaseFileController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/BaseFileController.java
@@ -33,13 +33,9 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-
-import static de.terrestris.shogun.lib.util.FileUtil.convertToFile;
 
 public abstract class BaseFileController<T extends BaseFileService<?, S>, S extends File> {
 
@@ -175,7 +171,7 @@ public abstract class BaseFileController<T extends BaseFileService<?, S>, S exte
 
         try {
 
-            service.isValidType(uploadedFile.getContentType());
+            service.isValid(uploadedFile);
 
             S persistedFile = service.create(uploadedFile);
 
@@ -218,7 +214,7 @@ public abstract class BaseFileController<T extends BaseFileService<?, S>, S exte
 
         try {
 
-            service.isValidType(uploadedFile.getContentType());
+            service.isValid(uploadedFile);
 
             S persistedFile = service.create(uploadedFile, true);
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/File.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/File.java
@@ -18,12 +18,8 @@ package de.terrestris.shogun.lib.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.UUID;
-import javax.persistence.Cacheable;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Inheritance;
-import javax.persistence.InheritanceType;
-import javax.persistence.Table;
+import javax.persistence.*;
+
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/File.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/File.java
@@ -68,6 +68,7 @@ public class File extends BaseEntity {
     @Getter @Setter
     private byte[] file;
 
+    @JsonIgnore
     @Column
     @Getter @Setter
     private String path;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/File.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/File.java
@@ -67,4 +67,8 @@ public class File extends BaseEntity {
     @Column(length = Integer.MAX_VALUE)
     @Getter @Setter
     private byte[] file;
+
+    @Column
+    @Getter @Setter
+    private String path;
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/BaseFileService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/BaseFileService.java
@@ -20,6 +20,7 @@ import de.terrestris.shogun.lib.model.File;
 import de.terrestris.shogun.lib.repository.BaseFileRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.security.access.prepost.PostAuthorize;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -27,8 +28,9 @@ import java.util.UUID;
 public abstract class BaseFileService<T extends BaseFileRepository<S, Long> & JpaSpecificationExecutor<S>, S extends File> extends BaseService<T, S> implements IBaseFileService<T, S> {
 
     @PostAuthorize("hasRole('ROLE_ADMIN') or hasPermission(returnObject.orElse(null), 'READ')")
-    public Optional<S> findOne(UUID fileUuid) {
-        return repository.findByFileUuid(fileUuid);
+    public Optional<S> findOne(UUID fileUuid) { return repository.findByFileUuid(fileUuid);
     }
+
+    public abstract S create(MultipartFile uploadFile, Boolean writeToSystem) throws Exception;
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/BaseFileService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/BaseFileService.java
@@ -18,14 +18,30 @@ package de.terrestris.shogun.lib.service;
 
 import de.terrestris.shogun.lib.model.File;
 import de.terrestris.shogun.lib.repository.BaseFileRepository;
+import de.terrestris.shogun.properties.UploadProperties;
+import org.apache.commons.io.FileUtils;
+import org.apache.tika.config.TikaConfig;
+import org.apache.tika.exception.TikaException;
+import org.apache.tika.io.TikaInputStream;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.mime.MediaType;
+import org.apache.tomcat.util.http.fileupload.impl.InvalidContentTypeException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.security.access.prepost.PostAuthorize;
+import org.springframework.util.PatternMatchUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public abstract class BaseFileService<T extends BaseFileRepository<S, Long> & JpaSpecificationExecutor<S>, S extends File> extends BaseService<T, S> implements IBaseFileService<T, S> {
+
+    @Autowired
+    private UploadProperties uploadProperties;
 
     @PostAuthorize("hasRole('ROLE_ADMIN') or hasPermission(returnObject.orElse(null), 'READ')")
     public Optional<S> findOne(UUID fileUuid) {
@@ -33,5 +49,35 @@ public abstract class BaseFileService<T extends BaseFileRepository<S, Long> & Jp
     }
 
     public abstract S create(MultipartFile uploadFile, Boolean writeToSystem) throws Exception;
+
+    public void isValid(MultipartFile file) throws Exception {
+        if (file == null) {
+            throw new Exception("Given file is null.");
+        } else if (file.isEmpty()) {
+            throw new Exception("Given file is empty.");
+        }
+        this.isValidType(file.getContentType());
+        this.verifyContentType(file);
+    }
+
+    public void verifyContentType(MultipartFile file) throws IOException, TikaException {
+        String contentType = file.getContentType();
+        String name = file.getName();
+        Metadata metadata = new Metadata();
+        metadata.set(Metadata.RESOURCE_NAME_KEY, name);
+        TikaConfig tika = new TikaConfig();
+        MediaType mediaType = tika.getDetector().detect(TikaInputStream.get(file.getBytes()), metadata);
+        if (!mediaType.toString().equals(contentType)) {
+            throw new IOException("Mediatype validation failed. Passed content type is " + contentType + " but detected mediatype is " + mediaType);
+        }
+    }
+
+    public void isValidType(String contentType) throws InvalidContentTypeException {
+        List<String> supportedContentTypes = getSupportedContentTypes();
+        boolean isMatch = PatternMatchUtils.simpleMatch(supportedContentTypes.toArray(new String[supportedContentTypes.size()]), contentType);
+        if (!isMatch) {
+            throw new InvalidContentTypeException("Unsupported content type for upload!");
+        }
+    }
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/BaseFileService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/BaseFileService.java
@@ -28,7 +28,8 @@ import java.util.UUID;
 public abstract class BaseFileService<T extends BaseFileRepository<S, Long> & JpaSpecificationExecutor<S>, S extends File> extends BaseService<T, S> implements IBaseFileService<T, S> {
 
     @PostAuthorize("hasRole('ROLE_ADMIN') or hasPermission(returnObject.orElse(null), 'READ')")
-    public Optional<S> findOne(UUID fileUuid) { return repository.findByFileUuid(fileUuid);
+    public Optional<S> findOne(UUID fileUuid) {
+        return repository.findByFileUuid(fileUuid);
     }
 
     public abstract S create(MultipartFile uploadFile, Boolean writeToSystem) throws Exception;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/BaseFileService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/BaseFileService.java
@@ -80,4 +80,26 @@ public abstract class BaseFileService<T extends BaseFileRepository<S, Long> & Jp
         }
     }
 
+    /**
+     * Get the file data as bytearray. Depends on storage strategy (DB vs. disk);
+     *
+     * @param file
+     * @return
+     * @throws IOException
+     */
+    public byte[] getFileData(S file) throws IOException {
+        if (file.getPath() == null) {
+            LOG.trace("… load file from database");
+            return file.getFile();
+        }
+        java.io.File dataFile = new java.io.File(uploadProperties.getBasePath() + "/" + file.getPath());
+        if (dataFile.exists()) {
+            LOG.trace("… load file from disk");
+            return FileUtils.readFileToByteArray(dataFile);
+        } else {
+            LOG.error("Could not load File {} from disk", file.getId());
+            throw new FileNotFoundException("Could not load File " + file.getId() + " from disk");
+        }
+    }
+
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/FileService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/FileService.java
@@ -80,11 +80,11 @@ public class FileService extends BaseFileService<FileRepository, File> {
         }
 
         String uploadBasePath = uploadProperties.getPath();
-        if(uploadBasePath == null || uploadBasePath.isEmpty()) {
+        if (StringUtils.isEmpty(uploadBasePath)) {
             throw new Exception("Could not upload file. uploadBasePath is null.");
         }
         String fileName = uploadFile.getOriginalFilename();
-        if(fileName == null || fileName.isEmpty()) {
+        if (StringUtils.isEmpty(fileName)) {
             throw new Exception("Could not upload file. fileName is null.");
         }
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/FileService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/FileService.java
@@ -80,11 +80,11 @@ public class FileService extends BaseFileService<FileRepository, File> {
         }
 
         String uploadBasePath = uploadProperties.getPath();
-        if(uploadBasePath != null) {
+        if(uploadBasePath == null || uploadBasePath.isEmpty()) {
             throw new Exception("Could not upload file. uploadBasePath is null.");
         }
         String fileName = uploadFile.getOriginalFilename();
-        if(fileName != null) {
+        if(fileName == null || fileName.isEmpty()) {
             throw new Exception("Could not upload file. fileName is null.");
         }
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/FileService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/FileService.java
@@ -21,6 +21,7 @@ import de.terrestris.shogun.lib.repository.FileRepository;
 import de.terrestris.shogun.lib.util.FileUtil;
 import de.terrestris.shogun.properties.UploadProperties;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.tomcat.util.http.fileupload.impl.InvalidContentTypeException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -79,7 +80,7 @@ public class FileService extends BaseFileService<FileRepository, File> {
             return this.create(uploadFile);
         }
 
-        String uploadBasePath = uploadProperties.getPath();
+        String uploadBasePath = uploadProperties.getBasePath();
         if (StringUtils.isEmpty(uploadBasePath)) {
             throw new Exception("Could not upload file. uploadBasePath is null.");
         }
@@ -115,6 +116,7 @@ public class FileService extends BaseFileService<FileRepository, File> {
             LOG.error("Error when saving file {} to disk: " + e.getMessage(), savedFile.getId());
             LOG.info("Rollback creation of file {}.", savedFile.getId());
             this.repository.delete(savedFile);
+            fileDirectory.delete();
             throw e;
         }
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/IBaseFileService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/IBaseFileService.java
@@ -19,6 +19,7 @@ package de.terrestris.shogun.lib.service;
 import de.terrestris.shogun.lib.model.File;
 import de.terrestris.shogun.lib.repository.BaseFileRepository;
 import org.apache.tika.exception.TikaException;
+import org.apache.tomcat.util.http.fileupload.InvalidFileNameException;
 import org.apache.tomcat.util.http.fileupload.impl.InvalidContentTypeException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -43,6 +44,14 @@ public interface IBaseFileService<T extends BaseFileRepository<S, Long> & JpaSpe
      * @throws TikaException
      */
     void verifyContentType(MultipartFile file) throws IOException, TikaException;
+
+    /**
+     * Checks if the given filename includes illegal characters.
+     *
+     * @param fileName
+     * @throws InvalidFileNameException
+     */
+    void isValidFileName(String fileName) throws InvalidFileNameException;
 
     /**
      * Checks if the given contentType is included in the content type whitelist configured via UploadProperties.

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/IBaseFileService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/IBaseFileService.java
@@ -18,10 +18,14 @@ package de.terrestris.shogun.lib.service;
 
 import de.terrestris.shogun.lib.model.File;
 import de.terrestris.shogun.lib.repository.BaseFileRepository;
+import org.apache.tika.exception.TikaException;
 import org.apache.tomcat.util.http.fileupload.impl.InvalidContentTypeException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -31,5 +35,36 @@ public interface IBaseFileService<T extends BaseFileRepository<S, Long> & JpaSpe
 
     S create(MultipartFile uploadFile) throws Exception;
 
+    /**
+     * Verifies if the content type of the file matches its content.
+     *
+     * @param file
+     * @throws IOException
+     * @throws TikaException
+     */
+    void verifyContentType(MultipartFile file) throws IOException, TikaException;
+
+    /**
+     * Checks if the given contentType is included in the content type whitelist configured via UploadProperties.
+     *
+     * @param contentType
+     * @throws InvalidContentTypeException
+     */
     void isValidType(String contentType) throws InvalidContentTypeException;
+
+    /**
+     * Checks if the file is not null or empty and has a valid content type.
+     *
+     * @param file
+     * @throws Exception
+     */
+    void isValid(MultipartFile file) throws Exception;
+
+    /**
+     * Get the list of supported content types. Should be implement by real class.
+     *
+     * @return
+     * @throws NoSuchBeanDefinitionException
+     */
+    List<String> getSupportedContentTypes() throws NoSuchBeanDefinitionException;
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/ImageFileService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/ImageFileService.java
@@ -22,6 +22,7 @@ import de.terrestris.shogun.lib.util.FileUtil;
 import de.terrestris.shogun.lib.util.ImageFileUtil;
 import de.terrestris.shogun.properties.UploadProperties;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.tomcat.util.http.fileupload.impl.InvalidContentTypeException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -101,12 +102,12 @@ public class ImageFileService extends BaseFileService<ImageFileRepository, Image
             return this.create(uploadFile);
         }
 
-        String uploadBasePath = uploadProperties.getPath();
-        if(uploadBasePath == null || uploadBasePath.isEmpty()) {
+        String uploadBasePath = uploadProperties.getBasePath();
+        if(StringUtils.isEmpty(uploadBasePath)) {
             throw new Exception("Could not upload file. uploadBasePath is null.");
         }
         String fileName = uploadFile.getOriginalFilename();
-        if(fileName == null || fileName.isEmpty()) {
+        if(StringUtils.isEmpty(fileName)) {
             throw new Exception("Could not upload file. fileName is null.");
         }
 
@@ -147,6 +148,7 @@ public class ImageFileService extends BaseFileService<ImageFileRepository, Image
             LOG.error("Error while saving file {} to disk: {}", e.getMessage(), savedFile.getId());
             LOG.info("Rollback creation of file {}.", savedFile.getId());
             this.repository.delete(savedFile);
+            fileDirectory.delete();
             throw e;
         }
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/ImageFileService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/ImageFileService.java
@@ -102,12 +102,16 @@ public class ImageFileService extends BaseFileService<ImageFileRepository, Image
         }
 
         String uploadBasePath = uploadProperties.getPath();
-        String filename = uploadFile.getOriginalFilename();
+        if(uploadBasePath != null) {
+            throw new Exception("Could not upload file. uploadBasePath is null.");
+        }
+        String fileName = uploadFile.getOriginalFilename();
+        if(fileName != null) {
+            throw new Exception("Could not upload file. fileName is null.");
+        }
 
         FileUtil.validateFile(uploadFile);
-
         byte[] fileByteArray = FileUtil.fileToByteArray(uploadFile);
-
         ImageFile file = new ImageFile();
         file.setFileType(uploadFile.getContentType());
         file.setFileName(uploadFile.getOriginalFilename());
@@ -128,12 +132,12 @@ public class ImageFileService extends BaseFileService<ImageFileRepository, Image
         UUID fileUuid = savedFile.getFileUuid();
 
         // Setup path and directory
-        String path = fileUuid + "/" + filename;
+        String path = fileUuid + "/" + fileName;
         java.io.File fileDirectory = new java.io.File(uploadBasePath + "/" + fileUuid);
         fileDirectory.mkdirs();
 
         // Write multipart file data to target directory
-        java.io.File outFile = new java.io.File(fileDirectory, filename);
+        java.io.File outFile = new java.io.File(fileDirectory, fileName);
         InputStream in = new ByteArrayInputStream(fileByteArray);
 
         try (OutputStream out = new FileOutputStream(outFile)) {
@@ -141,14 +145,13 @@ public class ImageFileService extends BaseFileService<ImageFileRepository, Image
             LOG.info("Saved file with id {} to {}: ", savedFile.getId(), savedFile.getPath());
         } catch (Exception e) {
             LOG.error("Error when saving file {} to disk: " + e.getMessage(), savedFile.getId());
+            LOG.info("Rollback creation of file {}.", savedFile.getId());
+            this.repository.delete(savedFile);
             throw e;
         }
 
         // Update entity with saved File
         savedFile.setPath(path);
-        this.repository.save(savedFile);
-
-
-        return savedFile;
+        return this.repository.save(savedFile);
     }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/ImageFileService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/ImageFileService.java
@@ -142,9 +142,9 @@ public class ImageFileService extends BaseFileService<ImageFileRepository, Image
 
         try (OutputStream out = new FileOutputStream(outFile)) {
             IOUtils.copy(in, out);
-            LOG.info("Saved file with id {} to {}: ", savedFile.getId(), savedFile.getPath());
+            LOG.info("Saved file with id {} to: {}", savedFile.getId(), savedFile.getPath());
         } catch (Exception e) {
-            LOG.error("Error when saving file {} to disk: " + e.getMessage(), savedFile.getId());
+            LOG.error("Error while saving file {} to disk: {}", e.getMessage(), savedFile.getId());
             LOG.info("Rollback creation of file {}.", savedFile.getId());
             this.repository.delete(savedFile);
             throw e;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/ImageFileService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/ImageFileService.java
@@ -79,11 +79,11 @@ public class ImageFileService extends BaseFileService<ImageFileRepository, Image
         }
 
         String uploadBasePath = uploadProperties.getBasePath();
-        if(StringUtils.isEmpty(uploadBasePath)) {
+        if (StringUtils.isEmpty(uploadBasePath)) {
             throw new Exception("Could not upload file. uploadBasePath is null.");
         }
         String fileName = uploadFile.getOriginalFilename();
-        if(StringUtils.isEmpty(fileName)) {
+        if (StringUtils.isEmpty(fileName)) {
             throw new Exception("Could not upload file. fileName is null.");
         }
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/ImageFileService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/ImageFileService.java
@@ -102,11 +102,11 @@ public class ImageFileService extends BaseFileService<ImageFileRepository, Image
         }
 
         String uploadBasePath = uploadProperties.getPath();
-        if(uploadBasePath != null) {
+        if(uploadBasePath == null || uploadBasePath.isEmpty()) {
             throw new Exception("Could not upload file. uploadBasePath is null.");
         }
         String fileName = uploadFile.getOriginalFilename();
-        if(fileName != null) {
+        if(fileName == null || fileName.isEmpty()) {
             throw new Exception("Could not upload file. fileName is null.");
         }
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/FileUtil.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/FileUtil.java
@@ -67,24 +67,4 @@ public class FileUtil {
         return file;
     }
 
-    public static void validateFile(MultipartFile file) throws Exception {
-        if (file == null) {
-            throw new Exception("Given file is null.");
-        } else if (file.isEmpty()) {
-            throw new Exception("Given file is empty.");
-        }
-
-        String name = file.getName();
-        String contentType = file.getContentType();
-        Metadata metadata = new Metadata();
-        metadata.set(Metadata.RESOURCE_NAME_KEY, name);
-        TikaConfig tika = new TikaConfig();
-        MediaType mediaType = tika.getDetector().detect(TikaInputStream.get(file.getBytes()), metadata);
-
-        if (!mediaType.toString().equals(contentType)) {
-            throw new Exception("Mediatype validation failed. Passed content type is " + contentType + " but detected mediatype is " + mediaType);
-        }
-
-    }
-
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/FileUtil.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/FileUtil.java
@@ -19,8 +19,6 @@ package de.terrestris.shogun.lib.util;
 import de.terrestris.shogun.properties.UploadProperties;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.io.IOUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.io.TikaInputStream;
 import org.apache.tika.metadata.Metadata;
@@ -38,8 +36,6 @@ public class FileUtil {
 
     @Autowired
     protected static UploadProperties uploadProperties;
-
-    protected final static Logger LOG = LogManager.getLogger(HttpUtil.class);
 
     public static byte[] fileToByteArray(MultipartFile file) throws Exception {
         byte[] fileByteArray;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/FileUtil.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/FileUtil.java
@@ -16,8 +16,16 @@
  */
 package de.terrestris.shogun.lib.util;
 
+import de.terrestris.shogun.properties.UploadProperties;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.tika.config.TikaConfig;
+import org.apache.tika.io.TikaInputStream;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.mime.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
@@ -27,6 +35,11 @@ import java.io.InputStream;
 
 @Log4j2
 public class FileUtil {
+
+    @Autowired
+    protected static UploadProperties uploadProperties;
+
+    protected final static Logger LOG = LogManager.getLogger(HttpUtil.class);
 
     public static byte[] fileToByteArray(MultipartFile file) throws Exception {
         byte[] fileByteArray;
@@ -64,6 +77,18 @@ public class FileUtil {
         } else if (file.isEmpty()) {
             throw new Exception("Given file is empty.");
         }
+
+        String name = file.getName();
+        String contentType = file.getContentType();
+        Metadata metadata = new Metadata();
+        metadata.set(Metadata.RESOURCE_NAME_KEY, name);
+        TikaConfig tika = new TikaConfig();
+        MediaType mediaType = tika.getDetector().detect(TikaInputStream.get(file.getBytes()), metadata);
+
+        if (!mediaType.toString().equals(contentType)) {
+            throw new Exception("Mediatype validation failed. Passed content type is " + contentType + " but detected mediatype is " + mediaType);
+        }
+
     }
 
 }

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/BaseFileServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/BaseFileServiceTest.java
@@ -53,7 +53,7 @@ public class BaseFileServiceTest {
             fileService.isValidFileName("Mein_Spezial_Bild_mit_Unterstrichen.png");
             fileService.isValidFileName("Mein-Spezial-Bild-mit-Bindestrichen.png");
             fileService.isValidFileName("@klammeraffe#hastag.png");
-            fileService.isValidFileName("@klammeraffe#hastag.png");
+            fileService.isValidFileName("lord-fauntleroy.png");
         } catch(InvalidFileNameException e) {
             fail(failMsg);
         }

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/BaseFileServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/BaseFileServiceTest.java
@@ -1,0 +1,77 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2020-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.terrestris.shogun.lib.service;
+
+import de.terrestris.shogun.properties.FileUploadProperties;
+import de.terrestris.shogun.properties.UploadProperties;
+import org.apache.tomcat.util.http.fileupload.InvalidFileNameException;
+import org.apache.tomcat.util.http.fileupload.impl.InvalidContentTypeException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BaseFileServiceTest {
+
+    @InjectMocks
+    private FileService fileService;
+
+    private String failMsg = "Validation shouldn't have thrown any exception.";
+
+
+    @Test
+    public void isValidFileName_shouldAllowRegularFilenames() {
+        try {
+            fileService.isValidFileName("Peter.pdf");
+            fileService.isValidFileName("Peter.png");
+            fileService.isValidFileName("Mein Spezial Bild mit Leerzeichen.png");
+            fileService.isValidFileName("Mein_Spezial_Bild_mit_Unterstrichen.png");
+            fileService.isValidFileName("Mein-Spezial-Bild-mit-Bindestrichen.png");
+            fileService.isValidFileName("@klammeraffe#hastag.png");
+            fileService.isValidFileName("@klammeraffe#hastag.png");
+        } catch(InvalidFileNameException e) {
+            fail(failMsg);
+        }
+    }
+
+    @Test
+    public void isValidFileName_throwsIfFileNameIsIllegal() {
+        assertThrows(InvalidFileNameException.class, () -> fileService.isValidFileName("Peter\\.pdf"));
+        assertThrows(InvalidFileNameException.class, () -> fileService.isValidFileName("Peter/.pdf"));
+        assertThrows(InvalidFileNameException.class, () -> fileService.isValidFileName("Peter:.pdf"));
+        assertThrows(InvalidFileNameException.class, () -> fileService.isValidFileName("Peter*.pdf"));
+        assertThrows(InvalidFileNameException.class, () -> fileService.isValidFileName("Peter?.pdf"));
+        assertThrows(InvalidFileNameException.class, () -> fileService.isValidFileName("Peter\".pdf"));
+        assertThrows(InvalidFileNameException.class, () -> fileService.isValidFileName("Peter<.pdf"));
+        assertThrows(InvalidFileNameException.class, () -> fileService.isValidFileName("Peter>.pdf"));
+        assertThrows(InvalidFileNameException.class, () -> fileService.isValidFileName("Peter|.pdf"));
+        assertThrows(InvalidFileNameException.class, () -> fileService.isValidFileName("Peter\\0.pdf"));
+        assertThrows(InvalidFileNameException.class, () -> fileService.isValidFileName("Peter\\n.pdf"));
+    }
+
+}

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/FileServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/FileServiceTest.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -55,7 +56,7 @@ public class FileServiceTest {
     public void isValidType_failsIfNoConfigIsGiven() {
         // initializeConfig hasn't been called.
         File mockFile = new File("/");
-        assertThrows(InvalidContentTypeException.class, () -> fileService.isValidType("application/zip"));
+        assertThrows(NoSuchBeanDefinitionException.class, () -> fileService.isValidType("application/zip"));
     }
 
     @Test

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/FileServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/FileServiceTest.java
@@ -25,6 +25,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -53,6 +54,7 @@ public class FileServiceTest {
     @Test
     public void isValidType_failsIfNoConfigIsGiven() {
         // initializeConfig hasn't been called.
+        File mockFile = new File("/");
         assertThrows(InvalidContentTypeException.class, () -> fileService.isValidType("application/zip"));
     }
 

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/ImageFileServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/ImageFileServiceTest.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,7 +54,7 @@ public class ImageFileServiceTest {
     @Test
     public void isValidType_failsIfNoConfigIsGiven() {
         // initializeConfig hasn't been called.
-        assertThrows(InvalidContentTypeException.class, () -> imageFileService.isValidType("image/png"));
+        assertThrows(NoSuchBeanDefinitionException.class, () -> imageFileService.isValidType("image/png"));
     }
 
     @Test


### PR DESCRIPTION
This introduces interfaces and methods to upload files to the filesystem instead of adding them as bytearray to the DB.

- Includes a migration to add the `path` property to the `File` entity.
- Includes config options to the `UploadProperties`
  - `path` --> The basePath of the upload directory
  - `maxSize` --> The maximum size of upload (currently not used)

## BREAKING CHANGE:

- Removes `validateFile` from the `FileUtil` and moved validation to the `BaseFileService`
