### PR TITLE
fix: set envers suffix instead of prefix

### DIFF
--- a/shogun-config/src/main/resources/application-base.yml
+++ b/shogun-config/src/main/resources/application-base.yml
@@ -47,7 +47,7 @@ spring:
             mode: ENABLE_SELECTIVE
       org:
         hibernate:
-          # See https://docs.jboss.org/envers/docs/#configuration
+          # See https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#envers-configuration
           envers:
             default_schema: shogun_rev
             audit_table_suffix: _rev

--- a/shogun-config/src/main/resources/application-base.yml
+++ b/shogun-config/src/main/resources/application-base.yml
@@ -50,7 +50,7 @@ spring:
           # See https://docs.jboss.org/envers/docs/#configuration
           envers:
             default_schema: shogun_rev
-            audit_table_prefix: _rev
+            audit_table_suffix: _rev
             global_with_modified_flag: true
       hibernate:
         javax:


### PR DESCRIPTION
## Description

`_rev` is supposed to be a suffix not a prefix. With this change the `value` of `@AuditTable` and probably also the `name` of `@AuditJoinTable` can be omitted.
<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [ ] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
