### PR TITLE
Conditional resource and SPA controller 

### DIFF
--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/controller/ResourceController.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/controller/ResourceController.java
@@ -18,6 +18,7 @@ package de.terrestris.shogun.boot.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.ModelAndView;
 
 @Controller
+@ConditionalOnExpression("${controller.resource.enabled:true}")
 public class ResourceController {
 
     @Value("${KEYCLOAK_HOST:1.2.3.4}")

--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/controller/SinglePageAppController.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/controller/SinglePageAppController.java
@@ -16,6 +16,7 @@
  */
 package de.terrestris.shogun.boot.controller;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
@@ -25,6 +26,7 @@ import javax.servlet.http.HttpServletRequest;
  * https://stackoverflow.com/questions/40769200/configure-spring-boot-for-spa-frontend
  */
 @Controller
+@ConditionalOnExpression("${controller.singlepageapp.enabled:true}")
 public class SinglePageAppController {
 
     @GetMapping("/**/{path:[^\\.]*}")

--- a/shogun-config/src/main/resources/application-base.yml
+++ b/shogun-config/src/main/resources/application-base.yml
@@ -132,6 +132,10 @@ controller:
     enabled: true
   users:
     enabled: true
+  resource:
+    enabled: true
+  singlepageapp:
+    enabled: true
 
 upload:
   file:


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This makes the bean creation of the resource and single page app controller configurable via

```yaml
resource:
  enabled: true
singlepageapp:
  enabled: true
```

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
