### PR TITLE
Store imageFile thumbnails as PNG

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/ImageFileController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/ImageFileController.java
@@ -18,22 +18,15 @@ package de.terrestris.shogun.lib.controller;
 
 import de.terrestris.shogun.lib.model.ImageFile;
 import de.terrestris.shogun.lib.service.ImageFileService;
-import java.util.Optional;
-import java.util.UUID;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.i18n.LocaleContextHolder;
-import org.springframework.http.ContentDisposition;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.security.access.AccessDeniedException;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Optional;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/imagefiles")
@@ -55,9 +48,10 @@ public class ImageFileController extends BaseFileController<ImageFileService, Im
                 LOG.info("Successfully got thumbnail for image file with UUID {}", fileUuid);
 
                 final HttpHeaders responseHeaders = new HttpHeaders();
-                responseHeaders.setContentType(MediaType.parseMediaType(file.getFileType()));
+                responseHeaders.setContentType(MediaType.IMAGE_PNG);
+                String thumbnailFileName = file.getFileName().split("\\.")[0] + ".png";
                 responseHeaders.setContentDisposition(ContentDisposition.parse(
-                    String.format("inline; filename=\"%s\"", file.getFileName())));
+                    String.format("inline; filename=\"%s\"", thumbnailFileName)));
 
                 return new ResponseEntity<>(file.getThumbnail(), responseHeaders, HttpStatus.OK);
             } else {

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/File.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/File.java
@@ -17,18 +17,13 @@
 package de.terrestris.shogun.lib.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import java.util.UUID;
-import javax.persistence.*;
-
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Type;
+
+import javax.persistence.*;
+import java.util.UUID;
 
 @Entity(name = "files")
 @Table(schema = "shogun")

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/BaseFileService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/BaseFileService.java
@@ -76,6 +76,7 @@ public abstract class BaseFileService<T extends BaseFileRepository<S, Long> & Jp
         List<String> supportedContentTypes = getSupportedContentTypes();
         boolean isMatch = PatternMatchUtils.simpleMatch(supportedContentTypes.toArray(new String[supportedContentTypes.size()]), contentType);
         if (!isMatch) {
+            LOG.warn("Unsupported content type {} for upload", contentType);
             throw new InvalidContentTypeException("Unsupported content type for upload!");
         }
     }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/ImageFileService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/ImageFileService.java
@@ -23,20 +23,16 @@ import de.terrestris.shogun.lib.util.ImageFileUtil;
 import de.terrestris.shogun.properties.UploadProperties;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.tika.config.TikaConfig;
-import org.apache.tika.exception.TikaException;
-import org.apache.tika.io.TikaInputStream;
-import org.apache.tika.metadata.Metadata;
-import org.apache.tika.mime.MediaType;
-import org.apache.tomcat.util.http.fileupload.impl.InvalidContentTypeException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.util.PatternMatchUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.awt.*;
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.List;
 import java.util.UUID;
 
@@ -67,9 +63,7 @@ public class ImageFileService extends BaseFileService<ImageFileRepository, Image
                 "nor the thumbnail can be set.");
         }
 
-        ImageFile savedFile = this.create(file);
-
-        return savedFile;
+        return this.create(file);
     }
 
     @Override

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/ImageFileUtil.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/ImageFileUtil.java
@@ -17,7 +17,6 @@
 package de.terrestris.shogun.lib.util;
 
 import lombok.extern.log4j.Log4j2;
-import org.apache.commons.io.FilenameUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.imageio.ImageIO;
@@ -74,7 +73,7 @@ public class ImageFileUtil {
 
         BufferedImage img = ImageFileUtil.toBufferedImage(scaledImgFile);
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        ImageIO.write(img, FilenameUtils.getExtension(uploadFile.getOriginalFilename()), bos);
+        ImageIO.write(img, "png", bos);
 
         return bos.toByteArray();
     }


### PR DESCRIPTION
- always saves thumbnail as PNG. This prevents encoding issues when writing JPEG files
- minor imageFile fixes (logging, imports etc.)

@terrestris/devs Please review