### PR TITLE
Set -Djdk.serialSetFilterAfterRead=true to hide keycloak warning in logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,7 @@
             <container>
               <jvmFlags>
                 <jvmFlag>-Djava.security.egd=file:/dev/./urandom</jvmFlag>
+                <jvmFlag>-Djdk.serialSetFilterAfterRead=true</jvmFlag>
               </jvmFlags>
               <creationTime>EPOCH</creationTime>
             </container>

--- a/shogun-boot/Dockerfile
+++ b/shogun-boot/Dockerfile
@@ -24,7 +24,7 @@ ENTRYPOINT [ \
   "mvn", \
   "spring-boot:run", \
   "-Dspring-boot.run.profiles=base,boot", \
-  "-Dspring-boot.run.jvmArguments=-Xdebug -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:4711", \
+  "-Dspring-boot.run.jvmArguments=-Xdebug -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:4711 -Djdk.serialSetFilterAfterRead=true", \
   # enable this line when using a custom application.yml
   # "-Dspring.config.location=/config/application.yml", \
   "-Djava.security.egd=file:/dev/./urandom", \


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

See [KEYCLOAK-15901](https://issues.redhat.com/browse/KEYCLOAK-15901) for details.

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
