### PR TITLE
fix: use keycloak id to test for group membership

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/KeycloakUtil.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/KeycloakUtil.java
@@ -174,8 +174,8 @@ public class KeycloakUtil {
 
     public boolean isUserInGroup(User user, Group group) {
         UserResource kcUser = this.getUserResource(user);
-        GroupResource kcGroup = this.getGroupResource(group);
-        return kcUser.groups().contains(kcGroup);
+        return kcUser.groups().stream()
+            .anyMatch(gr -> gr.getId().equals(group.getKeycloakId()));
     }
 
     /**


### PR DESCRIPTION
This uses the keycloak id instead of reference equality for testing group membership