### PR TITLE
Configurable authentication and identity provider

### DIFF
--- a/.github/workflows/startup.yml
+++ b/.github/workflows/startup.yml
@@ -53,6 +53,10 @@ jobs:
         run: docker-compose -f docker-compose.yml -f docker-compose-dev.yml up -d
         working-directory: ../shogun-docker
 
+      - name: Inspect network
+        run: docker network ls
+        working-directory: ../shogun-docker
+
       - name: Check if application has started
         run: ./scripts/wait.sh
 

--- a/.github/workflows/startup.yml
+++ b/.github/workflows/startup.yml
@@ -45,6 +45,10 @@ jobs:
         run: ./setEnvironment.sh
         working-directory: ../shogun-docker
 
+      - name: Show environment variables
+        run: cat .env
+        working-directory: ../shogun-docker
+
       - name: Start containers
         run: docker-compose -f docker-compose.yml -f docker-compose-dev.yml up -d
         working-directory: ../shogun-docker

--- a/.github/workflows/startup.yml
+++ b/.github/workflows/startup.yml
@@ -54,7 +54,7 @@ jobs:
         working-directory: ../shogun-docker
 
       - name: Inspect network
-        run: docker network ls
+        run: docker network inspect shogun-docker_default
         working-directory: ../shogun-docker
 
       - name: Check if application has started

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,8 @@
     <junit.jupiter.version>5.7.1</junit.jupiter.version>
     <mockito.version>4.4.0</mockito.version>
     <maven-dependency-plugin.version>3.3.0</maven-dependency-plugin.version>
+    <maven-project-info-reports-plugin.version>3.2.1</maven-project-info-reports-plugin.version>
+    <git.commit.id.abbrev>unknown</git.commit.id.abbrev>
   </properties>
 
   <build>
@@ -284,11 +286,6 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-site-plugin</artifactId>
             <version>${maven-site-plugin.version}</version>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-project-info-reports-plugin</artifactId>
-            <version>${maven-project-info-reports-plugin.version}</version>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -577,4 +577,3 @@
   </dependencyManagement>
 
 </project>
-

--- a/scripts/wait.sh
+++ b/scripts/wait.sh
@@ -15,7 +15,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 URL="https://localhost/"
-TIMEOUT=120
+TIMEOUT=240
 seconds=0
 
 echo 'Waiting up to' $TIMEOUT 'seconds for HTTP 200 from' $URL 

--- a/scripts/wait.sh
+++ b/scripts/wait.sh
@@ -15,7 +15,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 URL="https://localhost/"
-TIMEOUT=120
+TIMEOUT=360
 seconds=0
 
 echo 'Waiting up to' $TIMEOUT 'seconds for HTTP 200 from' $URL 

--- a/scripts/wait.sh
+++ b/scripts/wait.sh
@@ -15,7 +15,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 URL="https://localhost/"
-TIMEOUT=240
+TIMEOUT=120
 seconds=0
 
 echo 'Waiting up to' $TIMEOUT 'seconds for HTTP 200 from' $URL 

--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootKeycloakConfig.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootKeycloakConfig.java
@@ -17,7 +17,9 @@
 package de.terrestris.shogun.boot.config;
 
 import de.terrestris.shogun.config.KeycloakConfig;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Configuration;
 
+@ConditionalOnExpression("${keycloak.enabled:true}")
 @Configuration
 public class BootKeycloakConfig extends KeycloakConfig { }

--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/KeycloakBootWebSecurityConfig.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/KeycloakBootWebSecurityConfig.java
@@ -1,0 +1,66 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2020-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.terrestris.shogun.boot.config;
+
+import de.terrestris.shogun.config.DefaultWebSecurityConfig;
+import org.keycloak.adapters.springsecurity.KeycloakConfiguration;
+import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationProvider;
+import org.keycloak.adapters.springsecurity.config.KeycloakWebSecurityConfigurerAdapter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper;
+import org.springframework.security.core.session.SessionRegistryImpl;
+import org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy;
+import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
+
+@ConditionalOnExpression("${keycloak.enabled:true}")
+@Configuration
+@EnableWebSecurity
+@KeycloakConfiguration
+public class KeycloakBootWebSecurityConfig extends KeycloakWebSecurityConfigurerAdapter implements DefaultWebSecurityConfig {
+
+    @Autowired
+    public void configureGlobal(AuthenticationManagerBuilder auth) {
+        SimpleAuthorityMapper grantedAuthorityMapper = new SimpleAuthorityMapper();
+        grantedAuthorityMapper.setPrefix("ROLE_");
+
+        grantedAuthorityMapper.setConvertToUpperCase(true);
+
+        KeycloakAuthenticationProvider keycloakAuthenticationProvider = keycloakAuthenticationProvider();
+        keycloakAuthenticationProvider.setGrantedAuthoritiesMapper(grantedAuthorityMapper);
+        auth.authenticationProvider(keycloakAuthenticationProvider);
+    }
+
+    @Bean
+    @Override
+    protected SessionAuthenticationStrategy sessionAuthenticationStrategy() {
+        return new RegisterSessionAuthenticationStrategy(new SessionRegistryImpl());
+    }
+
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        super.configure(http);
+
+        customHttpConfiguration(http);
+    }
+
+}

--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/SimpleBootWebSecurityConfig.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/SimpleBootWebSecurityConfig.java
@@ -1,0 +1,62 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2020-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.terrestris.shogun.boot.config;
+
+import de.terrestris.shogun.config.DefaultWebSecurityConfig;
+import org.keycloak.adapters.springsecurity.KeycloakConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper;
+import org.springframework.security.core.session.SessionRegistryImpl;
+import org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy;
+import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
+
+@ConditionalOnExpression("${keycloak.enabled:false}")
+@Configuration
+@EnableWebSecurity
+@KeycloakConfiguration
+public class SimpleBootWebSecurityConfig extends WebSecurityConfigurerAdapter implements DefaultWebSecurityConfig {
+
+    @Autowired
+    public void configureGlobal(AuthenticationManagerBuilder auth) {
+        SimpleAuthorityMapper grantedAuthorityMapper = new SimpleAuthorityMapper();
+        grantedAuthorityMapper.setPrefix("ROLE_");
+
+        grantedAuthorityMapper.setConvertToUpperCase(true);
+
+        // TODO make this extendable
+    }
+
+    @Bean
+    protected SessionAuthenticationStrategy sessionAuthenticationStrategy() {
+        return new RegisterSessionAuthenticationStrategy(new SessionRegistryImpl());
+    }
+
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        super.configure(http);
+
+        customHttpConfiguration(http);
+    }
+
+}

--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/SimpleBootWebSecurityConfig.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/SimpleBootWebSecurityConfig.java
@@ -35,7 +35,7 @@ import org.springframework.security.web.authentication.session.SessionAuthentica
 @Configuration
 @EnableWebSecurity
 @KeycloakConfiguration
-public class SimpleBootWebSecurityConfig extends WebSecurityConfigurerAdapter implements DefaultWebSecurityConfig {
+public abstract class SimpleBootWebSecurityConfig extends WebSecurityConfigurerAdapter implements DefaultWebSecurityConfig {
 
     @Autowired
     public void configureGlobal(AuthenticationManagerBuilder auth) {

--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/service/ApplicationInfoService.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/service/ApplicationInfoService.java
@@ -19,6 +19,7 @@ package de.terrestris.shogun.boot.service;
 import de.terrestris.shogun.boot.dto.ApplicationInfo;
 import de.terrestris.shogun.lib.model.User;
 import de.terrestris.shogun.lib.security.SecurityContextUtil;
+import de.terrestris.shogun.lib.service.security.provider.UserProviderService;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.GrantedAuthority;
@@ -40,6 +41,9 @@ public class ApplicationInfoService {
     @Autowired
     protected SecurityContextUtil securityContextUtil;
 
+    @Autowired
+    private UserProviderService userProviderService;
+
     /**
      * Returns general application information such as the version.
      *
@@ -58,7 +62,7 @@ public class ApplicationInfoService {
             log.trace("Full stack trace: ", e);
         }
 
-        Optional<User> userOpt = securityContextUtil.getUserBySession();
+        Optional<User> userOpt = userProviderService.getUserBySession();
         ApplicationInfo applicationInfo = new ApplicationInfo();
 
         if (userOpt.isPresent()) {

--- a/shogun-boot/src/main/resources/db/migration/V0.11.0__rename_keycloak_id.sql
+++ b/shogun-boot/src/main/resources/db/migration/V0.11.0__rename_keycloak_id.sql
@@ -1,0 +1,4 @@
+alter table if exists shogun.users rename column keycloak_id to auth_provider_id;
+alter table if exists shogun.groups rename column keycloak_id to auth_provider_id;
+alter table if exists shogun_rev.users_rev rename column keycloak_id to auth_provider_id;
+alter table if exists shogun_rev.groups_rev rename column keycloak_id to auth_provider_id;

--- a/shogun-boot/src/test/java/de/terrestris/shogun/boot/config/JacksonConfigTest.java
+++ b/shogun-boot/src/test/java/de/terrestris/shogun/boot/config/JacksonConfigTest.java
@@ -60,7 +60,7 @@ public class JacksonConfigTest {
                 hasJtsModuleRegistered = true;
             }
         }
-        Assertions.assertTrue(hasJtsModuleRegistered, "JTS Module is not registrered in ObjectMapper");
+        Assertions.assertTrue(hasJtsModuleRegistered, "JTS Module is not registered in ObjectMapper");
     }
 
     @Test

--- a/shogun-boot/src/test/java/de/terrestris/shogun/boot/controller/BaseControllerTest.java
+++ b/shogun-boot/src/test/java/de/terrestris/shogun/boot/controller/BaseControllerTest.java
@@ -118,9 +118,9 @@ public abstract class BaseControllerTest<U extends BaseController, R extends Bas
     }
 
     public void initAdminUser() {
-        User adminUser = new User();
+        User<UserRepresentation> adminUser = new User();
         String keycloakId = "bf5efad6-50f5-448c-b808-60dc0259d70b";
-        adminUser.setKeycloakId(keycloakId);
+        adminUser.setAuthProviderId(keycloakId);
         UserRepresentation keycloakRepresentation = new UserRepresentation();
         keycloakRepresentation.setEmail("admin@shogun.de");
         keycloakRepresentation.setEnabled(true);
@@ -128,15 +128,15 @@ public abstract class BaseControllerTest<U extends BaseController, R extends Bas
         ArrayList<String> realmRoles = new ArrayList<>();
         realmRoles.add("ROLE_ADMIN");
         keycloakRepresentation.setRealmRoles(realmRoles);
-        adminUser.setKeycloakRepresentation(keycloakRepresentation);
+        adminUser.setProviderDetails(keycloakRepresentation);
 
         this.adminUser = userRepository.save(adminUser);
     }
 
     public void initUser() {
-        User user = new User();
+        User<UserRepresentation> user = new User();
         String keycloakId = "01e680f5-e8a4-460f-8897-12b4cf893739";
-        user.setKeycloakId(keycloakId);
+        user.setAuthProviderId(keycloakId);
         UserRepresentation keycloakRepresentation = new UserRepresentation();
         keycloakRepresentation.setEmail("user@shogun.de");
         keycloakRepresentation.setEnabled(true);
@@ -144,7 +144,7 @@ public abstract class BaseControllerTest<U extends BaseController, R extends Bas
         ArrayList<String> realmRoles = new ArrayList<>();
         realmRoles.add("ROLE_USER");
         keycloakRepresentation.setRealmRoles(realmRoles);
-        user.setKeycloakRepresentation(keycloakRepresentation);
+        user.setProviderDetails(keycloakRepresentation);
 
         this.user = userRepository.save(user);
     }
@@ -152,7 +152,7 @@ public abstract class BaseControllerTest<U extends BaseController, R extends Bas
     public void cleanupPermissions() {
         userInstancePermissionRepository.deleteAll();
         userClassPermissionRepository.deleteAll();
-    };
+    }
 
     public void deinitAdminUser() {
         userRepository.delete(this.adminUser);
@@ -166,14 +166,14 @@ public abstract class BaseControllerTest<U extends BaseController, R extends Bas
         repository.deleteAll();
     }
 
-    public Authentication getMockAuthentication(User mockUser) {
+    public Authentication getMockAuthentication(User<UserRepresentation> mockUser) {
         IDToken idToken = new IDToken();
-        idToken.setSubject(mockUser.getKeycloakId());
+        idToken.setSubject(mockUser.getAuthProviderId());
 
         KeycloakSecurityContext securityContext = new KeycloakSecurityContext(null, null, null, idToken);
-        KeycloakPrincipal<KeycloakSecurityContext> principal = new KeycloakPrincipal<>(mockUser.getKeycloakRepresentation().getUsername(), securityContext);
+        KeycloakPrincipal<KeycloakSecurityContext> principal = new KeycloakPrincipal<>(mockUser.getProviderDetails().getUsername(), securityContext);
 
-        Set<String> roles = new HashSet<>(mockUser.getKeycloakRepresentation().getRealmRoles());
+        Set<String> roles = new HashSet<>(mockUser.getProviderDetails().getRealmRoles());
         SimpleKeycloakAccount account = new SimpleKeycloakAccount(principal, roles, null);
 
         return new KeycloakAuthenticationToken(account, false);

--- a/shogun-boot/src/test/java/de/terrestris/shogun/boot/controller/BaseControllerTest.java
+++ b/shogun-boot/src/test/java/de/terrestris/shogun/boot/controller/BaseControllerTest.java
@@ -52,11 +52,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.*;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
@@ -134,9 +130,7 @@ public abstract class BaseControllerTest<U extends BaseController, R extends Bas
         keycloakRepresentation.setRealmRoles(realmRoles);
         adminUser.setKeycloakRepresentation(keycloakRepresentation);
 
-        User persistedAdminUser = userRepository.save(adminUser);
-
-        this.adminUser = persistedAdminUser;
+        this.adminUser = userRepository.save(adminUser);
     }
 
     public void initUser() {
@@ -152,9 +146,7 @@ public abstract class BaseControllerTest<U extends BaseController, R extends Bas
         keycloakRepresentation.setRealmRoles(realmRoles);
         user.setKeycloakRepresentation(keycloakRepresentation);
 
-        User persistedUser = userRepository.save(user);
-
-        this.user = persistedUser;
+        this.user = userRepository.save(user);
     }
 
     public void cleanupPermissions() {
@@ -181,11 +173,10 @@ public abstract class BaseControllerTest<U extends BaseController, R extends Bas
         KeycloakSecurityContext securityContext = new KeycloakSecurityContext(null, null, null, idToken);
         KeycloakPrincipal<KeycloakSecurityContext> principal = new KeycloakPrincipal<>(mockUser.getKeycloakRepresentation().getUsername(), securityContext);
 
-        Set<String> roles = mockUser.getKeycloakRepresentation().getRealmRoles().stream().collect(Collectors.toSet());
+        Set<String> roles = new HashSet<>(mockUser.getKeycloakRepresentation().getRealmRoles());
         SimpleKeycloakAccount account = new SimpleKeycloakAccount(principal, roles, null);
-        Authentication authentication = new KeycloakAuthenticationToken(account, false);
 
-        return authentication;
+        return new KeycloakAuthenticationToken(account, false);
     }
 
     @BeforeEach

--- a/shogun-boot/src/test/java/de/terrestris/shogun/boot/controller/GroupControllerTest.java
+++ b/shogun-boot/src/test/java/de/terrestris/shogun/boot/controller/GroupControllerTest.java
@@ -39,9 +39,9 @@ public class GroupControllerTest extends BaseControllerTest<GroupController, Gro
         Group entity2 = new Group();
         Group entity3 = new Group();
 
-        entity1.setKeycloakId(UUID.randomUUID().toString());
-        entity2.setKeycloakId(UUID.randomUUID().toString());
-        entity3.setKeycloakId(UUID.randomUUID().toString());
+        entity1.setAuthProviderId(UUID.randomUUID().toString());
+        entity2.setAuthProviderId(UUID.randomUUID().toString());
+        entity3.setAuthProviderId(UUID.randomUUID().toString());
 
         ArrayList<Group> entities = new ArrayList<>();
 

--- a/shogun-boot/src/test/java/de/terrestris/shogun/boot/controller/GroupControllerTest.java
+++ b/shogun-boot/src/test/java/de/terrestris/shogun/boot/controller/GroupControllerTest.java
@@ -49,9 +49,7 @@ public class GroupControllerTest extends BaseControllerTest<GroupController, Gro
         entities.add(entity2);
         entities.add(entity3);
 
-        List<Group> persistedEntities = (List<Group>) repository.saveAll(entities);
-
-        testData = persistedEntities;
+        testData = (List<Group>) repository.saveAll(entities);
     }
 
 }

--- a/shogun-boot/src/test/java/de/terrestris/shogun/boot/controller/UserControllerTest.java
+++ b/shogun-boot/src/test/java/de/terrestris/shogun/boot/controller/UserControllerTest.java
@@ -54,9 +54,9 @@ public class UserControllerTest extends BaseControllerTest<UserController, UserR
         User entity2 = new User();
         User entity3 = new User();
 
-        entity1.setKeycloakId(UUID.randomUUID().toString());
-        entity2.setKeycloakId(UUID.randomUUID().toString());
-        entity3.setKeycloakId(UUID.randomUUID().toString());
+        entity1.setAuthProviderId(UUID.randomUUID().toString());
+        entity2.setAuthProviderId(UUID.randomUUID().toString());
+        entity3.setAuthProviderId(UUID.randomUUID().toString());
 
         ArrayList<User> entities = new ArrayList<>();
 

--- a/shogun-config/src/main/java/de/terrestris/shogun/config/DefaultWebSecurityConfig.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/config/DefaultWebSecurityConfig.java
@@ -14,27 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.terrestris.shogun.boot.config;
+package de.terrestris.shogun.config;
 
-import de.terrestris.shogun.config.WebSecurityConfig;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
-import org.springframework.security.web.util.matcher.RequestMatcher;
 
-@Configuration
-@EnableWebSecurity
-public class BootWebSecurityConfig extends WebSecurityConfig {
+public interface DefaultWebSecurityConfig extends WebSecurityConfig {
 
-    RequestMatcher csrfRequestMatcher = httpServletRequest -> {
-        String refererHeader = httpServletRequest.getHeader("Referer");
-
-        return refererHeader != null && refererHeader.endsWith("swagger-ui/index.html");
-    };
-
-    @Override
-    protected void customHttpConfiguration(HttpSecurity http) throws Exception {
+    default void customHttpConfiguration(HttpSecurity http) throws Exception {
         http
             .authorizeRequests()
                 .antMatchers(
@@ -66,7 +53,7 @@ public class BootWebSecurityConfig extends WebSecurityConfig {
                 .httpBasic()
             .and()
                 .formLogin()
-                    .defaultSuccessUrl("/index.html")
+                .defaultSuccessUrl("/index.html")
                     .permitAll()
             .and()
                 .rememberMe()

--- a/shogun-config/src/main/java/de/terrestris/shogun/config/KeycloakConfig.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/config/KeycloakConfig.java
@@ -25,12 +25,14 @@ import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
  * Credits to https://stackoverflow.com/questions/57787768/issues-running-example-keycloak-spring-boot-app
  */
+@ConditionalOnExpression("${keycloak.enabled:true}")
 @Configuration
 public abstract class KeycloakConfig {
 

--- a/shogun-config/src/main/java/de/terrestris/shogun/config/WebSecurityConfig.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/config/WebSecurityConfig.java
@@ -16,45 +16,21 @@
  */
 package de.terrestris.shogun.config;
 
-import org.keycloak.adapters.springsecurity.KeycloakConfiguration;
-import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationProvider;
-import org.keycloak.adapters.springsecurity.config.KeycloakWebSecurityConfigurerAdapter;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper;
-import org.springframework.security.core.session.SessionRegistryImpl;
-import org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy;
-import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 
-@KeycloakConfiguration
-public abstract class WebSecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
+public interface WebSecurityConfig {
 
-    @Autowired
-    public void configureGlobal(AuthenticationManagerBuilder auth) {
-        SimpleAuthorityMapper grantedAuthorityMapper = new SimpleAuthorityMapper();
-        grantedAuthorityMapper.setPrefix("ROLE_");
+    RequestMatcher csrfRequestMatcher = httpServletRequest -> {
+        String refererHeader = httpServletRequest.getHeader("Referer");
 
-        grantedAuthorityMapper.setConvertToUpperCase(true);
+        return refererHeader != null && refererHeader.endsWith("swagger-ui/index.html");
+    };
 
-        KeycloakAuthenticationProvider keycloakAuthenticationProvider = keycloakAuthenticationProvider();
-        keycloakAuthenticationProvider.setGrantedAuthoritiesMapper(grantedAuthorityMapper);
-        auth.authenticationProvider(keycloakAuthenticationProvider);
-    }
-
-    @Bean
-    @Override
-    protected SessionAuthenticationStrategy sessionAuthenticationStrategy() {
-        return new RegisterSessionAuthenticationStrategy(new SessionRegistryImpl());
-    }
-
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        super.configure(http);
-
+    default void configure(HttpSecurity http) throws Exception {
         customHttpConfiguration(http);
     }
 
-    protected abstract void customHttpConfiguration(HttpSecurity http) throws Exception;
+    void customHttpConfiguration(HttpSecurity http) throws Exception;
+
 }

--- a/shogun-config/src/main/resources/application-base.yml
+++ b/shogun-config/src/main/resources/application-base.yml
@@ -93,7 +93,7 @@ spring:
 
 keycloak:
   enabled: true
-  auth-server-url: https://${?KEYCLOAK_HOST}/keycloak/auth
+  auth-server-url: https://${KEYCLOAK_HOST:shogun-keycloak}/keycloak/auth
   realm: SpringBootKeycloak
   resource: shogun-app
   public-client: true

--- a/shogun-config/src/main/resources/application-base.yml
+++ b/shogun-config/src/main/resources/application-base.yml
@@ -92,7 +92,8 @@ spring:
     password: pass
 
 keycloak:
-  auth-server-url: https://${KEYCLOAK_HOST}/keycloak/auth
+  enabled: true
+  auth-server-url: https://${?KEYCLOAK_HOST}/keycloak/auth
   realm: SpringBootKeycloak
   resource: shogun-app
   public-client: true

--- a/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/config/InterceptorWebSecurityConfig.java
+++ b/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/config/InterceptorWebSecurityConfig.java
@@ -24,7 +24,7 @@ import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
 @Configuration
-public class InterceptorWebSecurityConfig extends WebSecurityConfig {
+public class InterceptorWebSecurityConfig implements WebSecurityConfig {
 
     RequestMatcher csrfRequestMatcher = httpServletRequest -> {
         String refererHeader = httpServletRequest.getHeader("Referer");
@@ -32,7 +32,7 @@ public class InterceptorWebSecurityConfig extends WebSecurityConfig {
     };
 
     @Override
-    protected void customHttpConfiguration(HttpSecurity http) throws Exception {
+    public void customHttpConfiguration(HttpSecurity http) throws Exception {
         http
             .authorizeRequests()
             .antMatchers(

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/GroupController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/GroupController.java
@@ -20,7 +20,6 @@ import de.terrestris.shogun.lib.model.Group;
 import de.terrestris.shogun.lib.model.User;
 import de.terrestris.shogun.lib.service.GroupService;
 import de.terrestris.shogun.lib.service.UserService;
-import de.terrestris.shogun.lib.service.security.provider.GroupProviderService;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -40,9 +39,6 @@ public class GroupController extends BaseController<GroupService, Group> {
 
     @Autowired
     private UserService userService;
-
-    @Autowired
-    GroupProviderService groupProviderService;
 
     @GetMapping("/user/{id}")
     @ResponseStatus(HttpStatus.OK)
@@ -77,7 +73,7 @@ public class GroupController extends BaseController<GroupService, Group> {
     @ResponseStatus(HttpStatus.OK)
     public List<User> getGroupMembers(@PathVariable("id") String keycloakId) {
         try {
-            return groupProviderService.getGroupMembers(keycloakId);
+            return service.getGroupMembers(keycloakId);
         } catch (Exception e) {
             log.error("Error while requesting the members of keycloak group with ID {}: \n {}",
                 keycloakId, e.getMessage());

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/listener/KeycloakEventListener.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/listener/KeycloakEventListener.java
@@ -19,7 +19,7 @@ package de.terrestris.shogun.lib.listener;
 
 import de.terrestris.shogun.lib.event.KeycloakEvent;
 import de.terrestris.shogun.lib.service.GroupService;
-import de.terrestris.shogun.lib.service.UserService;
+import de.terrestris.shogun.lib.service.security.provider.UserProviderService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class KeycloakEventListener {
     @Autowired
-    UserService userService;
+    UserProviderService userProviderService;
 
     @Autowired
     GroupService groupService;
@@ -35,7 +35,7 @@ public class KeycloakEventListener {
     @EventListener
     public void onKeycloakEvent(KeycloakEvent event) {
         switch (event.getEventType()) {
-            case USER_CREATED -> userService.findOrCreateByKeyCloakId(event.getKeycloakId());
+            case USER_CREATED -> userProviderService.findOrCreateByProviderId(event.getKeycloakId());
             case GROUP_CREATED -> groupService.findOrCreateByKeycloakId(event.getKeycloakId());
         }
     }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/listener/LoginListener.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/listener/LoginListener.java
@@ -19,6 +19,7 @@ package de.terrestris.shogun.lib.listener;
 import de.terrestris.shogun.lib.security.SecurityContextUtil;
 import de.terrestris.shogun.lib.service.UserService;
 import de.terrestris.shogun.lib.service.security.provider.UserProviderService;
+import de.terrestris.shogun.lib.util.KeycloakUtil;
 import lombok.extern.log4j.Log4j2;
 import org.keycloak.KeycloakPrincipal;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,7 +53,7 @@ public class LoginListener implements ApplicationListener<InteractiveAuthenticat
             return;
         }
 
-        String keycloakUserId = SecurityContextUtil.getKeycloakUserIdFromAuthentication(authentication);
+        String keycloakUserId = KeycloakUtil.getKeycloakUserIdFromAuthentication(authentication);
 
         // Add missing user to shogun db
         userProviderService.findOrCreateByProviderId(keycloakUserId);

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/listener/LoginListener.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/listener/LoginListener.java
@@ -18,6 +18,7 @@ package de.terrestris.shogun.lib.listener;
 
 import de.terrestris.shogun.lib.security.SecurityContextUtil;
 import de.terrestris.shogun.lib.service.UserService;
+import de.terrestris.shogun.lib.service.security.provider.UserProviderService;
 import lombok.extern.log4j.Log4j2;
 import org.keycloak.KeycloakPrincipal;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +38,9 @@ public class LoginListener implements ApplicationListener<InteractiveAuthenticat
     @Autowired
     protected UserService userService;
 
+    @Autowired
+    private UserProviderService userProviderService;
+
     @Override
     @Transactional
     public synchronized void onApplicationEvent(InteractiveAuthenticationSuccessEvent event) {
@@ -51,6 +55,6 @@ public class LoginListener implements ApplicationListener<InteractiveAuthenticat
         String keycloakUserId = SecurityContextUtil.getKeycloakUserIdFromAuthentication(authentication);
 
         // Add missing user to shogun db
-        userService.findOrCreateByKeyCloakId(keycloakUserId);
+        userProviderService.findOrCreateByProviderId(keycloakUserId);
     }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Group.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Group.java
@@ -16,23 +16,14 @@
  */
 package de.terrestris.shogun.lib.model;
 
-import javax.persistence.Cacheable;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
-import javax.persistence.Transient;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
-import org.keycloak.representations.idm.GroupRepresentation;
+
+import javax.persistence.*;
 
 @Entity(name = "groups")
 @Table(schema = "shogun")
@@ -45,20 +36,20 @@ import org.keycloak.representations.idm.GroupRepresentation;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class Group extends BaseEntity {
+public class Group<T> extends BaseEntity {
 
     @Column(unique = true, nullable = false)
     @Schema(
         description = "The internal Keycloak ID of the group.",
         example = "image/png"
     )
-    private String keycloakId;
+    private String authProviderId;
 
     @Transient
     @Schema(
         description = "The group details stored in the associated Keycloak entity.",
         accessMode = Schema.AccessMode.READ_ONLY
     )
-    private GroupRepresentation keycloakRepresentation;
+    private T providerDetails;
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/User.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/User.java
@@ -18,27 +18,15 @@ package de.terrestris.shogun.lib.model;
 
 import de.terrestris.shogun.lib.model.jsonb.UserClientConfig;
 import de.terrestris.shogun.lib.model.jsonb.UserDetails;
-
-import javax.persistence.Basic;
-import javax.persistence.Cacheable;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.Table;
-import javax.persistence.Transient;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Type;
 import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
-import org.keycloak.representations.idm.UserRepresentation;
+
+import javax.persistence.*;
 
 @Entity(name = "users")
 @Table(schema = "shogun")
@@ -51,29 +39,28 @@ import org.keycloak.representations.idm.UserRepresentation;
 @NoArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class User extends BaseEntity {
+public class User<T> extends BaseEntity {
 
     @Column(unique = true, nullable = false)
     @Schema(
-        description = "The internal Keycloak ID of the user.",
+        description = "The backend ID of the user.",
         required = true
     )
-    // TODO Rename to authProviderId
-    private String keycloakId;
+    private String authProviderId;
 
     @Transient
     @Schema(
-        description = "The user details stored in the associated Keycloak entity.",
+        description = "The user details stored in the associated provider.",
         accessMode = Schema.AccessMode.READ_ONLY
     )
-    private UserRepresentation keycloakRepresentation;
+    private T providerDetails;
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
     @Basic(fetch = FetchType.LAZY)
     @ToString.Exclude
     @Schema(
-        description = "Custom user details that aren't stored inside the Keycloak representation."
+        description = "Custom user details that aren't stored inside the provider."
     )
     private UserDetails details;
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/User.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/User.java
@@ -58,6 +58,7 @@ public class User extends BaseEntity {
         description = "The internal Keycloak ID of the user.",
         required = true
     )
+    // TODO Rename to authProviderId
     private String keycloakId;
 
     @Transient

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/GroupRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/GroupRepository.java
@@ -17,16 +17,17 @@
 package de.terrestris.shogun.lib.repository;
 
 import de.terrestris.shogun.lib.model.Group;
-import java.util.Optional;
-import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.stereotype.Repository;
+
+import javax.persistence.QueryHint;
+import java.util.Optional;
 
 @Repository
 public interface GroupRepository extends BaseCrudRepository<Group, Long>, JpaSpecificationExecutor<Group> {
 
     @QueryHints(@QueryHint(name = org.hibernate.annotations.QueryHints.CACHEABLE, value = "true"))
-    Optional<Group> findByKeycloakId(String keycloakId);
+    Optional<Group> findByAuthProviderId(String authProviderId);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/UserRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/UserRepository.java
@@ -17,16 +17,17 @@
 package de.terrestris.shogun.lib.repository;
 
 import de.terrestris.shogun.lib.model.User;
-import java.util.Optional;
-import javax.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.stereotype.Repository;
+
+import javax.persistence.QueryHint;
+import java.util.Optional;
 
 @Repository
 public interface UserRepository extends BaseCrudRepository<User, Long>, JpaSpecificationExecutor<User> {
 
     @QueryHints(@QueryHint(name = org.hibernate.annotations.QueryHints.CACHEABLE, value = "true"))
-    Optional<User> findByKeycloakId(String keycloakId);
+    Optional<User> findByAuthProviderId(String authProviderId);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/security/SecurityContextUtil.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/security/SecurityContextUtil.java
@@ -17,7 +17,6 @@
 package de.terrestris.shogun.lib.security;
 
 import de.terrestris.shogun.lib.model.User;
-import de.terrestris.shogun.lib.repository.GroupRepository;
 import de.terrestris.shogun.lib.repository.UserRepository;
 import de.terrestris.shogun.lib.service.security.provider.UserProviderService;
 import lombok.extern.log4j.Log4j2;
@@ -43,9 +42,6 @@ public class SecurityContextUtil {
 
     @Autowired
     protected UserRepository userRepository;
-
-    @Autowired
-    protected GroupRepository groupRepository;
 
     @Autowired
     private UserProviderService userProviderService;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/security/access/BasePermissionEvaluator.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/security/access/BasePermissionEvaluator.java
@@ -22,6 +22,7 @@ import de.terrestris.shogun.lib.model.User;
 import de.terrestris.shogun.lib.security.SecurityContextUtil;
 import de.terrestris.shogun.lib.security.access.entity.BaseEntityPermissionEvaluator;
 import de.terrestris.shogun.lib.security.access.entity.DefaultPermissionEvaluator;
+import de.terrestris.shogun.lib.service.security.provider.UserProviderService;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.PermissionEvaluator;
@@ -44,6 +45,9 @@ public class BasePermissionEvaluator implements PermissionEvaluator {
 
     @Autowired
     protected SecurityContextUtil securityContextUtil;
+
+    @Autowired
+    private UserProviderService userProviderService;
 
     @Override
     public boolean hasPermission(Authentication authentication, Object targetDomainObject,
@@ -69,7 +73,7 @@ public class BasePermissionEvaluator implements PermissionEvaluator {
         }
 
         // fetch user from securityUtil
-        Optional<User> userOpt = securityContextUtil.getUserFromAuthentication(authentication);
+        Optional<User> userOpt = userProviderService.getUserFromAuthentication(authentication);
         User user = userOpt.orElse(null);
 
         final BaseEntity persistentObject;
@@ -108,7 +112,7 @@ public class BasePermissionEvaluator implements PermissionEvaluator {
         }
 
         // fetch user from securityUtil
-        Optional<User> userOpt = securityContextUtil.getUserFromAuthentication(authentication);
+        Optional<User> userOpt = userProviderService.getUserFromAuthentication(authentication);
         User user = userOpt.orElse(null);
 
         final PermissionType permission = PermissionType.valueOf((String) permissionObject);

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/GroupService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/GroupService.java
@@ -109,7 +109,7 @@ public class GroupService extends BaseService<GroupRepository, Group> {
     @Transactional
     @PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#keycloakGroupId, 'DELETE')")
     public void deleteByKeycloakId(String keycloakGroupId) {
-        Optional<Group> groupOptional = repository.findByKeycloakId(keycloakGroupId);
+        Optional<Group> groupOptional = repository.findByAuthProviderId(keycloakGroupId);
         Group group = groupOptional.orElse(null);
         if (group == null) {
             log.debug("Group with keycloak id {} was deleted in Keycloak. It did not exists in SHOGun DB. No action needed.", keycloakGroupId);

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/GroupService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/GroupService.java
@@ -19,19 +19,16 @@ package de.terrestris.shogun.lib.service;
 import de.terrestris.shogun.lib.model.Group;
 import de.terrestris.shogun.lib.model.User;
 import de.terrestris.shogun.lib.repository.GroupRepository;
-import de.terrestris.shogun.lib.repository.UserRepository;
 import de.terrestris.shogun.lib.service.security.provider.GroupProviderService;
 import lombok.extern.log4j.Log4j2;
-import org.keycloak.admin.client.resource.GroupResource;
-import org.keycloak.representations.idm.GroupRepresentation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.security.access.prepost.PostFilter;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -39,20 +36,14 @@ import java.util.Optional;
 @Log4j2
 public class GroupService extends BaseService<GroupRepository, Group> {
 
-//    @Autowired
-//    KeycloakUtil keycloakUtil;
-
     @Autowired
     GroupProviderService groupProviderService;
-
-    @Autowired
-    UserRepository userRepository;
 
     @PostFilter("hasRole('ROLE_ADMIN') or hasPermission(filterObject, 'READ')")
     @Transactional(readOnly = true)
     @Override
     public List<Group> findAll() {
-        List<Group> groups = (List<Group>) repository.findAll();
+        List<Group> groups = repository.findAll();
 
         for (Group group : groups) {
             groupProviderService.setTransientRepresentations(group);
@@ -72,6 +63,11 @@ public class GroupService extends BaseService<GroupRepository, Group> {
         }
 
         return groups;
+    }
+
+    @PostFilter("hasRole('ROLE_ADMIN') or hasPermission(filterObject, 'READ')")
+    public List<User> getGroupMembers(String id) {
+        return groupProviderService.getGroupMembers(id);
     }
 
     @PostAuthorize("hasRole('ROLE_ADMIN') or hasPermission(returnObject.orElse(null), 'READ')")
@@ -94,20 +90,9 @@ public class GroupService extends BaseService<GroupRepository, Group> {
      * @return
      */
     @Transactional
-//    @PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#keycloakGroupId, 'CREATE')")
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#keycloakGroupId, 'CREATE')")
     public Group findOrCreateByKeycloakId(String keycloakGroupId) {
-        Optional<Group> groupOptional = repository.findByKeycloakId(keycloakGroupId);
-        Group group = groupOptional.orElse(null);
-
-        if (group == null) {
-            group = new Group(keycloakGroupId, null);
-            repository.save(group);
-
-            log.info("Group with keycloak id {} did not yet exist in the SHOGun DB and was therefore created.", keycloakGroupId);
-            return group;
-        }
-
-        return group;
+        return groupProviderService.findOrCreateByProviderId(keycloakGroupId);
     }
 
     @PostFilter("hasRole('ROLE_ADMIN') or hasPermission(filterObject, 'READ')")
@@ -122,7 +107,7 @@ public class GroupService extends BaseService<GroupRepository, Group> {
      * @param keycloakGroupId
      */
     @Transactional
-//    @PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#keycloakGroupId, 'DELETE')")
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#keycloakGroupId, 'DELETE')")
     public void deleteByKeycloakId(String keycloakGroupId) {
         Optional<Group> groupOptional = repository.findByKeycloakId(keycloakGroupId);
         Group group = groupOptional.orElse(null);

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/UserService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/UserService.java
@@ -16,15 +16,11 @@
  */
 package de.terrestris.shogun.lib.service;
 
-import de.terrestris.shogun.lib.enumeration.PermissionCollectionType;
-import de.terrestris.shogun.lib.event.OnRegistrationConfirmedEvent;
 import de.terrestris.shogun.lib.model.User;
 import de.terrestris.shogun.lib.repository.UserRepository;
 import de.terrestris.shogun.lib.service.security.provider.UserProviderService;
 import lombok.extern.log4j.Log4j2;
-import org.keycloak.representations.idm.GroupRepresentation;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.security.access.prepost.PostFilter;
@@ -83,7 +79,7 @@ public class UserService extends BaseService<UserRepository, User> {
     @PostAuthorize("hasRole('ROLE_ADMIN') or hasPermission(returnObject.orElse(null), 'READ')")
     @Transactional(readOnly = true)
     public Optional<User> findByKeyCloakId(String keycloakId) {
-        Optional<User> user = repository.findByKeycloakId(keycloakId);
+        Optional<User> user = repository.findByAuthProviderId(keycloakId);
 
         if (user.isPresent()) {
             userProviderService.setTransientRepresentations(user.get());
@@ -100,7 +96,7 @@ public class UserService extends BaseService<UserRepository, User> {
     @Transactional
 //    @PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#keycloakUserId, 'DELETE')")
     public void deleteByKeycloakId(String keycloakUserId) {
-        Optional<User> userOptional = repository.findByKeycloakId(keycloakUserId);
+        Optional<User> userOptional = repository.findByAuthProviderId(keycloakUserId);
         User user = userOptional.orElse(null);
         if (user == null) {
             log.debug("User with keycloak id {} was deleted in Keycloak. It did not exists in SHOGun DB. No action needed.", keycloakUserId);

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/UserService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/UserService.java
@@ -20,11 +20,9 @@ import de.terrestris.shogun.lib.enumeration.PermissionCollectionType;
 import de.terrestris.shogun.lib.event.OnRegistrationConfirmedEvent;
 import de.terrestris.shogun.lib.model.User;
 import de.terrestris.shogun.lib.repository.UserRepository;
-import de.terrestris.shogun.lib.util.KeycloakUtil;
+import de.terrestris.shogun.lib.service.security.provider.UserProviderService;
 import lombok.extern.log4j.Log4j2;
-import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.representations.idm.GroupRepresentation;
-import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.jpa.domain.Specification;
@@ -41,13 +39,7 @@ import java.util.Optional;
 public class UserService extends BaseService<UserRepository, User> {
 
     @Autowired
-    KeycloakUtil keycloakUtil;
-
-    @Autowired
-    GroupService groupService;
-
-    @Autowired
-    ApplicationEventPublisher eventPublisher;
+    UserProviderService userProviderService;
 
     @PostFilter("hasRole('ROLE_ADMIN') or hasPermission(filterObject, 'READ')")
     @Transactional(readOnly = true)
@@ -56,7 +48,7 @@ public class UserService extends BaseService<UserRepository, User> {
         List<User> users = repository.findAll();
 
         for (User user : users) {
-            this.setTransientKeycloakRepresentations(user);
+            userProviderService.setTransientRepresentations(user);
         }
 
         return users;
@@ -69,7 +61,7 @@ public class UserService extends BaseService<UserRepository, User> {
         List<User> users = (List<User>) repository.findAll(specification);
 
         for (User user : users) {
-            this.setTransientKeycloakRepresentations(user);
+            userProviderService.setTransientRepresentations(user);
         }
 
         return users;
@@ -82,7 +74,7 @@ public class UserService extends BaseService<UserRepository, User> {
         Optional<User> user = repository.findById(id);
 
         if (user.isPresent()) {
-            this.setTransientKeycloakRepresentations(user.get());
+            userProviderService.setTransientRepresentations(user.get());
         }
 
         return user;
@@ -94,51 +86,9 @@ public class UserService extends BaseService<UserRepository, User> {
         Optional<User> user = repository.findByKeycloakId(keycloakId);
 
         if (user.isPresent()) {
-            this.setTransientKeycloakRepresentations(user.get());
+            userProviderService.setTransientRepresentations(user.get());
         }
 
-        return user;
-    }
-
-    /**
-     * Finds a User by the passed keycloak ID. If it does not exists in the SHOGun DB it gets created.
-     *
-     * The groups of the user are also checked and created if needed.
-     *
-     * @param keycloakUserId
-     * @return
-     */
-//    @PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#keycloakUserId, 'CREATE')")
-    @Transactional
-    public User findOrCreateByKeyCloakId(String keycloakUserId) {
-        Optional<User> userOptional = repository.findByKeycloakId(keycloakUserId);
-        User user = userOptional.orElse(null);
-
-        // User is not yet it SHOGun DB
-        if (user == null) {
-            user = new User(keycloakUserId, null, null, null);
-            repository.save(user);
-
-            // If the user doesn't exist, we assume it's the first login after registration.
-            eventPublisher.publishEvent(new OnRegistrationConfirmedEvent(user));
-
-            // Add admin instance permissions for the user.
-            userInstancePermissionService.setPermission(user, user, PermissionCollectionType.ADMIN);
-
-            log.info("User with keycloak id {} did not yet exist in the SHOGun DB and was therefore created.", keycloakUserId);
-            this.setTransientKeycloakRepresentations(user);
-            return user;
-        }
-
-        List<GroupRepresentation> keycloakUserGroups = keycloakUtil.getKeycloakUserGroups(user);
-
-        // Add missing groups to shogun db
-        keycloakUserGroups
-            .stream()
-            .map(GroupRepresentation::getId)
-            .forEach(groupService::findOrCreateByKeycloakId);
-
-        this.setTransientKeycloakRepresentations(user);
         return user;
     }
 
@@ -159,22 +109,6 @@ public class UserService extends BaseService<UserRepository, User> {
         userInstancePermissionService.deleteAllForEntity(user);
         repository.delete(user);
         log.info("User with keycloak id {} was deleted in Keycloak and was therefore deleted in SHOGun DB, too.", keycloakUserId);
-    }
-
-    private User setTransientKeycloakRepresentations(User user) {
-        UserResource userResource = keycloakUtil.getUserResource(user);
-
-        try {
-            UserRepresentation userRepresentation = userResource.toRepresentation();
-            user.setKeycloakRepresentation(userRepresentation);
-        } catch (Exception e) {
-            log.warn("Could not get the UserRepresentation for user with SHOGun ID {} and " +
-                    "Keycloak ID {}. This may happen if the user is not available in Keycloak.",
-                    user.getId(), user.getKeycloakId());
-            log.trace("Full stack trace: ", e);
-        }
-
-        return user;
     }
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupClassPermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupClassPermissionService.java
@@ -56,7 +56,7 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
     public List<GroupClassPermission> findFor(Group group) {
 
         log.trace("Getting all group class permissions for group with Keycloak ID {}",
-            group.getKeycloakId());
+            group.getAuthProviderId());
 
         return repository.findAllByGroup(group);
     }
@@ -72,7 +72,7 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
         String className = entity.getClass().getCanonicalName();
 
         log.trace("Getting all group class permissions for group with Keycloak ID {} and " +
-            "entity class {}", group.getKeycloakId(), className);
+            "entity class {}", group.getAuthProviderId(), className);
 
         return repository.findByGroupIdAndClassName(group.getId(), className);
     }
@@ -88,7 +88,7 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
         String className = clazz.getCanonicalName();
 
         log.trace("Getting all group class permissions for group with Keycloak ID {} and " +
-            "entity class {}", group.getKeycloakId(), className);
+            "entity class {}", group.getAuthProviderId(), className);
 
         return repository.findByGroupIdAndClassName(group.getId(), className);
     }
@@ -105,7 +105,7 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
         String className = clazz.getCanonicalName();
 
         log.trace("Getting all group class permissions for user with Keycloak ID {} and " +
-            "entity class {}", user.getKeycloakId(), className);
+            "entity class {}", user.getAuthProviderId(), className);
 
         // Get all groups of the user from Keycloak
         List<Group> groups = groupProviderService.findByUser(user);
@@ -135,8 +135,8 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
     public Optional<GroupClassPermission> findFor(BaseEntity entity, Group group, User user) {
 
         log.trace("Getting all group class permissions for user with Keycloak ID {} and " +
-            "entity with ID {} in the context of group with Keycloak ID {}", user.getKeycloakId(),
-            entity.getId(), group.getKeycloakId());
+            "entity with ID {} in the context of group with Keycloak ID {}", user.getAuthProviderId(),
+            entity.getId(), group.getAuthProviderId());
 
         List<Group> userGroups = groupProviderService.findByUser(user);
         boolean isUserMemberInGroup = userGroups.contains(group);
@@ -231,7 +231,7 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
         // Check if there is already an existing permission set on the entity
         if (existingPermission.isPresent()) {
             log.debug("Permission is already set for class {} and group with " +
-                "Keycloak ID {}: {}", clazz, group.getKeycloakId(), permissionCollection);
+                "Keycloak ID {}: {}", clazz, group.getAuthProviderId(), permissionCollection);
 
             // Remove the existing one
             repository.delete(existingPermission.get());

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupClassPermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupClassPermissionService.java
@@ -26,13 +26,13 @@ import de.terrestris.shogun.lib.repository.security.permission.GroupClassPermiss
 import de.terrestris.shogun.lib.repository.security.permission.PermissionCollectionRepository;
 import de.terrestris.shogun.lib.security.SecurityContextUtil;
 import de.terrestris.shogun.lib.service.BaseService;
-import de.terrestris.shogun.lib.util.KeycloakUtil;
-import java.util.List;
-import java.util.Optional;
-
+import de.terrestris.shogun.lib.service.security.provider.GroupProviderService;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @Log4j2
@@ -42,10 +42,10 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
     protected SecurityContextUtil securityContextUtil;
 
     @Autowired
-    protected KeycloakUtil keycloakUtil;
+    protected PermissionCollectionRepository permissionCollectionRepository;
 
     @Autowired
-    protected PermissionCollectionRepository permissionCollectionRepository;
+    private GroupProviderService groupProviderService;
 
     /**
      * Returns all {@link GroupClassPermission} for the given query arguments.
@@ -138,7 +138,8 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
             "entity with ID {} in the context of group with Keycloak ID {}", user.getKeycloakId(),
             entity.getId(), group.getKeycloakId());
 
-        boolean isUserMemberInGroup = keycloakUtil.isUserInGroup(user, group);
+        List<Group> userGroups = groupProviderService.findByUser(user);
+        boolean isUserMemberInGroup = userGroups.contains(group);
 
         if (!isUserMemberInGroup) {
             log.trace("The user is not a member of the given group, no permissions available.");

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupClassPermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupClassPermissionService.java
@@ -108,7 +108,7 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
             "entity class {}", user.getKeycloakId(), className);
 
         // Get all groups of the user from Keycloak
-        List<Group> groups = securityContextUtil.getGroupsForUser(user);
+        List<Group> groups = groupProviderService.findByUser(user);
         Optional<GroupClassPermission> gcp = Optional.empty();
         for (Group g : groups) {
             Optional<GroupClassPermission> permissionsForGroup = repository

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionService.java
@@ -111,7 +111,7 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
             "entity with ID {}", user.getKeycloakId(), entity.getId());
 
         // Get all groups of the user from Keycloak
-        List<Group> groups = securityContextUtil.getGroupsForUser(user);
+        List<Group> groups = groupProviderService.findByUser(user);
         Optional<GroupInstancePermission> gip = Optional.empty();
         for (Group g : groups) {
             Optional<GroupInstancePermission> permissionsForGroup = repository

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionService.java
@@ -26,14 +26,14 @@ import de.terrestris.shogun.lib.repository.security.permission.GroupInstancePerm
 import de.terrestris.shogun.lib.repository.security.permission.PermissionCollectionRepository;
 import de.terrestris.shogun.lib.security.SecurityContextUtil;
 import de.terrestris.shogun.lib.service.BaseService;
-import de.terrestris.shogun.lib.util.KeycloakUtil;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
+import de.terrestris.shogun.lib.service.security.provider.GroupProviderService;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @Log4j2
@@ -43,10 +43,10 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
     protected SecurityContextUtil securityContextUtil;
 
     @Autowired
-    protected KeycloakUtil keycloakUtil;
+    protected PermissionCollectionRepository permissionCollectionRepository;
 
     @Autowired
-    protected PermissionCollectionRepository permissionCollectionRepository;
+    private GroupProviderService groupProviderService;
 
     /**
      * Returns all {@link GroupInstancePermission} for the given query arguments.
@@ -140,7 +140,8 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
             "and entity with ID {} in the context of group with Keycloak ID {}",
             user.getKeycloakId(), entity.getId(), group.getKeycloakId());
 
-        boolean isUserMemberInGroup = keycloakUtil.isUserInGroup(user, group);
+        List<Group> userGroups = groupProviderService.findByUser(user);
+        boolean isUserMemberInGroup = userGroups.contains(group);
 
         if (!isUserMemberInGroup) {
             log.trace("The user is not a member of the given group, no permissions available.");

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionService.java
@@ -57,7 +57,7 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
     public List<GroupInstancePermission> findFor(Group group) {
 
         log.trace("Getting all group instance permissions for group with Keycloak ID {}",
-            group.getKeycloakId());
+            group.getAuthProviderId());
 
         return repository.findAllByGroup(group);
     }
@@ -80,7 +80,7 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
         }
 
         log.trace("Getting all group permissions for group with Keycloak ID {} and " +
-            "entity with ID {}", group.getKeycloakId(), entity.getId());
+            "entity with ID {}", group.getAuthProviderId(), entity.getId());
 
         return repository.findByGroupIdAndEntityId(group.getId(), entity.getId());
     }
@@ -108,7 +108,7 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
      */
     public Optional<GroupInstancePermission> findFor(BaseEntity entity, User user) {
         log.trace("Getting all group permissions for user with Keycloak ID {} and " +
-            "entity with ID {}", user.getKeycloakId(), entity.getId());
+            "entity with ID {}", user.getAuthProviderId(), entity.getId());
 
         // Get all groups of the user from Keycloak
         List<Group> groups = groupProviderService.findByUser(user);
@@ -138,7 +138,7 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
 
         log.trace("Getting all group instance permissions for user with Keycloak ID {} " +
             "and entity with ID {} in the context of group with Keycloak ID {}",
-            user.getKeycloakId(), entity.getId(), group.getKeycloakId());
+            user.getAuthProviderId(), entity.getId(), group.getAuthProviderId());
 
         List<Group> userGroups = groupProviderService.findByUser(user);
         boolean isUserMemberInGroup = userGroups.contains(group);
@@ -263,7 +263,7 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
         // Check if there is already an existing permission set on the entity
         if (existingPermission.isPresent()) {
             log.debug("Permission is already set for entity with ID {} and group with " +
-                "Keycloak ID {}: {}", entity.getId(), group.getKeycloakId(), permissionCollection);
+                "Keycloak ID {}: {}", entity.getId(), group.getAuthProviderId(), permissionCollection);
 
             // Remove the existing one
             repository.delete(existingPermission.get());

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/UserClassPermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/UserClassPermissionService.java
@@ -23,24 +23,24 @@ import de.terrestris.shogun.lib.model.security.permission.PermissionCollection;
 import de.terrestris.shogun.lib.model.security.permission.UserClassPermission;
 import de.terrestris.shogun.lib.repository.security.permission.PermissionCollectionRepository;
 import de.terrestris.shogun.lib.repository.security.permission.UserClassPermissionRepository;
-import de.terrestris.shogun.lib.security.SecurityContextUtil;
 import de.terrestris.shogun.lib.service.BaseService;
-import java.util.List;
-import java.util.Optional;
-
+import de.terrestris.shogun.lib.service.security.provider.UserProviderService;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @Log4j2
 public class UserClassPermissionService extends BaseService<UserClassPermissionRepository, UserClassPermission> {
 
     @Autowired
-    protected SecurityContextUtil securityContextUtil;
+    protected PermissionCollectionRepository permissionCollectionRepository;
 
     @Autowired
-    protected PermissionCollectionRepository permissionCollectionRepository;
+    private UserProviderService userProviderService;
 
     /**
      * Returns all {@link UserClassPermission} for the given query arguments.
@@ -109,7 +109,7 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
      * @param permissionCollectionType The permission to set.
      */
     public void setPermission(Class<? extends BaseEntity> clazz, PermissionCollectionType permissionCollectionType) {
-        Optional<User> activeUser = securityContextUtil.getUserBySession();
+        Optional<User> activeUser = userProviderService.getUserBySession();
 
         if (activeUser.isEmpty()) {
             throw new RuntimeException("Could not detect the logged in user.");

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/UserClassPermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/UserClassPermissionService.java
@@ -51,7 +51,7 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
     public List<UserClassPermission> findFor(User user) {
 
         log.trace("Getting all user class permissions for user with Keycloak ID {}",
-            user.getKeycloakId());
+            user.getAuthProviderId());
 
         return repository.findAllByUser(user);
     }
@@ -66,7 +66,7 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
         String className = clazz.getCanonicalName();
 
         log.trace("Getting all user class permissions for user with Keycloak ID {} and " +
-            "entity class {}", user.getKeycloakId(), className);
+            "entity class {}", user.getAuthProviderId(), className);
 
         return repository.findByUserIdAndClassName(user.getId(), className);
     }
@@ -81,7 +81,7 @@ public class UserClassPermissionService extends BaseService<UserClassPermissionR
      */
     public Optional<UserClassPermission> findFor(BaseEntity entity, User user) {
         log.trace("Getting all user class permissions for user with Keycloak ID {} and " +
-            "entity class {}", user.getKeycloakId(), entity.getClass().getCanonicalName());
+            "entity class {}", user.getAuthProviderId(), entity.getClass().getCanonicalName());
 
         return repository.findByUserIdAndClassName(user.getId(), entity.getClass().getCanonicalName());
     }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/UserInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/UserInstancePermissionService.java
@@ -23,23 +23,19 @@ import de.terrestris.shogun.lib.model.security.permission.PermissionCollection;
 import de.terrestris.shogun.lib.model.security.permission.UserInstancePermission;
 import de.terrestris.shogun.lib.repository.security.permission.PermissionCollectionRepository;
 import de.terrestris.shogun.lib.repository.security.permission.UserInstancePermissionRepository;
-import de.terrestris.shogun.lib.security.SecurityContextUtil;
 import de.terrestris.shogun.lib.service.BaseService;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import lombok.extern.log4j.Log4j2;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 @Service
 @Log4j2
 public class UserInstancePermissionService extends BaseService<UserInstancePermissionRepository, UserInstancePermission> {
-
-    @Autowired
-    protected SecurityContextUtil securityContextUtil;
 
     @Autowired
     protected PermissionCollectionRepository permissionCollectionRepository;
@@ -137,23 +133,6 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
         Optional<UserInstancePermission> userInstancePermission = this.findFor(entity, user);
 
         return getPermissionCollection(userInstancePermission);
-    }
-
-    /**
-     * Sets the given {@link PermissionCollectionType} for the given entity and the currently
-     * logged in user.
-     *
-     * @param persistedEntity The entity to set the permission for.
-     * @param permissionCollectionType The permission to set.
-     */
-    public void setPermission(BaseEntity persistedEntity, PermissionCollectionType permissionCollectionType) {
-        Optional<User> activeUser = securityContextUtil.getUserBySession();
-
-        if (activeUser.isEmpty()) {
-            throw new RuntimeException("Could not detect the logged in user.");
-        }
-
-        setPermission(persistedEntity, activeUser.get(), permissionCollectionType);
     }
 
     /**

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/UserInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/UserInstancePermissionService.java
@@ -62,7 +62,7 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
      */
     public Optional<UserInstancePermission> findFor(BaseEntity entity, User user) {
         log.trace("Getting all user permissions for user with Keycloak ID {} and " +
-            "entity with ID {}", user.getKeycloakId(), entity);
+            "entity with ID {}", user.getAuthProviderId(), entity);
 
         return repository.findByUserIdAndEntityId(user.getId(), entity.getId());
     }
@@ -206,7 +206,7 @@ public class UserInstancePermissionService extends BaseService<UserInstancePermi
         // Check if there is already an existing permission set on the entity
         if (existingPermission.isPresent()) {
             log.debug("Permission is already set for entity with ID {} and user with " +
-                "Keycloak ID {}: {}", entity.getId(), user.getKeycloakId(), permissionCollection);
+                "Keycloak ID {}: {}", entity.getId(), user.getAuthProviderId(), permissionCollection);
 
             // Remove the existing one
             repository.delete(existingPermission.get());

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/GroupProviderService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/GroupProviderService.java
@@ -1,3 +1,19 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2022-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.terrestris.shogun.lib.service.security.provider;
 
 import de.terrestris.shogun.lib.model.Group;
@@ -14,5 +30,7 @@ public interface GroupProviderService {
     void setTransientRepresentations(Group group);
 
     List<Group> getGroupsForUser();
+
+    Group findOrCreateByProviderId(String keycloakGroupId);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/GroupProviderService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/GroupProviderService.java
@@ -1,0 +1,15 @@
+package de.terrestris.shogun.lib.service.security.provider;
+
+import de.terrestris.shogun.lib.model.Group;
+import de.terrestris.shogun.lib.model.User;
+
+import java.util.List;
+
+public interface GroupProviderService {
+    public List<Group> findByUser(User user);
+
+    public List<User> getGroupMembers(String keycloakId);
+
+    public Group setTransientRepresentations(Group group);
+
+}

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/GroupProviderService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/GroupProviderService.java
@@ -21,16 +21,16 @@ import de.terrestris.shogun.lib.model.User;
 
 import java.util.List;
 
-public interface GroupProviderService {
+public interface GroupProviderService<UserType, GroupType> {
 
-    List<Group> findByUser(User user);
+    List<Group<GroupType>> findByUser(User<UserType> user);
 
-    List<User> getGroupMembers(String keycloakId);
+    List<User<UserType>> getGroupMembers(String providerId);
 
-    void setTransientRepresentations(Group group);
+    void setTransientRepresentations(Group<GroupType> group);
 
-    List<Group> getGroupsForUser();
+    List<Group<GroupType>> getGroupsForUser();
 
-    Group findOrCreateByProviderId(String keycloakGroupId);
+    Group<GroupType> findOrCreateByProviderId(String providerGroupId);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/GroupProviderService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/GroupProviderService.java
@@ -6,10 +6,13 @@ import de.terrestris.shogun.lib.model.User;
 import java.util.List;
 
 public interface GroupProviderService {
-    public List<Group> findByUser(User user);
 
-    public List<User> getGroupMembers(String keycloakId);
+    List<Group> findByUser(User user);
 
-    public Group setTransientRepresentations(Group group);
+    List<User> getGroupMembers(String keycloakId);
+
+    void setTransientRepresentations(Group group);
+
+    List<Group> getGroupsForUser();
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/UserProviderService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/UserProviderService.java
@@ -21,14 +21,14 @@ import org.springframework.security.core.Authentication;
 
 import java.util.Optional;
 
-public interface UserProviderService {
+public interface UserProviderService<T> {
 
-    User findOrCreateByProviderId(String keycloakUserId);
+    User<T> findOrCreateByProviderId(String providerUserId);
 
-    User setTransientRepresentations(User user);
+    User<T> setTransientRepresentations(User<T> user);
 
-    Optional<User> getUserBySession();
+    Optional<User<T>> getUserBySession();
 
-    Optional<User> getUserFromAuthentication(Authentication authentication);
+    Optional<User<T>> getUserFromAuthentication(Authentication authentication);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/UserProviderService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/UserProviderService.java
@@ -1,0 +1,9 @@
+package de.terrestris.shogun.lib.service.security.provider;
+
+import de.terrestris.shogun.lib.model.User;
+
+public interface UserProviderService {
+    public User findOrCreateByProviderId(String keycloakUserId);
+
+    public User setTransientRepresentations(User user);
+}

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/UserProviderService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/UserProviderService.java
@@ -17,11 +17,18 @@
 package de.terrestris.shogun.lib.service.security.provider;
 
 import de.terrestris.shogun.lib.model.User;
+import org.springframework.security.core.Authentication;
+
+import java.util.Optional;
 
 public interface UserProviderService {
 
     User findOrCreateByProviderId(String keycloakUserId);
 
     User setTransientRepresentations(User user);
+
+    Optional<User> getUserBySession();
+
+    Optional<User> getUserFromAuthentication(Authentication authentication);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/UserProviderService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/UserProviderService.java
@@ -1,9 +1,27 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2022-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.terrestris.shogun.lib.service.security.provider;
 
 import de.terrestris.shogun.lib.model.User;
 
 public interface UserProviderService {
-    public User findOrCreateByProviderId(String keycloakUserId);
 
-    public User setTransientRepresentations(User user);
+    User findOrCreateByProviderId(String keycloakUserId);
+
+    User setTransientRepresentations(User user);
+
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakGroupProviderService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakGroupProviderService.java
@@ -137,4 +137,20 @@ public class KeycloakGroupProviderService implements GroupProviderService {
         }
     }
 
+    @Transactional
+    public Group findOrCreateByProviderId(String keycloakGroupId) {
+        Optional<Group> groupOptional = repository.findByKeycloakId(keycloakGroupId);
+        Group group = groupOptional.orElse(null);
+
+        if (group == null) {
+            group = new Group(keycloakGroupId, null);
+            repository.save(group);
+
+            log.info("Group with keycloak id {} did not yet exist in the SHOGun DB and was therefore created.", keycloakGroupId);
+            return group;
+        }
+
+        return group;
+    }
+
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakGroupProviderService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakGroupProviderService.java
@@ -1,0 +1,126 @@
+package de.terrestris.shogun.lib.service.security.provider.keycloak;
+
+import de.terrestris.shogun.lib.model.Group;
+import de.terrestris.shogun.lib.model.User;
+import de.terrestris.shogun.lib.repository.GroupRepository;
+import de.terrestris.shogun.lib.repository.UserRepository;
+import de.terrestris.shogun.lib.service.security.provider.GroupProviderService;
+import de.terrestris.shogun.lib.util.KeycloakUtil;
+import lombok.extern.log4j.Log4j2;
+import org.keycloak.KeycloakPrincipal;
+import org.keycloak.KeycloakSecurityContext;
+import org.keycloak.admin.client.resource.GroupResource;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.IDToken;
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.security.access.prepost.PostFilter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@ConditionalOnExpression("${keycloak.enabled:true}")
+@Log4j2
+@Component
+public class KeycloakGroupProviderService implements GroupProviderService {
+
+    public static final String groupUuidsClaimName = "groups_uuid";
+
+    @Autowired
+    KeycloakUtil keycloakUtil;
+
+    @Autowired
+    GroupRepository repository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public List<Group> findByUser(User user) {
+        List<Group> groups = new ArrayList<>();
+
+        List<GroupRepresentation> keycloakGroups = keycloakUtil.getKeycloakUserGroups(user);
+
+        for (GroupRepresentation keycloakGroup : keycloakGroups) {
+            Optional<Group> group = repository.findByKeycloakId(keycloakGroup.getId());
+            if (group.isPresent()) {
+                group.get().setKeycloakRepresentation(keycloakGroup);
+                groups.add(group.get());
+            }
+        }
+
+        return groups;
+    }
+
+    public List<User> getGroupMembers(String id) {
+        GroupResource groupResource = keycloakUtil.getGroupResource(id);
+        List<UserRepresentation> groupMembers = groupResource.members();
+
+        ArrayList<User> users = new ArrayList<>();
+        for (UserRepresentation groupMember : groupMembers) {
+            Optional<User> user = userRepository.findByKeycloakId(groupMember.getId());
+            if (user.isPresent()) {
+                user.get().setKeycloakRepresentation(groupMember);
+                users.add(user.get());
+            }
+        }
+
+        return users;
+    }
+
+    /**
+     * Get SHOGun groups for currently logged in user based on actual assignment in keycloak
+     * @return List of SHOGun for currently logged in user
+     */
+    public List<Group> getGroupsForUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (!(authentication.getPrincipal() instanceof KeycloakPrincipal)) {
+            // TODO Check what happens for an anon user
+            return Collections.emptyList();
+        }
+
+        KeycloakPrincipal<?> keycloakPrincipal = (KeycloakPrincipal<KeycloakSecurityContext>) authentication.getPrincipal();
+        KeycloakSecurityContext keycloakSecurityContext = keycloakPrincipal.getKeycloakSecurityContext();
+        // TODO This should happen everywhere!
+        IDToken idToken = keycloakSecurityContext.getIdToken();
+        AccessToken token = keycloakSecurityContext.getToken();
+
+        ArrayList<String> idTokenGroups = (idToken == null) ? null : (ArrayList<String>) idToken.getOtherClaims().get(groupUuidsClaimName);
+        ArrayList<String> tokenGroups = (token == null) ? null : (ArrayList<String>) token.getOtherClaims().get(groupUuidsClaimName);
+
+        Set<String> keycloakGroupIds = new HashSet<>();
+        if (idTokenGroups != null && !idTokenGroups.isEmpty()) {
+            keycloakGroupIds.addAll(idTokenGroups);
+        }
+
+        if (tokenGroups != null && !tokenGroups.isEmpty()) {
+            keycloakGroupIds.addAll(tokenGroups);
+        }
+
+        return keycloakGroupIds.stream().
+            map(keycloakGroupId -> repository.findByKeycloakId(keycloakGroupId).orElseThrow()).
+            collect(Collectors.toList());
+    }
+
+    public Group setTransientRepresentations(Group group) {
+        GroupResource groupResource = keycloakUtil.getGroupResource(group);
+
+        try {
+            GroupRepresentation groupRepresentation = groupResource.toRepresentation();
+            group.setKeycloakRepresentation(groupRepresentation);
+        } catch (Exception e) {
+            log.warn("Could not get the GroupRepresentation for group with SHOGun ID {} and " +
+                    "Keycloak ID {}. This may happen if the group is not available in Keycloak.",
+                group.getId(), group.getKeycloakId());
+            log.trace("Full stack trace: ", e);
+        }
+
+        return group;
+    }
+}

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakGroupProviderService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakGroupProviderService.java
@@ -1,3 +1,19 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2022-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.terrestris.shogun.lib.service.security.provider.keycloak;
 
 import de.terrestris.shogun.lib.model.Group;
@@ -16,7 +32,6 @@ import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -36,7 +51,7 @@ public class KeycloakGroupProviderService implements GroupProviderService {
     KeycloakUtil keycloakUtil;
 
     @Autowired
-    GroupRepository repository;
+    public GroupRepository repository;
 
     @Autowired
     UserRepository userRepository;
@@ -108,7 +123,7 @@ public class KeycloakGroupProviderService implements GroupProviderService {
             collect(Collectors.toList());
     }
 
-    public Group setTransientRepresentations(Group group) {
+    public void setTransientRepresentations(Group group) {
         GroupResource groupResource = keycloakUtil.getGroupResource(group);
 
         try {
@@ -120,7 +135,6 @@ public class KeycloakGroupProviderService implements GroupProviderService {
                 group.getId(), group.getKeycloakId());
             log.trace("Full stack trace: ", e);
         }
-
-        return group;
     }
+
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakGroupProviderService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakGroupProviderService.java
@@ -40,6 +40,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.*;
 import java.util.stream.Collectors;
 
+/**
+ * NOTE: Make sure not to use services here, else the security checks will not run on them due to circular
+ * references.
+ */
 @ConditionalOnExpression("${keycloak.enabled:true}")
 @Log4j2
 @Component

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakUserProviderService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakUserProviderService.java
@@ -37,6 +37,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * NOTE: Make sure not to use services here, else the security checks will not run on them due to circular
+ * references.
+ */
 @ConditionalOnExpression("${keycloak.enabled:true}")
 @Log4j2
 @Component

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakUserProviderService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakUserProviderService.java
@@ -1,0 +1,104 @@
+package de.terrestris.shogun.lib.service.security.provider.keycloak;
+
+import de.terrestris.shogun.lib.enumeration.PermissionCollectionType;
+import de.terrestris.shogun.lib.event.OnRegistrationConfirmedEvent;
+import de.terrestris.shogun.lib.model.User;
+import de.terrestris.shogun.lib.repository.UserRepository;
+import de.terrestris.shogun.lib.service.GroupService;
+import de.terrestris.shogun.lib.service.security.permission.UserInstancePermissionService;
+import de.terrestris.shogun.lib.service.security.provider.UserProviderService;
+import de.terrestris.shogun.lib.util.KeycloakUtil;
+import lombok.extern.log4j.Log4j2;
+import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@ConditionalOnExpression("${keycloak.enabled:true}")
+@Log4j2
+@Component
+public class KeycloakUserProviderService implements UserProviderService {
+
+    @Autowired
+    KeycloakUtil keycloakUtil;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    GroupService groupService;
+
+    @Autowired
+    protected UserInstancePermissionService userInstancePermissionService;
+
+    /**
+     * Finds a User by the passed keycloak ID. If it does not exists in the SHOGun DB it gets created.
+     *
+     * The groups of the user are also checked and created if needed.
+     *
+     * @param keycloakUserId
+     * @return
+     */
+//    @PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#keycloakUserId, 'CREATE')")
+    @Transactional
+    public User findOrCreateByProviderId(String keycloakUserId) {
+        Optional<User> userOptional = userRepository.findByKeycloakId(keycloakUserId);
+        User user = userOptional.orElse(null);
+
+        // User is not yet it SHOGun DB
+        if (user == null) {
+            user = new User(keycloakUserId, null, null, null);
+            userRepository.save(user);
+
+            // If the user doesn't exist, we assume it's the first login after registration.
+            eventPublisher.publishEvent(new OnRegistrationConfirmedEvent(user));
+
+            // Add admin instance permissions for the user.
+            userInstancePermissionService.setPermission(user, user, PermissionCollectionType.ADMIN);
+
+            log.info("User with keycloak id {} did not yet exist in the SHOGun DB and was therefore created.", keycloakUserId);
+
+            this.setTransientRepresentations(user);
+
+            return user;
+        }
+
+        List<GroupRepresentation> keycloakUserGroups = keycloakUtil.getKeycloakUserGroups(user);
+
+        // Add missing groups to shogun db
+        keycloakUserGroups
+            .stream()
+            .map(GroupRepresentation::getId)
+            .forEach(groupService::findOrCreateByKeycloakId);
+
+        this.setTransientRepresentations(user);
+
+        return user;
+    }
+
+    public User setTransientRepresentations(User user) {
+        UserResource userResource = keycloakUtil.getUserResource(user);
+
+        try {
+            UserRepresentation userRepresentation = userResource.toRepresentation();
+            user.setKeycloakRepresentation(userRepresentation);
+        } catch (Exception e) {
+            log.warn("Could not get the UserRepresentation for user with SHOGun ID {} and " +
+                    "Keycloak ID {}. This may happen if the user is not available in Keycloak.",
+                user.getId(), user.getKeycloakId());
+            log.trace("Full stack trace: ", e);
+        }
+
+        return user;
+    }
+}

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakUserProviderService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakUserProviderService.java
@@ -20,8 +20,8 @@ import de.terrestris.shogun.lib.enumeration.PermissionCollectionType;
 import de.terrestris.shogun.lib.event.OnRegistrationConfirmedEvent;
 import de.terrestris.shogun.lib.model.User;
 import de.terrestris.shogun.lib.repository.UserRepository;
-import de.terrestris.shogun.lib.service.GroupService;
 import de.terrestris.shogun.lib.service.security.permission.UserInstancePermissionService;
+import de.terrestris.shogun.lib.service.security.provider.GroupProviderService;
 import de.terrestris.shogun.lib.service.security.provider.UserProviderService;
 import de.terrestris.shogun.lib.util.KeycloakUtil;
 import lombok.extern.log4j.Log4j2;
@@ -52,7 +52,7 @@ public class KeycloakUserProviderService implements UserProviderService {
     ApplicationEventPublisher eventPublisher;
 
     @Autowired
-    GroupService groupService;
+    GroupProviderService groupProviderService;
 
     @Autowired
     protected UserInstancePermissionService userInstancePermissionService;
@@ -95,7 +95,7 @@ public class KeycloakUserProviderService implements UserProviderService {
         keycloakUserGroups
             .stream()
             .map(GroupRepresentation::getId)
-            .forEach(groupService::findOrCreateByKeycloakId);
+            .forEach(groupProviderService::findOrCreateByProviderId);
 
         this.setTransientRepresentations(user);
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakUserProviderService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakUserProviderService.java
@@ -1,3 +1,19 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2022-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.terrestris.shogun.lib.service.security.provider.keycloak;
 
 import de.terrestris.shogun.lib.enumeration.PermissionCollectionType;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/KeycloakUtil.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/KeycloakUtil.java
@@ -61,9 +61,9 @@ public class KeycloakUtil {
     @Autowired
     private SecurityContextUtil securityContextUtil;
 
-    public UserResource getUserResource(User user) {
+    public UserResource getUserResource(User<UserRepresentation> user) {
         UsersResource kcUsers = this.keycloakRealm.users();
-        return kcUsers.get(user.getKeycloakId());
+        return kcUsers.get(user.getAuthProviderId());
     }
 
     public UserResource getUserResource(String id) {
@@ -71,9 +71,9 @@ public class KeycloakUtil {
         return kcUsers.get(id);
     }
 
-    public GroupResource getGroupResource(Group group) {
+    public GroupResource getGroupResource(Group<GroupRepresentation> group) {
         GroupsResource kcGroups = this.keycloakRealm.groups();
-        return kcGroups.group(group.getKeycloakId());
+        return kcGroups.group(group.getAuthProviderId());
     }
 
     public GroupResource getGroupResource(String id) {
@@ -81,14 +81,14 @@ public class KeycloakUtil {
         return kcGroups.group(id);
     }
 
-    public void addUserToGroup(User user, Group group) {
+    public void addUserToGroup(User<UserRepresentation> user, Group<GroupRepresentation> group) {
         UserResource kcUser = this.getUserResource(user);
         GroupResource kcGroup = this.getGroupResource(group);
 
         kcUser.joinGroup(kcGroup.toRepresentation().getId());
     }
 
-    public void addUserToGroup(User user, GroupRepresentation kcGroup) {
+    public void addUserToGroup(User<UserRepresentation> user, GroupRepresentation kcGroup) {
         UserResource kcUser = this.getUserResource(user);
 
         kcUser.joinGroup(kcGroup.getId());
@@ -168,10 +168,10 @@ public class KeycloakUtil {
         return keycloakRealm.roles();
     }
 
-    public boolean isUserInGroup(User user, Group group) {
+    public boolean isUserInGroup(User<UserRepresentation> user, Group<GroupRepresentation> group) {
         UserResource kcUser = this.getUserResource(user);
         return kcUser.groups().stream()
-            .anyMatch(gr -> gr.getId().equals(group.getKeycloakId()));
+            .anyMatch(gr -> gr.getId().equals(group.getAuthProviderId()));
     }
 
     /**
@@ -179,9 +179,9 @@ public class KeycloakUtil {
      * @param user
      * @return
      */
-    public String getUserNameFromKeycloak(User user) {
+    public String getUserNameFromKeycloak(User<UserRepresentation> user) {
         UsersResource users = this.keycloakRealm.users();
-        UserResource kcUser = users.get(user.getKeycloakId());
+        UserResource kcUser = users.get(user.getAuthProviderId());
         UserRepresentation kcUserRepresentation = kcUser.toRepresentation();
         return String.format("%s %s", kcUserRepresentation.getFirstName(), kcUserRepresentation.getLastName());
     }
@@ -191,7 +191,7 @@ public class KeycloakUtil {
      * Renamed to `getKeycloakUserGroups`.
      */
     @Deprecated
-    public List<GroupRepresentation> getUserGroups(User user) {
+    public List<GroupRepresentation> getUserGroups(User<UserRepresentation> user) {
         return this.getKeycloakUserGroups(user);
     }
 
@@ -201,7 +201,7 @@ public class KeycloakUtil {
      * @param user
      * @return
      */
-    public List<GroupRepresentation> getKeycloakUserGroups(User user) {
+    public List<GroupRepresentation> getKeycloakUserGroups(User<UserRepresentation> user) {
         UserResource userResource = this.getUserResource(user);
         List<GroupRepresentation> groups = new ArrayList<>();
 
@@ -210,7 +210,7 @@ public class KeycloakUtil {
         } catch (Exception e) {
             log.warn("Could not get the GroupRepresentations for the groups of user with SHOGun ID {} and " +
                     "Keycloak ID {}. This may happen if the user is not available in Keycloak.",
-                     user.getId(), user.getKeycloakId());
+                     user.getId(), user.getAuthProviderId());
             log.trace("Full stack trace: ", e);
         }
 
@@ -223,7 +223,7 @@ public class KeycloakUtil {
      * @param user
      * @return
      */
-    public List<RoleRepresentation> getKeycloakUserRoles(User user) {
+    public List<RoleRepresentation> getKeycloakUserRoles(User<UserRepresentation> user) {
         UserResource userResource = this.getUserResource(user);
         List<RoleRepresentation> roles = new ArrayList<>();
         try {
@@ -231,7 +231,7 @@ public class KeycloakUtil {
         } catch (Exception e) {
             log.warn("Could not get the RoleMappingResource for the user with SHOGun ID {} and " +
                     "Keycloak ID {}. This may happen if the user is not available in Keycloak.",
-                     user.getId(), user.getKeycloakId());
+                     user.getId(), user.getAuthProviderId());
             log.trace("Full stack trace: ", e);
         }
         return roles;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/KeycloakUtil.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/KeycloakUtil.java
@@ -30,6 +30,7 @@ import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
@@ -40,6 +41,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+// TODO Check for keycloak object key length instead?
+@ConditionalOnExpression("${keycloak.enabled:true}")
 @Log4j2
 @Component
 public class KeycloakUtil {
@@ -52,9 +55,6 @@ public class KeycloakUtil {
 
     @Autowired
     protected GroupRepository groupRepository;
-
-    @Autowired
-    private KeycloakUtil keycloakUtil;
 
     @Autowired
     private SecurityContextUtil securityContextUtil;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/KeycloakUtil.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/KeycloakUtil.java
@@ -21,7 +21,6 @@ import de.terrestris.shogun.lib.model.User;
 import de.terrestris.shogun.lib.repository.GroupRepository;
 import de.terrestris.shogun.lib.repository.UserRepository;
 import de.terrestris.shogun.lib.security.SecurityContextUtil;
-import de.terrestris.shogun.lib.service.security.permission.UserInstancePermissionService;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 import org.keycloak.admin.client.CreatedResponseUtil;
@@ -31,7 +30,6 @@ import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
@@ -58,12 +56,6 @@ public class KeycloakUtil {
 
     @Autowired
     private SecurityContextUtil securityContextUtil;
-
-    @Autowired
-    private ApplicationEventPublisher eventPublisher;
-
-    @Autowired
-    private UserInstancePermissionService userInstancePermissionService;
 
     public UserResource getUserResource(User user) {
         UsersResource kcUsers = this.keycloakRealm.users();

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/security/SecurityContextUtilTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/security/SecurityContextUtilTest.java
@@ -135,11 +135,11 @@ public class SecurityContextUtilTest {
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         final GroupRepository groupRepository = mock(GroupRepository.class);
-        when(groupRepository.findByKeycloakId(anyString())).thenReturn(Optional.of(new Group()));
+        when(groupRepository.findByAuthProviderId(anyString())).thenReturn(Optional.of(new Group()));
 
         groupProviderService.repository = groupRepository;
 
-        List<Group> groupsForUser = groupProviderService.getGroupsForUser();
+        List<Group<?>> groupsForUser = (List) groupProviderService.getGroupsForUser();
         assertNotNull(groupsForUser);
         assertEquals("Number of mocked group instances matches number of returned group instances.", 2, groupsForUser.size());
     }

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/security/SecurityContextUtilTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/security/SecurityContextUtilTest.java
@@ -19,22 +19,19 @@ package de.terrestris.shogun.lib.security;
 import de.terrestris.shogun.lib.model.Group;
 import de.terrestris.shogun.lib.repository.GroupRepository;
 import de.terrestris.shogun.lib.service.GroupService;
-import de.terrestris.shogun.lib.service.security.provider.GroupProviderService;
+import de.terrestris.shogun.lib.service.security.provider.UserProviderService;
 import de.terrestris.shogun.lib.service.security.provider.keycloak.KeycloakGroupProviderService;
+import de.terrestris.shogun.lib.service.security.provider.keycloak.KeycloakUserProviderService;
 import org.junit.After;
 import org.junit.Test;
 import org.keycloak.KeycloakPrincipal;
 import org.keycloak.KeycloakSecurityContext;
 import org.keycloak.adapters.springsecurity.token.KeycloakAuthenticationToken;
 import org.keycloak.representations.IDToken;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 
@@ -43,7 +40,8 @@ import java.util.*;
 import static de.terrestris.shogun.lib.service.security.provider.keycloak.KeycloakGroupProviderService.groupUuidsClaimName;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Test for {@link SecurityContextUtil}
@@ -60,6 +58,9 @@ public class SecurityContextUtilTest {
 
     @Mock
     private final KeycloakGroupProviderService groupProviderService = new KeycloakGroupProviderService();
+
+    @Mock
+    private final UserProviderService userProviderService = new KeycloakUserProviderService();
 
     @After
     public void logoutMockUser() {
@@ -110,7 +111,7 @@ public class SecurityContextUtilTest {
     public void getGroupsForUser() {
         loginMockUser("USER");
         Optional<de.terrestris.shogun.lib.model.User> user = Optional.of(new de.terrestris.shogun.lib.model.User());
-        when(securityContextUtilMock.getUserBySession()).thenReturn(user);
+        when(userProviderService.getUserBySession()).thenReturn(user);
         assertNotNull(groupProviderService.getGroupsForUser());
     }
 

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/security/SecurityContextUtilTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/security/SecurityContextUtilTest.java
@@ -18,6 +18,9 @@ package de.terrestris.shogun.lib.security;
 
 import de.terrestris.shogun.lib.model.Group;
 import de.terrestris.shogun.lib.repository.GroupRepository;
+import de.terrestris.shogun.lib.service.GroupService;
+import de.terrestris.shogun.lib.service.security.provider.GroupProviderService;
+import de.terrestris.shogun.lib.service.security.provider.keycloak.KeycloakGroupProviderService;
 import org.junit.After;
 import org.junit.Test;
 import org.keycloak.KeycloakPrincipal;
@@ -37,7 +40,7 @@ import org.springframework.security.core.userdetails.User;
 
 import java.util.*;
 
-import static de.terrestris.shogun.lib.security.SecurityContextUtil.groupUuidsClaimName;
+import static de.terrestris.shogun.lib.service.security.provider.keycloak.KeycloakGroupProviderService.groupUuidsClaimName;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -51,6 +54,12 @@ public class SecurityContextUtilTest {
     private final SecurityContextUtil securityContextUtilMock = mock(SecurityContextUtil.class);
 
     private final SecurityContextUtil securityContextUtil = new SecurityContextUtil();
+
+    @Mock
+    private final GroupService groupService = mock(GroupService.class);
+
+    @Mock
+    private final KeycloakGroupProviderService groupProviderService = new KeycloakGroupProviderService();
 
     @After
     public void logoutMockUser() {
@@ -100,8 +109,9 @@ public class SecurityContextUtilTest {
     @Test
     public void getGroupsForUser() {
         loginMockUser("USER");
-        when(securityContextUtilMock.getUserBySession()).thenReturn(Optional.empty());
-        assertNotNull(securityContextUtilMock.getGroupsForUser());
+        Optional<de.terrestris.shogun.lib.model.User> user = Optional.of(new de.terrestris.shogun.lib.model.User());
+        when(securityContextUtilMock.getUserBySession()).thenReturn(user);
+        assertNotNull(groupProviderService.getGroupsForUser());
     }
 
     @Test
@@ -126,9 +136,9 @@ public class SecurityContextUtilTest {
         final GroupRepository groupRepository = mock(GroupRepository.class);
         when(groupRepository.findByKeycloakId(anyString())).thenReturn(Optional.of(new Group()));
 
-        securityContextUtil.groupRepository = groupRepository;
+        groupProviderService.repository = groupRepository;
 
-        List<Group> groupsForUser = securityContextUtil.getGroupsForUser();
+        List<Group> groupsForUser = groupProviderService.getGroupsForUser();
         assertNotNull(groupsForUser);
         assertEquals("Number of mocked group instances matches number of returned group instances.", 2, groupsForUser.size());
     }

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/security/access/BasePermissionEvaluatorTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/security/access/BasePermissionEvaluatorTest.java
@@ -20,10 +20,11 @@ import de.terrestris.shogun.lib.enumeration.PermissionType;
 import de.terrestris.shogun.lib.model.Application;
 import de.terrestris.shogun.lib.model.BaseEntity;
 import de.terrestris.shogun.lib.model.User;
-import de.terrestris.shogun.lib.security.SecurityContextUtil;
 import de.terrestris.shogun.lib.security.access.entity.ApplicationPermissionEvaluator;
 import de.terrestris.shogun.lib.security.access.entity.BaseEntityPermissionEvaluator;
 import de.terrestris.shogun.lib.security.access.entity.DefaultPermissionEvaluator;
+import de.terrestris.shogun.lib.service.security.provider.UserProviderService;
+import de.terrestris.shogun.lib.service.security.provider.keycloak.KeycloakUserProviderService;
 import de.terrestris.shogun.lib.util.IdHelper;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,7 +51,7 @@ public class BasePermissionEvaluatorTest {
     private ApplicationPermissionEvaluator applicationPermissionEvaluatorMock;
 
     @Mock
-    private SecurityContextUtil securityContextUtilMock;
+    private UserProviderService userProviderService = new KeycloakUserProviderService();
 
     @Spy
     private ArrayList<BaseEntityPermissionEvaluator> baseEntityPermissionEvaluatorMock;
@@ -122,7 +123,7 @@ public class BasePermissionEvaluatorTest {
         IdHelper.setIdForEntity(targetDomainObject, 1L);
         String permissionObject = "READ";
 
-        when(securityContextUtilMock.getUserFromAuthentication(authentication)).thenReturn(Optional.of(mockUser));
+        when(userProviderService.getUserFromAuthentication(authentication)).thenReturn(Optional.of(mockUser));
 
         baseEntityPermissionEvaluatorMock.add(defaultPermissionEvaluatorMock);
 
@@ -130,7 +131,7 @@ public class BasePermissionEvaluatorTest {
 
         verify(defaultPermissionEvaluatorMock, times(1)).hasPermission(mockUser, targetDomainObject, PermissionType.READ);
 
-        reset(securityContextUtilMock);
+        reset(userProviderService);
         baseEntityPermissionEvaluatorMock.clear();
     }
 
@@ -142,7 +143,7 @@ public class BasePermissionEvaluatorTest {
         IdHelper.setIdForEntity(targetDomainObject, 1L);
         String permissionObject = "READ";
 
-        when(securityContextUtilMock.getUserFromAuthentication(authentication)).thenReturn(Optional.of(mockUser));
+        when(userProviderService.getUserFromAuthentication(authentication)).thenReturn(Optional.of(mockUser));
 
         baseEntityPermissionEvaluatorMock.add(defaultPermissionEvaluatorMock);
 
@@ -150,7 +151,7 @@ public class BasePermissionEvaluatorTest {
 
         verify(defaultPermissionEvaluatorMock, times(1)).hasPermission(mockUser, targetDomainObject, PermissionType.READ);
 
-        reset(securityContextUtilMock);
+        reset(userProviderService);
         baseEntityPermissionEvaluatorMock.clear();
     }
 
@@ -162,7 +163,7 @@ public class BasePermissionEvaluatorTest {
         IdHelper.setIdForEntity(targetDomainObject, 1L);
         String permissionObject = "READ";
 
-        when(securityContextUtilMock.getUserFromAuthentication(authentication)).thenReturn(Optional.of(mockUser));
+        when(userProviderService.getUserFromAuthentication(authentication)).thenReturn(Optional.of(mockUser));
 
         baseEntityPermissionEvaluatorMock.add(defaultPermissionEvaluatorMock);
         baseEntityPermissionEvaluatorMock.add(applicationPermissionEvaluatorMock);
@@ -172,7 +173,7 @@ public class BasePermissionEvaluatorTest {
         verify(defaultPermissionEvaluatorMock, times(0)).hasPermission(mockUser, targetDomainObject, PermissionType.READ);
         verify(applicationPermissionEvaluatorMock, times(1)).hasPermission(mockUser, targetDomainObject, PermissionType.READ);
 
-        reset(securityContextUtilMock);
+        reset(userProviderService);
     }
 
 }

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/security/access/BasePermissionEvaluatorTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/security/access/BasePermissionEvaluatorTest.java
@@ -65,7 +65,7 @@ public class BasePermissionEvaluatorTest {
     @Before
     public void setup() {
         mockUser = new User();
-        mockUser.setKeycloakId(mockUserKeycloakId);
+        mockUser.setAuthProviderId(mockUserKeycloakId);
 
         when(defaultPermissionEvaluatorMock.getEntityClassName()).thenReturn(BaseEntity.class);
         when(applicationPermissionEvaluatorMock.getEntityClassName()).thenReturn(Application.class);

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/security/access/entity/DefaultPermissionEvaluatorTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/security/access/entity/DefaultPermissionEvaluatorTest.java
@@ -65,7 +65,7 @@ public class DefaultPermissionEvaluatorTest {
     @Before
     public void setup() {
         mockUser = new User();
-        mockUser.setKeycloakId(mockUserKeycloakId);
+        mockUser.setAuthProviderId(mockUserKeycloakId);
     }
 
     @Test

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/ApplicationServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/ApplicationServiceTest.java
@@ -17,21 +17,32 @@
 package de.terrestris.shogun.lib.service;
 
 import de.terrestris.shogun.lib.model.Application;
+import de.terrestris.shogun.lib.model.User;
 import de.terrestris.shogun.lib.repository.ApplicationRepository;
+import de.terrestris.shogun.lib.service.security.provider.UserProviderService;
+import de.terrestris.shogun.lib.service.security.provider.keycloak.KeycloakUserProviderService;
 import org.junit.Before;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
 
 public class ApplicationServiceTest extends BaseServiceTest<ApplicationService, Application> {
 
     @Mock
     ApplicationRepository repositoryMock;
 
+    @Mock
+    private UserProviderService userProviderService = new KeycloakUserProviderService();
+
     @InjectMocks
     ApplicationService service;
 
     @Before
     public void init() {
+        when(userProviderService.getUserBySession()).thenReturn(Optional.of(new User()));
         super.setRepository(repositoryMock);
         super.setService(service);
         super.setEntityClass(Application.class);

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/GroupServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/GroupServiceTest.java
@@ -18,6 +18,7 @@ package de.terrestris.shogun.lib.service;
 
 import de.terrestris.shogun.lib.model.Group;
 import de.terrestris.shogun.lib.repository.GroupRepository;
+import de.terrestris.shogun.lib.service.security.provider.keycloak.KeycloakGroupProviderService;
 import de.terrestris.shogun.lib.util.KeycloakUtil;
 import org.junit.Before;
 import org.mockito.InjectMocks;
@@ -37,9 +38,13 @@ public class GroupServiceTest extends BaseServiceTest<GroupService, Group> {
     @InjectMocks
     GroupService service;
 
+    @InjectMocks
+    KeycloakGroupProviderService groupProviderService;
+
     @Before
     public void init() {
         when(keycloakUtilMock.getGroupResource(any(Group.class))).thenReturn(null);
+        service.groupProviderService = groupProviderService;
 
         super.setRepository(repositoryMock);
         super.setService(service);

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/GroupServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/GroupServiceTest.java
@@ -17,12 +17,17 @@
 package de.terrestris.shogun.lib.service;
 
 import de.terrestris.shogun.lib.model.Group;
+import de.terrestris.shogun.lib.model.User;
 import de.terrestris.shogun.lib.repository.GroupRepository;
+import de.terrestris.shogun.lib.service.security.provider.UserProviderService;
 import de.terrestris.shogun.lib.service.security.provider.keycloak.KeycloakGroupProviderService;
+import de.terrestris.shogun.lib.service.security.provider.keycloak.KeycloakUserProviderService;
 import de.terrestris.shogun.lib.util.KeycloakUtil;
 import org.junit.Before;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -38,13 +43,15 @@ public class GroupServiceTest extends BaseServiceTest<GroupService, Group> {
     @InjectMocks
     GroupService service;
 
-    @InjectMocks
-    KeycloakGroupProviderService groupProviderService;
+    @Mock
+    KeycloakGroupProviderService groupProviderService = new KeycloakGroupProviderService();
+
+    @Mock
+    private UserProviderService userProviderService = new KeycloakUserProviderService();
 
     @Before
     public void init() {
-        when(keycloakUtilMock.getGroupResource(any(Group.class))).thenReturn(null);
-        service.groupProviderService = groupProviderService;
+        when(userProviderService.getUserBySession()).thenReturn(Optional.of(new User()));
 
         super.setRepository(repositoryMock);
         super.setService(service);

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/LayerServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/LayerServiceTest.java
@@ -17,21 +17,32 @@
 package de.terrestris.shogun.lib.service;
 
 import de.terrestris.shogun.lib.model.Layer;
+import de.terrestris.shogun.lib.model.User;
 import de.terrestris.shogun.lib.repository.LayerRepository;
+import de.terrestris.shogun.lib.service.security.provider.UserProviderService;
+import de.terrestris.shogun.lib.service.security.provider.keycloak.KeycloakUserProviderService;
 import org.junit.Before;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
 
 public class LayerServiceTest extends BaseServiceTest<LayerService, Layer> {
 
     @Mock
     LayerRepository repositoryMock;
 
+    @Mock
+    private UserProviderService userProviderService = new KeycloakUserProviderService();
+
     @InjectMocks
     LayerService service;
 
     @Before
     public void init() {
+        when(userProviderService.getUserBySession()).thenReturn(Optional.of(new User()));
         super.setRepository(repositoryMock);
         super.setService(service);
         super.setEntityClass(Layer.class);

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/UserServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/UserServiceTest.java
@@ -18,14 +18,12 @@ package de.terrestris.shogun.lib.service;
 
 import de.terrestris.shogun.lib.model.User;
 import de.terrestris.shogun.lib.repository.UserRepository;
+import de.terrestris.shogun.lib.service.security.provider.keycloak.KeycloakUserProviderService;
 import de.terrestris.shogun.lib.util.KeycloakUtil;
 import org.junit.Before;
-import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.security.access.prepost.PostAuthorize;
 
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -40,9 +38,13 @@ public class UserServiceTest extends BaseServiceTest<UserService, User> {
     @InjectMocks
     UserService service;
 
+    @InjectMocks
+    KeycloakUserProviderService userProviderService;
+
     @Before
     public void init() {
         when(keycloakUtilMock.getUserResource(any(User.class))).thenReturn(null);
+        service.userProviderService = userProviderService;
 
         super.setRepository(repositoryMock);
         super.setService(service);

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/UserServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/UserServiceTest.java
@@ -24,7 +24,8 @@ import org.junit.Before;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
-import static org.mockito.ArgumentMatchers.any;
+import java.util.Optional;
+
 import static org.mockito.Mockito.when;
 
 public class UserServiceTest extends BaseServiceTest<UserService, User> {
@@ -38,13 +39,12 @@ public class UserServiceTest extends BaseServiceTest<UserService, User> {
     @InjectMocks
     UserService service;
 
-    @InjectMocks
-    KeycloakUserProviderService userProviderService;
+    @Mock
+    KeycloakUserProviderService userProviderService = new KeycloakUserProviderService();
 
     @Before
     public void init() {
-        when(keycloakUtilMock.getUserResource(any(User.class))).thenReturn(null);
-        service.userProviderService = userProviderService;
+        when(userProviderService.getUserBySession()).thenReturn(Optional.of(new User()));
 
         super.setRepository(repositoryMock);
         super.setService(service);

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/security/permission/GroupClassPermissionServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/security/permission/GroupClassPermissionServiceTest.java
@@ -16,23 +16,34 @@
  */
 package de.terrestris.shogun.lib.service.security.permission;
 
+import de.terrestris.shogun.lib.model.User;
 import de.terrestris.shogun.lib.model.security.permission.GroupClassPermission;
 import de.terrestris.shogun.lib.repository.security.permission.GroupClassPermissionRepository;
 import de.terrestris.shogun.lib.service.BaseServiceTest;
+import de.terrestris.shogun.lib.service.security.provider.UserProviderService;
+import de.terrestris.shogun.lib.service.security.provider.keycloak.KeycloakUserProviderService;
 import org.junit.Before;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
 
 public class GroupClassPermissionServiceTest extends BaseServiceTest<GroupClassPermissionService, GroupClassPermission> {
 
     @Mock
     GroupClassPermissionRepository repositoryMock;
 
+    @Mock
+    private UserProviderService userProviderService = new KeycloakUserProviderService();
+
     @InjectMocks
     GroupClassPermissionService service;
 
     @Before
     public void init() {
+        when(userProviderService.getUserBySession()).thenReturn(Optional.of(new User()));
         super.setRepository(repositoryMock);
         super.setService(service);
         super.setEntityClass(GroupClassPermission.class);

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionServiceTest.java
@@ -16,23 +16,33 @@
  */
 package de.terrestris.shogun.lib.service.security.permission;
 
+import de.terrestris.shogun.lib.model.User;
 import de.terrestris.shogun.lib.model.security.permission.GroupInstancePermission;
 import de.terrestris.shogun.lib.repository.security.permission.GroupInstancePermissionRepository;
 import de.terrestris.shogun.lib.service.BaseServiceTest;
+import de.terrestris.shogun.lib.service.security.provider.keycloak.KeycloakUserProviderService;
 import org.junit.Before;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
 
 public class GroupInstancePermissionServiceTest extends BaseServiceTest<GroupInstancePermissionService, GroupInstancePermission> {
 
     @Mock
     GroupInstancePermissionRepository repositoryMock;
 
+    @Mock
+    KeycloakUserProviderService userProviderService = new KeycloakUserProviderService();
+
     @InjectMocks
     GroupInstancePermissionService service;
 
     @Before
     public void init() {
+        when(userProviderService.getUserBySession()).thenReturn(Optional.of(new User()));
         super.setRepository(repositoryMock);
         super.setService(service);
         super.setEntityClass(GroupInstancePermission.class);

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/security/permission/PermissionCollectionServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/security/permission/PermissionCollectionServiceTest.java
@@ -16,23 +16,33 @@
  */
 package de.terrestris.shogun.lib.service.security.permission;
 
+import de.terrestris.shogun.lib.model.User;
 import de.terrestris.shogun.lib.model.security.permission.PermissionCollection;
 import de.terrestris.shogun.lib.repository.security.permission.PermissionCollectionRepository;
 import de.terrestris.shogun.lib.service.BaseServiceTest;
+import de.terrestris.shogun.lib.service.security.provider.keycloak.KeycloakUserProviderService;
 import org.junit.Before;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
 
 public class PermissionCollectionServiceTest extends BaseServiceTest<PermissionCollectionService, PermissionCollection> {
 
     @Mock
     PermissionCollectionRepository repositoryMock;
 
+    @Mock
+    KeycloakUserProviderService userProviderService = new KeycloakUserProviderService();
+
     @InjectMocks
     PermissionCollectionService service;
 
     @Before
     public void init() {
+        when(userProviderService.getUserBySession()).thenReturn(Optional.of(new User()));
         super.setRepository(repositoryMock);
         super.setService(service);
         super.setEntityClass(PermissionCollection.class);

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/security/permission/UserClassPermissionServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/security/permission/UserClassPermissionServiceTest.java
@@ -16,23 +16,33 @@
  */
 package de.terrestris.shogun.lib.service.security.permission;
 
+import de.terrestris.shogun.lib.model.User;
 import de.terrestris.shogun.lib.model.security.permission.UserClassPermission;
 import de.terrestris.shogun.lib.repository.security.permission.UserClassPermissionRepository;
 import de.terrestris.shogun.lib.service.BaseServiceTest;
+import de.terrestris.shogun.lib.service.security.provider.keycloak.KeycloakUserProviderService;
 import org.junit.Before;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
 
 public class UserClassPermissionServiceTest extends BaseServiceTest<UserClassPermissionService, UserClassPermission> {
 
     @Mock
     UserClassPermissionRepository repositoryMock;
 
+    @Mock
+    KeycloakUserProviderService userProviderService = new KeycloakUserProviderService();
+
     @InjectMocks
     UserClassPermissionService service;
 
     @Before
     public void init() {
+        when(userProviderService.getUserBySession()).thenReturn(Optional.of(new User()));
         super.setRepository(repositoryMock);
         super.setService(service);
         super.setEntityClass(UserClassPermission.class);

--- a/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/security/permission/UserInstancePermissionServiceTest.java
+++ b/shogun-lib/src/test/java/de/terrestris/shogun/lib/service/security/permission/UserInstancePermissionServiceTest.java
@@ -16,23 +16,33 @@
  */
 package de.terrestris.shogun.lib.service.security.permission;
 
+import de.terrestris.shogun.lib.model.User;
 import de.terrestris.shogun.lib.model.security.permission.UserInstancePermission;
 import de.terrestris.shogun.lib.repository.security.permission.UserInstancePermissionRepository;
 import de.terrestris.shogun.lib.service.BaseServiceTest;
+import de.terrestris.shogun.lib.service.security.provider.keycloak.KeycloakUserProviderService;
 import org.junit.Before;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
 
 public class UserInstancePermissionServiceTest extends BaseServiceTest<UserInstancePermissionService, UserInstancePermission> {
 
     @Mock
     UserInstancePermissionRepository repositoryMock;
 
+    @Mock
+    KeycloakUserProviderService userProviderService = new KeycloakUserProviderService();
+
     @InjectMocks
     UserInstancePermissionService service;
 
     @Before
     public void init() {
+        when(userProviderService.getUserBySession()).thenReturn(Optional.of(new User()));
         super.setRepository(repositoryMock);
         super.setService(service);
         super.setEntityClass(UserInstancePermission.class);

--- a/shogun-proxy/src/main/java/de/terrestris/shogun/config/HttpProxyWebSecurityConfig.java
+++ b/shogun-proxy/src/main/java/de/terrestris/shogun/config/HttpProxyWebSecurityConfig.java
@@ -20,10 +20,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 
 @Configuration
-public class HttpProxyWebSecurityConfig extends WebSecurityConfig {
+public class HttpProxyWebSecurityConfig implements WebSecurityConfig {
 
     @Override
-    protected void customHttpConfiguration(HttpSecurity http) throws Exception {
+    public void customHttpConfiguration(HttpSecurity http) throws Exception {
         http
             .authorizeRequests()
             .anyRequest()


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

Currently SHOGun is capable to deal with Keycloak as authentication provider only. Even if Keycloak supports a broad range of external connectors (LDAP, OAuth2, …) in some scenarios it is required to become compatible with a custom provider.

This MR suggests to make all existing Keycloak related operations optional.

### Disable/Enable built-in Keycloak support

To decide whether to make use of Keycloak or not, a new property `keycloak.enabled` (default is to `true`) has been introduced. Example configuration for the `application.yml`:

```
keycloak:
  enabled: false
```

In case of `true` default implementations of the Keycloak integration in SHOGun will be used. For `false` projects need to implement several methods by itself (see ahead).

### Provider services

Two new interfaces have been introduced that hold the methods required in the context of authentication:

- `GroupProviderService`
   - Default implementation: `KeycloakGroupProviderService`
- `UserProviderService`
   - Default implementation: `KeycloakUserProviderService`

### Breaking changes

#### BootWebSecurityConfig

Previously SHOGun applications needed to extend the `BootWebSecurityConfig`, now it's either:

- `KeycloakBootWebSecurityConfig` if Keycloak is active
- `SimpleBootWebSecurityConfig` if Keycloak is not active

#### SecurityContextUtil

All Keycloak specific methods have been moved to the `UserProviderService` or `KeycloakUtil`:

- `getUserBySession()` -> `UserProviderService.getUserBySession()`
- `getUserFromAuthentication()` -> `UserProviderService.getUserFromAuthentication()`
- `getKeycloakUserIdFromAuthentication()` -> `KeycloakUtil.getKeycloakUserIdFromAuthentication()`
- `getGroupsForUser -> `GroupProviderService.findByUser`
- `isUserInGroup()` -> removed

#### Services

- Removed deprecated method `GroupService.findByKeycloakId()`
- `GroupService.setTransientKeycloakRepresentations()` -> `GroupProviderService.setTransientRepresentations()`
- `UserService.findOrCreateByKeyCloakId()` -> `UserProviderService.findOrCreateByProviderId()`

#### User

- The field `keycloakId` is renamed to `authProviderId`
- The field `keycloakRepresentation` is renamed to `providerDetails`
- The `User` class requires a type argument for the authentication provider details object.

#### Group

- The field `keycloakId` is renamed to `authProviderId`
- The field `keycloakRepresentation` is renamed to `providerDetails`
- The `Group` class requires a type argument for the authentication provider details object.

#### GroupRepository

- `findByKeycloakId()` has been renamed to `findByAuthProviderId()`

#### UserRepository

- `findByKeycloakId()` has been renamed to `findByAuthProviderId()`

#### GroupController

- GET endpoint `/groups/keycloak/{id}` has been removed

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [x] Yes
- [ ] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
