### PR TITLE
Fix dev dockerfile

### DIFF
--- a/.github/workflows/startup.yml
+++ b/.github/workflows/startup.yml
@@ -14,6 +14,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      KEYCLOAK_HOST: 1.2.3.4
+
     steps:
       - uses: actions/checkout@v2
       - name: Set up Java 17

--- a/shogun-boot/Dockerfile
+++ b/shogun-boot/Dockerfile
@@ -14,8 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM terrestris/openjdk-maven-docker:jdk17-bullseye
-WORKDIR /shogun-boot
+FROM openjdk@sha256:d50104b0b5811b60c198a3e5ced23c783a49e0d4f78b99762fca4bfdbbc59dd2
 
 RUN mkdir /usr/share/man/man1 && apt-get update && apt-get install -y maven
 

--- a/shogun-boot/Dockerfile
+++ b/shogun-boot/Dockerfile
@@ -16,7 +16,9 @@
 # limitations under the License.
 FROM openjdk@sha256:d50104b0b5811b60c198a3e5ced23c783a49e0d4f78b99762fca4bfdbbc59dd2
 
-RUN mkdir /usr/share/man/man1 && apt-get update && apt-get install -y maven
+WORKDIR /shogun/shogun-boot
+
+RUN microdnf install maven
 
 ENTRYPOINT [ \
   "mvn", \

--- a/shogun-boot/src/main/resources/application-boot.yml
+++ b/shogun-boot/src/main/resources/application-boot.yml
@@ -44,7 +44,7 @@ spring:
 server:
   port: 8080
   servlet:
-    context-path: /shogun-boot
+    context-path: /
 
 support:
   email: noreply@terrestris.de


### PR DESCRIPTION
This suggests:

* To make use of the same openjdk base image as in production (referenced by the jib plugin). 
* To set the correct workdir path and
* To set the default application servlet path to `/`.

Replaces #390 and requires [#21](https://github.com/terrestris/shogun-docker/pull/21) (shogun-docker).

Please review @terrestris/devs.

