### PR TITLE
Adjust log level for the CacheLogger

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/listener/CacheLogger.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/listener/CacheLogger.java
@@ -35,7 +35,7 @@ public class CacheLogger implements CacheEventListener<Object, Object> {
      */
     @Override
     public void onEvent(CacheEvent<?, ?> event) {
-        log.info("Key: {} | EventType: {} | Old value: {} | New value: {}",
+        log.debug("Key: {} | EventType: {} | Old value: {} | New value: {}",
             event.getKey(), event.getType(), event.getOldValue(),
             event.getNewValue());
     }


### PR DESCRIPTION
This ajusts the log level for the `CacheLogger` to `debug` to minimize log output in production environments.

Please note @terrestris/devs.