### PR TITLE
Fix jib jvmFlags configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,8 +233,9 @@
               </tags>
             </to>
             <container>
-              <jvmFlags>-Djava.security.egd=file:/dev/./urandom</jvmFlags>
-              <jvmFlags>-Dspring.config.location=/config/application.yml</jvmFlags>
+              <jvmFlags>
+                <jvmFlag>-Djava.security.egd=file:/dev/./urandom</jvmFlag>
+              </jvmFlags>
               <creationTime>EPOCH</creationTime>
             </container>
           </configuration>


### PR DESCRIPTION
This fixes the specification of the `jvmFlags` set by `jib` to the docker container (see [docs](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#example)).

The `-Dspring.config.location=/config/application.yml` parameter has been removed as it should be set by applications if needed via the `JAVA_TOOL_OPTIONS` environment parameter (see [!14](https://github.com/terrestris/shogun-docker/pull/14)).

Please review @terrestris/devs.