### PR TITLE
Enhance OpenAPI documentation

### DIFF
--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootKeycloakConfig.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootKeycloakConfig.java
@@ -20,5 +20,4 @@ import de.terrestris.shogun.config.KeycloakConfig;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class BootKeycloakConfig extends KeycloakConfig {
-}
+public class BootKeycloakConfig extends KeycloakConfig { }

--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootSwaggerConfig.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootSwaggerConfig.java
@@ -16,7 +16,7 @@
  */
 package de.terrestris.shogun.boot.config;
 
-import de.terrestris.shogun.config.SwaggerConfig;
+import de.terrestris.shogun.lib.config.SwaggerConfig;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.PathSelectors;

--- a/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/config/InterceptorSwaggerConfig.java
+++ b/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/config/InterceptorSwaggerConfig.java
@@ -16,7 +16,7 @@
  */
 package de.terrestris.shogun.interceptor.config;
 
-import de.terrestris.shogun.config.SwaggerConfig;
+import de.terrestris.shogun.lib.config.SwaggerConfig;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.PathSelectors;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Application.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Application.java
@@ -20,6 +20,7 @@ import de.terrestris.shogun.lib.model.jsonb.ApplicationClientConfig;
 import de.terrestris.shogun.lib.model.jsonb.ApplicationToolConfig;
 import de.terrestris.shogun.lib.model.jsonb.LayerConfig;
 import de.terrestris.shogun.lib.model.jsonb.LayerTree;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -44,32 +45,57 @@ import java.util.List;
 public class Application extends BaseEntity {
 
     @Column
+    @Schema(
+        description = "The name of the application.",
+        required = true,
+        example = "My SHOGun application"
+    )
     private String name;
 
     @Column
+    @Schema(
+        description = "Whether the application configuration is considered as state or not. A state may be used " +
+            "as snapshot of a given application.",
+        example = "false"
+    )
     private Boolean stateOnly;
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
     @Basic(fetch = FetchType.LAZY)
     @ToString.Exclude
+    @Schema(
+        description = "The configuration to be considered by the client/application which may include all specific " +
+            "configurations required by the project."
+    )
     private ApplicationClientConfig clientConfig;
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
     @Basic(fetch = FetchType.LAZY)
     @ToString.Exclude
+    @Schema(
+        description = "The tree shaped configuration entry of the applications table of contents."
+    )
     private LayerTree layerTree;
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
     @Basic(fetch = FetchType.LAZY)
     @ToString.Exclude
+    @Schema(
+        description = "The definition of layer configurations. This may be used to set application specific " +
+            "configurations for any layers in the given application."
+    )
     private List<LayerConfig> layerConfig;
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
     @Basic(fetch = FetchType.LAZY)
     @ToString.Exclude
+    @Schema(
+        description = "The definition of tool configurations. This may be used to set application specific " +
+            "configurations for any tools in the given application, e.g. the visibility or the layers the tool should work on."
+    )
     private List<ApplicationToolConfig> toolConfig;
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/BaseEntity.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/BaseEntity.java
@@ -17,8 +17,10 @@
 package de.terrestris.shogun.lib.model;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.TypeDef;
@@ -47,16 +49,31 @@ public abstract class BaseEntity implements Serializable {
     @GeneratedValue(strategy= GenerationType.SEQUENCE)
     @Column(unique = true, nullable = false)
     @Getter
+    @Schema(
+        description = "The ID of the entity.",
+        accessMode = Schema.AccessMode.READ_ONLY,
+        readOnly = true
+    )
     private Long id;
 
     @CreationTimestamp
     @Column(updatable = false)
     @Getter @Setter
+    @Schema(
+        description = "The timestamp of creation.",
+        accessMode = Schema.AccessMode.READ_ONLY,
+        readOnly = true
+    )
     private OffsetDateTime created;
 
     @UpdateTimestamp
     @Column
     @Getter @Setter
+    @Schema(
+        description = "The timestamp of the last modification.",
+        accessMode = Schema.AccessMode.READ_ONLY,
+        readOnly = true
+    )
     private OffsetDateTime modified;
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/File.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/File.java
@@ -17,6 +17,7 @@
 package de.terrestris.shogun.lib.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -39,18 +40,34 @@ public class File extends BaseEntity {
     @Column(columnDefinition = "uuid", updatable = false, nullable = false)
     @Type(type="pg-uuid")
     @Getter
+    @Schema(
+        description = "The (auto assigned) UUID of the file.",
+        accessMode = Schema.AccessMode.READ_ONLY
+    )
     private UUID fileUuid = UUID.randomUUID();
 
     @Column
     @Getter @Setter
+    @Schema(
+        description = "Whether the file is considered as active or not.",
+        example = "true"
+    )
     private Boolean active;
 
     @Column(nullable = false)
     @Getter @Setter
+    @Schema(
+        description = "The (original) name of the file.",
+        example = "shogun.png"
+    )
     private String fileName;
 
     @Column(nullable = false)
     @Getter @Setter
+    @Schema(
+        description = "The (original) type of the file.",
+        example = "image/png"
+    )
     private String fileType;
 
     @JsonIgnore

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Group.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Group.java
@@ -21,6 +21,8 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 import javax.persistence.Transient;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -46,9 +48,17 @@ import org.keycloak.representations.idm.GroupRepresentation;
 public class Group extends BaseEntity {
 
     @Column(unique = true, nullable = false)
+    @Schema(
+        description = "The internal Keycloak ID of the group.",
+        example = "image/png"
+    )
     private String keycloakId;
 
     @Transient
+    @Schema(
+        description = "The group details stored in the associated Keycloak entity.",
+        accessMode = Schema.AccessMode.READ_ONLY
+    )
     private GroupRepresentation keycloakRepresentation;
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/ImageFile.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/ImageFile.java
@@ -21,6 +21,8 @@ import javax.persistence.Cacheable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -38,9 +40,17 @@ import lombok.ToString;
 public class ImageFile extends File {
 
     @Column
+    @Schema(
+        description = "The (original) width of the image file.",
+        example = "100"
+    )
     private Integer width;
 
     @Column
+    @Schema(
+        description = "The (original) height of the image file.",
+        example = "100"
+    )
     private Integer height;
 
     @JsonIgnore

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Layer.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Layer.java
@@ -19,6 +19,7 @@ package de.terrestris.shogun.lib.model;
 import de.terrestris.shogun.lib.enumeration.LayerType;
 import de.terrestris.shogun.lib.model.jsonb.LayerClientConfig;
 import de.terrestris.shogun.lib.model.jsonb.LayerSourceConfig;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import org.geojson.GeoJsonObject;
 import org.hibernate.annotations.Cache;
@@ -43,27 +44,48 @@ import javax.persistence.*;
 public class Layer extends BaseEntity {
 
     @Column(nullable = false)
+    @Schema(
+        description = "The internal name of the layer.",
+        example = "MySHOGunLayer"
+    )
     private String name;
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
     @Basic(fetch = FetchType.LAZY)
     @ToString.Exclude
+    @Schema(
+        description = "The configuration of the layer which should be used to define client specific aspects of " +
+            "the layer. This may include the name, the visible resolution range, search configurations or similiar."
+    )
     private LayerClientConfig clientConfig;
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
     @Basic(fetch = FetchType.LAZY)
     @ToString.Exclude
+    @Schema(
+        description = "The configuration of the datasource of the layer, e.g. the URL of the server, the name or " +
+            "the grid configuration.",
+        required = true
+    )
     private LayerSourceConfig sourceConfig;
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
     @Basic(fetch = FetchType.LAZY)
     @ToString.Exclude
+    @Schema(
+        description = "Custom features for the layers that aren't available in the datasource. This might be used " +
+            "for custom draw layers or similiar. It's advised to store the features using the GeoJSON format."
+    )
     private GeoJsonObject features;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
+    @Schema(
+        description = "The type of the layer. Currently one of `TileWMS`, `VectorTile`, `WFS`, `WMS`, `WMTS` or `XYZ`.",
+        required = true
+    )
     private LayerType type;
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/User.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/User.java
@@ -26,6 +26,8 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.Table;
 import javax.persistence.Transient;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -52,21 +54,36 @@ import org.keycloak.representations.idm.UserRepresentation;
 public class User extends BaseEntity {
 
     @Column(unique = true, nullable = false)
+    @Schema(
+        description = "The internal Keycloak ID of the user.",
+        required = true
+    )
     private String keycloakId;
 
     @Transient
+    @Schema(
+        description = "The user details stored in the associated Keycloak entity.",
+        accessMode = Schema.AccessMode.READ_ONLY
+    )
     private UserRepresentation keycloakRepresentation;
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
     @Basic(fetch = FetchType.LAZY)
     @ToString.Exclude
+    @Schema(
+        description = "Custom user details that aren't stored inside the Keycloak representation."
+    )
     private UserDetails details;
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
     @Basic(fetch = FetchType.LAZY)
     @ToString.Exclude
+    @Schema(
+        description = "The configuration of the user which should be used to define client specific aspects of " +
+            "the user. This may include the locale set by the user, the last application visited by the user or similiar."
+    )
     private UserClientConfig clientConfig;
 
 }

--- a/shogun-lib/src/main/resources/graphql/shogun.graphqls
+++ b/shogun-lib/src/main/resources/graphql/shogun.graphqls
@@ -1137,6 +1137,34 @@ type Application implements BaseEntity {
     ```
     """
     layerTree: JSON
+    """
+    The definition of layer configurations. This may be used to set application specific configurations for any
+    layers in the given application. For example:
+
+    ```
+    [{
+      "id": 1909,
+      "name": "A custom name"
+    }]
+    ```
+
+    **Please note:** The structure of the `layerConfig` has to be defined by each project separately by implementing the
+    `LayerConfig`. Otherwise (de-)serializing the body is not possible. A minimal example implementation might look
+    like (shortened):
+
+    ```
+    @Data
+    @JsonDeserialize(as = ProjectLayerConfig.class)
+    @JsonSuperType(type = LayerConfig.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @ToString
+    @EqualsAndHashCode
+    public class ProjectLayerConfig implements LayerConfig {
+    private Integer id;
+    private String name;
+    }
+    ```
+    """
     layerConfig: JSON
     """
     The definition of tool configurations. This may be used to set application specific configurations for any tools

--- a/shogun-lib/src/main/resources/graphql/shogun.graphqls
+++ b/shogun-lib/src/main/resources/graphql/shogun.graphqls
@@ -1185,8 +1185,8 @@ type Application implements BaseEntity {
 
     ```
     @Data
-    @JsonDeserialize(as = ProjectLayerTree.class)
-    @JsonSuperType(type = LayerTree.class)
+    @JsonDeserialize(as = ProjectToolConfig.class)
+    @JsonSuperType(type = ToolConfig.class)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @ToString
     @EqualsAndHashCode

--- a/shogun-lib/src/main/resources/graphql/shogun.graphqls
+++ b/shogun-lib/src/main/resources/graphql/shogun.graphqls
@@ -1007,7 +1007,7 @@ type Application implements BaseEntity {
     """
     name: String
     """
-    Wheather the application configuration is considered as state or not. A state may be used as snapshot of a given
+    Whether the application configuration is considered as state or not. A state may be used as snapshot of a given
     application.
     """
     stateOnly: Boolean
@@ -1139,7 +1139,7 @@ type Application implements BaseEntity {
     layerTree: JSON
     layerConfig: JSON
     """
-    The definition of tool configurations. This may be used to set appliction specific configurations for any tools
+    The definition of tool configurations. This may be used to set application specific configurations for any tools
     in the given application, e.g. the visibility or the layers the tool should work on. For example:
 
     ```


### PR DESCRIPTION
This adds support for auto-consideration of any JSONB model extensions in the OpenAPI specification by substituting the base classes with the given implementations (see `docket.directModelSubstitute()`). 

In addition the OpenAPI docs are enhanced by some addtional field informations and some minors in the GraphQL schema documentation were resolved as well.

See the following screenshot for an example of a project extension:

![Screenshot from 2021-09-24 15-18-36](https://user-images.githubusercontent.com/1137620/134681729-c456582c-020e-4aa9-b0c0-00aead36c1ba.png)

Please note: This is considered as *breaking change* as the `SwaggerConfig` is moved from the `shogun-config` to the `shogun-lib` module.

Please review @terrestris/devs.