### PR TITLE
Add elementary tests for services extending the BaseService class 

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/UserService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/UserService.java
@@ -53,7 +53,7 @@ public class UserService extends BaseService<UserRepository, User> {
     @Transactional(readOnly = true)
     @Override
     public List<User> findAll() {
-        List<User> users = (List<User>) repository.findAll();
+        List<User> users = repository.findAll();
 
         for (User user : users) {
             this.setTransientKeycloakRepresentations(user);

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/ApplicationServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/ApplicationServiceTest.java
@@ -1,0 +1,40 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2020-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.terrestris.shogun.lib.service;
+
+import de.terrestris.shogun.lib.model.Application;
+import de.terrestris.shogun.lib.repository.ApplicationRepository;
+import org.junit.Before;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+public class ApplicationServiceTest extends BaseServiceTest<ApplicationService, Application> {
+
+    @Mock
+    ApplicationRepository repositoryMock;
+
+    @InjectMocks
+    ApplicationService service;
+
+    @Before
+    public void init() {
+        super.setRepository(repositoryMock);
+        super.setService(service);
+        super.setEntityClass(Application.class);
+    }
+
+}

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/BaseFileServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/BaseFileServiceTest.java
@@ -43,7 +43,6 @@ public class BaseFileServiceTest {
 
     private String failMsg = "Validation shouldn't have thrown any exception.";
 
-
     @Test
     public void isValidFileName_shouldAllowRegularFilenames() {
         try {

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/BaseServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/BaseServiceTest.java
@@ -1,0 +1,222 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2020-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.terrestris.shogun.lib.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import de.terrestris.shogun.lib.model.BaseEntity;
+import de.terrestris.shogun.lib.repository.BaseCrudRepository;
+import de.terrestris.shogun.lib.service.security.permission.GroupInstancePermissionService;
+import de.terrestris.shogun.lib.service.security.permission.UserInstancePermissionService;
+import de.terrestris.shogun.lib.util.IdHelper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.access.prepost.PostAuthorize;
+import org.springframework.security.access.prepost.PostFilter;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public abstract class BaseServiceTest<U extends BaseService, S extends BaseEntity> implements IBaseServiceTest {
+
+    protected Class<S> entityClass;
+
+    @Mock
+    ObjectMapper objectMapperMock;
+
+    @Mock
+    ObjectReader objectReaderMock;
+
+    @Mock
+    private UserInstancePermissionService userInstancePermissionServiceMock;
+
+    @Mock
+    private GroupInstancePermissionService groupInstancePermissionServiceMock;
+
+    private BaseCrudRepository baseCrudRepositoryMock;
+
+    protected U service;
+
+    @Test
+    public void class_isAnnotatedAsService() {
+        assertNotNull(service.getClass().getAnnotation(Service.class));
+    }
+
+    @Test
+    public void findAll_IsAnnotatedAsExpected() throws NoSuchMethodException {
+        PostFilter findAllPostFilter =
+            service.getClass().getMethod("findAll").getAnnotation(PostFilter.class);
+
+        assertNotNull(findAllPostFilter);
+        assertTrue(findAllPostFilter.value().contains("hasRole"));
+        assertTrue(findAllPostFilter.value().contains("hasPermission"));
+    }
+
+    @Test
+    public void findAll_ShouldCallCorrectRepositoryMethodAndShouldReturnListOfGivenBaseEntity() {
+        S mockEntity1 = mock(entityClass);
+        S mockEntity2 = mock(entityClass);
+        S mockEntity3 = mock(entityClass);
+
+        ArrayList<S> entityList = new ArrayList<>();
+
+        entityList.add(mockEntity1);
+        entityList.add(mockEntity2);
+        entityList.add(mockEntity3);
+
+        when(baseCrudRepositoryMock.findAll()).thenReturn(entityList);
+
+        List returnValue = service.findAll();
+
+        verify(baseCrudRepositoryMock, times(1)).findAll();
+        assertEquals(returnValue, entityList);
+    }
+
+    @Test
+    public void findOne_IsAnnotatedAsExpected() throws NoSuchMethodException {
+        PostAuthorize findOnePostAuthorize =
+            service.getClass().getMethod("findOne", Long.class).getAnnotation(PostAuthorize.class);
+
+        assertNotNull(findOnePostAuthorize);
+        assertTrue(findOnePostAuthorize.value().contains("hasRole"));
+        assertTrue(findOnePostAuthorize.value().contains("hasPermission"));
+    }
+
+    @Test
+    public void findOne_ShouldCallCorrectRepositoryMethodAndShouldReturnSingleResultOfGivenBaseEntity() {
+        Optional<S> mockEntity = Optional.of(mock(entityClass));
+
+        when(baseCrudRepositoryMock.findById(1909L)).thenReturn(mockEntity);
+
+        Optional returnValue = service.findOne(1909L);
+
+        verify(baseCrudRepositoryMock, times(1)).findById(1909L);
+        assertEquals(returnValue, mockEntity);
+
+        Optional anotherReturnValue = service.findOne(1904L);
+
+        verify(baseCrudRepositoryMock, times(1)).findById(1904L);
+        assertNotEquals(anotherReturnValue, mockEntity);
+    }
+
+    @Test
+    public void create_IsAnnotatedAsExpected() throws NoSuchMethodException {
+        PreAuthorize createPreAuthorize =
+            service.getClass().getMethod("create", BaseEntity.class).getAnnotation(PreAuthorize.class);
+
+        assertNotNull(createPreAuthorize);
+        assertTrue(createPreAuthorize.value().contains("hasRole"));
+        assertTrue(createPreAuthorize.value().contains("hasPermission"));
+    }
+
+    @Test
+    public void create_ShouldCallCorrectRepositoryMethodAndShouldReturnTheCreatedEntityOfGivenBaseEntity() throws NoSuchFieldException {
+        S mockEntity = mock(entityClass, CALLS_REAL_METHODS);
+        IdHelper.setIdForEntity(mockEntity, 1909L);
+
+        S entityToSave = mock(entityClass);
+
+        when(baseCrudRepositoryMock.save(entityToSave)).thenReturn(mockEntity);
+
+        S returnValue = (S) service.create(entityToSave);
+
+        verify(baseCrudRepositoryMock, times(1)).save(entityToSave);
+        assertNotEquals(returnValue.getId(), entityToSave.getId());
+    }
+
+    @Test
+    public void update_IsAnnotatedAsExpected() throws NoSuchMethodException {
+        PreAuthorize updatePreAuthorize =
+            service.getClass().getMethod("update", Long.class, BaseEntity.class).getAnnotation(PreAuthorize.class);
+
+        assertNotNull(updatePreAuthorize);
+        assertTrue(updatePreAuthorize.value().contains("hasRole"));
+        assertTrue(updatePreAuthorize.value().contains("hasPermission"));
+    }
+
+    @Test
+    public void update_ShouldCallCorrectRepositoryMethodAndShouldReturnTheCreatedEntityOfGivenBaseEntity() throws IOException, NoSuchFieldException {
+        S mockEntity = mock(entityClass, CALLS_REAL_METHODS);
+        OffsetDateTime date = OffsetDateTime.now();
+        IdHelper.setIdForEntity(mockEntity, 1909L);
+        mockEntity.setCreated(date);
+        mockEntity.setModified(date);
+
+        JsonNode returnNode = JsonNodeFactory.instance.objectNode();
+        ((ObjectNode) returnNode).put("id", 1909);
+        ((ObjectNode) returnNode).put("created", date.toString());
+        ((ObjectNode) returnNode).put("modified", date.toString());
+
+        when(baseCrudRepositoryMock.findById(1909L)).thenReturn(Optional.of(mockEntity));
+        when(baseCrudRepositoryMock.save(mockEntity)).thenReturn(mockEntity);
+
+        when(objectMapperMock.valueToTree(mockEntity)).thenReturn(returnNode);
+        when(objectMapperMock.readerForUpdating(mockEntity)).thenReturn(objectReaderMock);
+        when(objectReaderMock.readValue(returnNode)).thenReturn(mockEntity);
+
+        S returnValue = (S) service.update(1909L, mockEntity);
+
+        verify(baseCrudRepositoryMock, times(1)).findById(1909L);
+        verify(baseCrudRepositoryMock, times(1)).save(mockEntity);
+        assertEquals(returnValue, mockEntity);
+    }
+
+    @Test
+    public void delete_IsAnnotatedAsExpected() throws NoSuchMethodException {
+        PreAuthorize deletePreAuthorize =
+            service.getClass().getMethod("delete", BaseEntity.class).getAnnotation(PreAuthorize.class);
+
+        assertNotNull(deletePreAuthorize);
+        assertTrue(deletePreAuthorize.value().contains("hasRole"));
+        assertTrue(deletePreAuthorize.value().contains("hasPermission"));
+    }
+
+    @Test
+    public void delete_ShouldCallCorrectRepositoryMethod() {
+        S mockEntity = mock(entityClass);
+
+        service.delete(mockEntity);
+
+        verify(baseCrudRepositoryMock, times(1)).delete(mockEntity);
+    }
+
+    protected void setService(U service) {
+        this.service = service;
+    }
+
+    protected void setRepository(BaseCrudRepository repository) {
+        this.baseCrudRepositoryMock = repository;
+    }
+
+    protected void setEntityClass(Class<S> entityClass) {
+        this.entityClass = entityClass;
+    }
+}

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/GroupServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/GroupServiceTest.java
@@ -1,0 +1,49 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2020-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.terrestris.shogun.lib.service;
+
+import de.terrestris.shogun.lib.model.Group;
+import de.terrestris.shogun.lib.repository.GroupRepository;
+import de.terrestris.shogun.lib.util.KeycloakUtil;
+import org.junit.Before;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+public class GroupServiceTest extends BaseServiceTest<GroupService, Group> {
+
+    @Mock
+    GroupRepository repositoryMock;
+
+    @Mock
+    KeycloakUtil keycloakUtilMock;
+
+    @InjectMocks
+    GroupService service;
+
+    @Before
+    public void init() {
+        when(keycloakUtilMock.getGroupResource(any(Group.class))).thenReturn(null);
+
+        super.setRepository(repositoryMock);
+        super.setService(service);
+        super.setEntityClass(Group.class);
+    }
+
+}

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/IBaseServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/IBaseServiceTest.java
@@ -1,0 +1,27 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2020-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.terrestris.shogun.lib.service;
+
+import org.junit.Before;
+
+public interface IBaseServiceTest {
+    /**
+     * All service tests must call the init method (including the {@link Before})
+     * to set the desired service, repository and entity.
+     */
+    void init();
+}

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/LayerServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/LayerServiceTest.java
@@ -1,0 +1,40 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2020-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.terrestris.shogun.lib.service;
+
+import de.terrestris.shogun.lib.model.Layer;
+import de.terrestris.shogun.lib.repository.LayerRepository;
+import org.junit.Before;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+public class LayerServiceTest extends BaseServiceTest<LayerService, Layer> {
+
+    @Mock
+    LayerRepository repositoryMock;
+
+    @InjectMocks
+    LayerService service;
+
+    @Before
+    public void init() {
+        super.setRepository(repositoryMock);
+        super.setService(service);
+        super.setEntityClass(Layer.class);
+    }
+
+}

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/UserServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/UserServiceTest.java
@@ -1,0 +1,52 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2020-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.terrestris.shogun.lib.service;
+
+import de.terrestris.shogun.lib.model.User;
+import de.terrestris.shogun.lib.repository.UserRepository;
+import de.terrestris.shogun.lib.util.KeycloakUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.security.access.prepost.PostAuthorize;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+public class UserServiceTest extends BaseServiceTest<UserService, User> {
+
+    @Mock
+    UserRepository repositoryMock;
+
+    @Mock
+    KeycloakUtil keycloakUtilMock;
+
+    @InjectMocks
+    UserService service;
+
+    @Before
+    public void init() {
+        when(keycloakUtilMock.getUserResource(any(User.class))).thenReturn(null);
+
+        super.setRepository(repositoryMock);
+        super.setService(service);
+        super.setEntityClass(User.class);
+    }
+
+}

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/security/permission/GroupClassPermissionServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/security/permission/GroupClassPermissionServiceTest.java
@@ -1,0 +1,41 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2020-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.terrestris.shogun.lib.service.security.permission;
+
+import de.terrestris.shogun.lib.model.security.permission.GroupClassPermission;
+import de.terrestris.shogun.lib.repository.security.permission.GroupClassPermissionRepository;
+import de.terrestris.shogun.lib.service.BaseServiceTest;
+import org.junit.Before;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+public class GroupClassPermissionServiceTest extends BaseServiceTest<GroupClassPermissionService, GroupClassPermission> {
+
+    @Mock
+    GroupClassPermissionRepository repositoryMock;
+
+    @InjectMocks
+    GroupClassPermissionService service;
+
+    @Before
+    public void init() {
+        super.setRepository(repositoryMock);
+        super.setService(service);
+        super.setEntityClass(GroupClassPermission.class);
+    }
+
+}

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionServiceTest.java
@@ -1,0 +1,41 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2020-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.terrestris.shogun.lib.service.security.permission;
+
+import de.terrestris.shogun.lib.model.security.permission.GroupInstancePermission;
+import de.terrestris.shogun.lib.repository.security.permission.GroupInstancePermissionRepository;
+import de.terrestris.shogun.lib.service.BaseServiceTest;
+import org.junit.Before;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+public class GroupInstancePermissionServiceTest extends BaseServiceTest<GroupInstancePermissionService, GroupInstancePermission> {
+
+    @Mock
+    GroupInstancePermissionRepository repositoryMock;
+
+    @InjectMocks
+    GroupInstancePermissionService service;
+
+    @Before
+    public void init() {
+        super.setRepository(repositoryMock);
+        super.setService(service);
+        super.setEntityClass(GroupInstancePermission.class);
+    }
+
+}

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/security/permission/PermissionCollectionServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/security/permission/PermissionCollectionServiceTest.java
@@ -1,0 +1,41 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2020-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.terrestris.shogun.lib.service.security.permission;
+
+import de.terrestris.shogun.lib.model.security.permission.PermissionCollection;
+import de.terrestris.shogun.lib.repository.security.permission.PermissionCollectionRepository;
+import de.terrestris.shogun.lib.service.BaseServiceTest;
+import org.junit.Before;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+public class PermissionCollectionServiceTest extends BaseServiceTest<PermissionCollectionService, PermissionCollection> {
+
+    @Mock
+    PermissionCollectionRepository repositoryMock;
+
+    @InjectMocks
+    PermissionCollectionService service;
+
+    @Before
+    public void init() {
+        super.setRepository(repositoryMock);
+        super.setService(service);
+        super.setEntityClass(PermissionCollection.class);
+    }
+
+}

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/security/permission/UserClassPermissionServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/security/permission/UserClassPermissionServiceTest.java
@@ -1,0 +1,41 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2020-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.terrestris.shogun.lib.service.security.permission;
+
+import de.terrestris.shogun.lib.model.security.permission.UserClassPermission;
+import de.terrestris.shogun.lib.repository.security.permission.UserClassPermissionRepository;
+import de.terrestris.shogun.lib.service.BaseServiceTest;
+import org.junit.Before;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+public class UserClassPermissionServiceTest extends BaseServiceTest<UserClassPermissionService, UserClassPermission> {
+
+    @Mock
+    UserClassPermissionRepository repositoryMock;
+
+    @InjectMocks
+    UserClassPermissionService service;
+
+    @Before
+    public void init() {
+        super.setRepository(repositoryMock);
+        super.setService(service);
+        super.setEntityClass(UserClassPermission.class);
+    }
+
+}

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/security/permission/UserInstancePermissionServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/security/permission/UserInstancePermissionServiceTest.java
@@ -1,0 +1,41 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2020-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.terrestris.shogun.lib.service.security.permission;
+
+import de.terrestris.shogun.lib.model.security.permission.UserInstancePermission;
+import de.terrestris.shogun.lib.repository.security.permission.UserInstancePermissionRepository;
+import de.terrestris.shogun.lib.service.BaseServiceTest;
+import org.junit.Before;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+public class UserInstancePermissionServiceTest extends BaseServiceTest<UserInstancePermissionService, UserInstancePermission> {
+
+    @Mock
+    UserInstancePermissionRepository repositoryMock;
+
+    @InjectMocks
+    UserInstancePermissionService service;
+
+    @Before
+    public void init() {
+        super.setRepository(repositoryMock);
+        super.setService(service);
+        super.setEntityClass(UserInstancePermission.class);
+    }
+
+}


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This adds a new abstract `BaseServiceTest` class that can be used as a starter for testing a service class that extends the `BaseService`. It includes dummy implementations for all appropriate services. 

Depends on #404 and #405.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
