### PR TITLE
Replace deprecated SubTypesScanner and TypeAnnotationsScanner

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/config/JacksonConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/config/JacksonConfig.java
@@ -27,8 +27,7 @@ import de.terrestris.shogun.lib.annotation.JsonSuperType;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.PrecisionModel;
 import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
-import org.reflections.scanners.TypeAnnotationsScanner;
+import org.reflections.scanners.Scanners;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
 import org.springframework.beans.factory.annotation.Value;
@@ -93,8 +92,11 @@ public class JacksonConfig implements ObjectMapperSupplier {
     private Map<Class<?>, Class<?>> findAnnotatedClasses() {
         var reflections = new Reflections(new ConfigurationBuilder()
             .setUrls(ClasspathHelper.forJavaClassPath())
-            .setScanners(new SubTypesScanner(),
-                new TypeAnnotationsScanner()));
+            .setScanners(
+                Scanners.SubTypes,
+                Scanners.TypesAnnotated
+            )
+        );
 
         Map<Class<?>, Class<?>> implementers = new HashMap<>();
 


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This PR replaces deprecated `SubTypesScanner` and `TypeAnnotationsScanner` by `Scanners.SubTypes` / `Scanners.TypesAnnotated` respectively to fix scan of `@JsonSuperType` in classpath.

Plz review @terrestris/devs 

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
