### PR TITLE
Init license checker workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
 
+    - name: Check License Header
+      uses: apache/skywalking-eyes@v0.1.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Test SHOGun with Maven
       run: mvn -B test

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -20,8 +20,6 @@ header:
       limitations under the License.
 
   paths-ignore:
-    - '**/*.md'
-    - '**/*.sql'
     - '.github'
     - '.editorconfig'
     - '.gitignore'
@@ -37,5 +35,8 @@ header:
     - 'shogun-gs-interceptor/target'
     - 'shogun-lib/target'
     - 'shogun-manager/target'
+    - 'docs'
+    - '**/*.md'
+    - '**/*.sql'
 
   comment: on-failure

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,41 @@
+header:
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: terrestris GmbH & Co. KG
+    content: |
+      SHOGun, https://terrestris.github.io/shogun/
+
+      Copyright © 2020-present terrestris GmbH & Co. KG
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0.txt
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+  paths-ignore:
+    - '**/*.md'
+    - '**/*.sql'
+    - '.github'
+    - '.editorconfig'
+    - '.gitignore'
+    - '.licenserc.yaml'
+    - 'LICENSE'
+    - 'shogun-lib/src/main/java/de/terrestris/shogun/lib/envers/DefaultRevisionEntityInformation.java'
+    - 'shogun-lib/src/main/java/de/terrestris/shogun/lib/envers/ShogunAnnotationRevisionMetadata.java'
+    - 'shogun-lib/src/main/java/de/terrestris/shogun/lib/envers/ShogunEnversRevisionRepositoryFactoryBean.java'
+    - 'shogun-lib/src/main/java/de/terrestris/shogun/lib/envers/ShogunRevisionMetadata.java'
+    - 'shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/impl/ShogunRevisionRepositoryImpl.java'
+    - 'shogun-boot/target'
+    - 'shogun-config/target'
+    - 'shogun-gs-interceptor/target'
+    - 'shogun-lib/target'
+    - 'shogun-manager/target'
+
+  comment: on-failure

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SHOGun, https://terrestris.github.io/shogun/
+
+  Copyright © 2020-present terrestris GmbH & Co. KG
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-
+#  SHOGun, https://terrestris.github.io/shogun/
+#
+#  Copyright © 2020-present terrestris GmbH & Co. KG
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 # stop at first command failure
 set -e
 

--- a/scripts/wait.sh
+++ b/scripts/wait.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
-
+#  SHOGun, https://terrestris.github.io/shogun/
+#
+#  Copyright © 2020-present terrestris GmbH & Co. KG
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 URL="http://localhost:8080/shogun-boot/"
 TIMEOUT=120
 seconds=0

--- a/shogun-boot/pom.xml
+++ b/shogun-boot/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SHOGun, https://terrestris.github.io/shogun/
+
+  Copyright © 2020-present terrestris GmbH & Co. KG
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 

--- a/shogun-boot/src/main/resources/application-boot.yml
+++ b/shogun-boot/src/main/resources/application-boot.yml
@@ -1,3 +1,18 @@
+#  SHOGun, https://terrestris.github.io/shogun/
+#
+#  Copyright © 2020-present terrestris GmbH & Co. KG
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 spring:
   servlet:
     multipart:

--- a/shogun-boot/src/main/resources/public/index.html
+++ b/shogun-boot/src/main/resources/public/index.html
@@ -1,4 +1,21 @@
 <!DOCTYPE html>
+<!--
+  SHOGun, https://terrestris.github.io/shogun/
+
+  Copyright © 2020-present terrestris GmbH & Co. KG
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <html lang="de">
 <head>
     <meta charset="utf-8">

--- a/shogun-boot/src/main/resources/public/websocket.html
+++ b/shogun-boot/src/main/resources/public/websocket.html
@@ -1,4 +1,21 @@
 <!DOCTYPE html>
+<!--
+  SHOGun, https://terrestris.github.io/shogun/
+
+  Copyright © 2020-present terrestris GmbH & Co. KG
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <html>
 <head>
     <title>Hello WebSocket</title>

--- a/shogun-boot/src/main/resources/public/websocket.js
+++ b/shogun-boot/src/main/resources/public/websocket.js
@@ -1,3 +1,19 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2020-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 var stompClient = null;
 
 function setConnected(connected) {

--- a/shogun-boot/src/main/resources/templates/error.html
+++ b/shogun-boot/src/main/resources/templates/error.html
@@ -1,4 +1,21 @@
 <!DOCTYPE html>
+<!--
+  SHOGun, https://terrestris.github.io/shogun/
+
+  Copyright © 2020-present terrestris GmbH & Co. KG
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <html>
 <head>
     <style>

--- a/shogun-boot/src/main/resources/templates/error/404.html
+++ b/shogun-boot/src/main/resources/templates/error/404.html
@@ -1,4 +1,21 @@
 <!DOCTYPE html>
+<!--
+  SHOGun, https://terrestris.github.io/shogun/
+
+  Copyright © 2020-present terrestris GmbH & Co. KG
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <html>
 <head>
     <style>

--- a/shogun-boot/src/main/resources/templates/error/error.css
+++ b/shogun-boot/src/main/resources/templates/error/error.css
@@ -1,3 +1,19 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2020-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 html, body {
   margin: auto;
   width: 100%;

--- a/shogun-boot/src/site/site.xml
+++ b/shogun-boot/src/site/site.xml
@@ -1,1 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SHOGun, https://terrestris.github.io/shogun/
+
+  Copyright © 2020-present terrestris GmbH & Co. KG
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <project name="SHOGun Boot" combine.self="override" />

--- a/shogun-boot/src/test/resources/application-test.yml
+++ b/shogun-boot/src/test/resources/application-test.yml
@@ -1,3 +1,18 @@
+#  SHOGun, https://terrestris.github.io/shogun/
+#
+#  Copyright © 2020-present terrestris GmbH & Co. KG
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 shogun:
   srid: 25832
 

--- a/shogun-boot/src/test/resources/jdbc.properties
+++ b/shogun-boot/src/test/resources/jdbc.properties
@@ -1,3 +1,18 @@
+#  SHOGun, https://terrestris.github.io/shogun/
+#
+#  Copyright © 2020-present terrestris GmbH & Co. KG
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 shogun.model.packages=de.terrestris.shogun.lib.model
 
 hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect

--- a/shogun-config/pom.xml
+++ b/shogun-config/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SHOGun, https://terrestris.github.io/shogun/
+
+  Copyright © 2020-present terrestris GmbH & Co. KG
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 

--- a/shogun-config/src/main/resources/application-base.yml
+++ b/shogun-config/src/main/resources/application-base.yml
@@ -1,3 +1,18 @@
+#  SHOGun, https://terrestris.github.io/shogun/
+#
+#  Copyright © 2020-present terrestris GmbH & Co. KG
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 server:
   port: 8080
   servlet:

--- a/shogun-config/src/main/resources/ehcache.xml
+++ b/shogun-config/src/main/resources/ehcache.xml
@@ -1,3 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SHOGun, https://terrestris.github.io/shogun/
+
+  Copyright © 2020-present terrestris GmbH & Co. KG
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <config
   xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
   xmlns='http://www.ehcache.org/v3'

--- a/shogun-config/src/main/resources/log4j2.yml
+++ b/shogun-config/src/main/resources/log4j2.yml
@@ -1,3 +1,18 @@
+#  SHOGun, https://terrestris.github.io/shogun/
+#
+#  Copyright © 2020-present terrestris GmbH & Co. KG
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 Configuration:
   Appenders:
     Console:

--- a/shogun-config/src/site/site.xml
+++ b/shogun-config/src/site/site.xml
@@ -1,1 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SHOGun, https://terrestris.github.io/shogun/
+
+  Copyright © 2020-present terrestris GmbH & Co. KG
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <project name="SHOGun Boot" combine.self="override" />

--- a/shogun-gs-interceptor/pom.xml
+++ b/shogun-gs-interceptor/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SHOGun, https://terrestris.github.io/shogun/
+
+  Copyright © 2020-present terrestris GmbH & Co. KG
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 

--- a/shogun-gs-interceptor/src/main/resources/application-interceptor.yml
+++ b/shogun-gs-interceptor/src/main/resources/application-interceptor.yml
@@ -1,3 +1,18 @@
+#  SHOGun, https://terrestris.github.io/shogun/
+#
+#  Copyright © 2020-present terrestris GmbH & Co. KG
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 spring:
   datasource:
     url: jdbc:postgresql://localhost:5555/shogun?currentSchema=interceptor

--- a/shogun-lib/pom.xml
+++ b/shogun-lib/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SHOGun, https://terrestris.github.io/shogun/
+
+  Copyright © 2020-present terrestris GmbH & Co. KG
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/WebhookController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/WebhookController.java
@@ -1,3 +1,19 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2020-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.terrestris.shogun.lib.controller;
 
 import de.terrestris.shogun.lib.dto.KeycloakEventDto;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/dto/KeycloakEventDto.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/dto/KeycloakEventDto.java
@@ -1,3 +1,19 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2020-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.terrestris.shogun.lib.dto;
 
 import lombok.AllArgsConstructor;

--- a/shogun-lib/src/main/resources/de/terrestris/shogun/lib/messages.properties
+++ b/shogun-lib/src/main/resources/de/terrestris/shogun/lib/messages.properties
@@ -1,3 +1,18 @@
+#  SHOGun, https://terrestris.github.io/shogun/
+#
+#  Copyright © 2020-present terrestris GmbH & Co. KG
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 BaseController.NOT_FOUND=Requested resource not found
 BaseController.INTERNAL_SERVER_ERROR=Internal server error
 

--- a/shogun-lib/src/main/resources/de/terrestris/shogun/lib/messages_de.properties
+++ b/shogun-lib/src/main/resources/de/terrestris/shogun/lib/messages_de.properties
@@ -1,3 +1,18 @@
+#  SHOGun, https://terrestris.github.io/shogun/
+#
+#  Copyright © 2020-present terrestris GmbH & Co. KG
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 BaseController.NOT_FOUND=Angeforderte Ressource nicht gefunden
 BaseController.INTERNAL_SERVER_ERROR=Serverseitiger Fehler bei Bearbeitung der Anfrage
 

--- a/shogun-lib/src/main/resources/graphql/shogun.graphqls
+++ b/shogun-lib/src/main/resources/graphql/shogun.graphqls
@@ -1,3 +1,20 @@
+"""
+  SHOGun, https://terrestris.github.io/shogun/
+
+  Copyright © 2020-present terrestris GmbH & Co. KG
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+"""
 scalar JSON
 scalar Geometry
 scalar DateTime

--- a/shogun-lib/src/main/resources/hibernate.properties
+++ b/shogun-lib/src/main/resources/hibernate.properties
@@ -1,1 +1,16 @@
+#  SHOGun, https://terrestris.github.io/shogun/
+#
+#  Copyright © 2020-present terrestris GmbH & Co. KG
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 hibernate.types.jackson.object.mapper=de.terrestris.shogun.lib.config.JacksonConfig

--- a/shogun-lib/src/site/site.xml
+++ b/shogun-lib/src/site/site.xml
@@ -1,1 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SHOGun, https://terrestris.github.io/shogun/
+
+  Copyright © 2020-present terrestris GmbH & Co. KG
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <project name="SHOGun Lib" combine.self="override" />

--- a/shogun-lib/src/test/resources/jdbc.properties
+++ b/shogun-lib/src/test/resources/jdbc.properties
@@ -1,3 +1,18 @@
+#  SHOGun, https://terrestris.github.io/shogun/
+#
+#  Copyright © 2020-present terrestris GmbH & Co. KG
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 shogun.model.packages=de.terrestris.shogun.lib.model
 
 hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect

--- a/shogun-lib/src/test/resources/log4j2.properties
+++ b/shogun-lib/src/test/resources/log4j2.properties
@@ -1,3 +1,18 @@
+#  SHOGun, https://terrestris.github.io/shogun/
+#
+#  Copyright © 2020-present terrestris GmbH & Co. KG
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 name=PropertiesConfig
 
 appender.console.type=Console

--- a/shogun-manager/pom.xml
+++ b/shogun-manager/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SHOGun, https://terrestris.github.io/shogun/
+
+  Copyright © 2020-present terrestris GmbH & Co. KG
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0.txt
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>shogun</artifactId>

--- a/shogun-manager/src/main/resources/log4j2.yml
+++ b/shogun-manager/src/main/resources/log4j2.yml
@@ -1,3 +1,18 @@
+#  SHOGun, https://terrestris.github.io/shogun/
+#
+#  Copyright © 2020-present terrestris GmbH & Co. KG
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 Configuration:
   Appenders:
     Console:


### PR DESCRIPTION
This initializes an extra step `Check License Header` (based on [license-eye](https://github.com/marketplace/actions/license-eye)) to the existing `test` workflow.

In addition the license header is added to files it was missing.

Please review @terrestris/devs.