### PR TITLE
Default JSONB (de-)serializers

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/annotation/JsonSuperType.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/annotation/JsonSuperType.java
@@ -26,7 +26,8 @@ import java.lang.annotation.Target;
  * The `JsonSuperType` annotation helps to identify a type that should be deserialized instead of a parent type.
  * The `type` property specifies the parent type. This annotation needs to go along with a `JsonDeserialize` pointing
  * to the own type.
- * If the super type that should get replaced is not an interface, than `override` needs to be set to `true`.
+ * If the super type that should get replaced is already used by another parent, and it should be overridden by another
+ * type, then `override` needs to be set to `true`.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/config/SwaggerConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/config/SwaggerConfig.java
@@ -16,28 +16,33 @@
  */
 package de.terrestris.shogun.lib.config;
 
+import com.fasterxml.classmate.TypeResolver;
 import de.terrestris.shogun.lib.annotation.JsonSuperType;
 import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
-import org.reflections.scanners.TypeAnnotationsScanner;
+import org.reflections.scanners.Scanners;
 import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.schema.AlternateTypeRules;
 import springfox.documentation.service.*;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 
-import java.util.Collections;
+import java.util.*;
 import java.util.function.Predicate;
 
 @Configuration
 @EnableAutoConfiguration
 public abstract class SwaggerConfig {
+
+    @Autowired
+    private TypeResolver typeResolver;
 
     protected String title = "SHOGun REST API";
     protected String description = "This is the REST API description of SHOGun";
@@ -81,18 +86,69 @@ public abstract class SwaggerConfig {
     protected void directModelSubsitutions(Docket docket) {
         var reflections = new Reflections(new ConfigurationBuilder()
             .setUrls(ClasspathHelper.forJavaClassPath())
-            .setScanners(new SubTypesScanner(), new TypeAnnotationsScanner()));
+            .setScanners(
+                Scanners.SubTypes,
+                Scanners.TypesAnnotated
+            )
+        );
+
+        Map<Class<?>, Class<?>> substitutions = new HashMap<>();
 
         for (var cl : reflections.getTypesAnnotatedWith(JsonSuperType.class)) {
             var annotation = cl.getAnnotation(JsonSuperType.class);
             var superType = annotation.type();
 
-            if (!annotation.override() && !superType.isInterface()) {
-                throw new IllegalStateException("The super type " + superType.getName() + " is not an interface. " +
-                    "Set override to true if this is intended.");
+            if (!substitutions.containsKey(superType)) {
+                substitutions.put(superType, cl);
+                continue;
             }
 
+            var previous = substitutions.get(superType);
+
+            var currentOverride = annotation.override();
+            var previousOverride = previous.getAnnotation(JsonSuperType.class).override();
+
+            if (currentOverride && previousOverride) {
+                throw new IllegalStateException("Found two types (" + cl.getName() + ", " + previous.getName() + ") " +
+                    "that both want to (de-)serialize to the type " + superType.getName() + " and both have set " +
+                    "override to true. Override must be set for a single type only.");
+            }
+
+            if (!currentOverride && !previousOverride) {
+                throw new IllegalStateException("Found two types (" + cl.getName() + ", " + previous.getName() + ") " +
+                    "that both want to (de-)serialize to the type " + superType.getName() + ". Any existing type " +
+                    "should get extended.");
+            }
+
+            if (previousOverride) {
+                continue;
+            }
+
+            if (annotation.override()) {
+                substitutions.remove(previous);
+                substitutions.put(superType, cl);
+            }
+        }
+
+        for (var entry : substitutions.entrySet()) {
+            Class<?> superType = entry.getKey();
+            Class<?> cl = entry.getValue();
+
             docket.directModelSubstitute(superType, cl);
+            docket.alternateTypeRules(
+                AlternateTypeRules.newRule(
+                    typeResolver.resolve(List.class, superType),
+                    typeResolver.resolve(List.class, cl)
+                ),
+                AlternateTypeRules.newRule(
+                    typeResolver.resolve(Set.class, superType),
+                    typeResolver.resolve(Set.class, cl)
+                ),
+                AlternateTypeRules.newRule(
+                    typeResolver.resolve(Collection.class, superType),
+                    typeResolver.resolve(Collection.class, cl)
+                )
+            );
         }
     }
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Layer.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Layer.java
@@ -56,7 +56,7 @@ public class Layer extends BaseEntity {
     @ToString.Exclude
     @Schema(
         description = "The configuration of the layer which should be used to define client specific aspects of " +
-            "the layer. This may include the name, the visible resolution range, search configurations or similiar."
+            "the layer. This may include the name, the visible resolution range, search configurations or similar."
     )
     private LayerClientConfig clientConfig;
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationClientConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationClientConfig.java
@@ -1,3 +1,19 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2022-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.terrestris.shogun.lib.model.jsonb.application;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationClientConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationClientConfig.java
@@ -1,0 +1,29 @@
+package de.terrestris.shogun.lib.model.jsonb.application;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import de.terrestris.shogun.lib.annotation.JsonSuperType;
+import de.terrestris.shogun.lib.model.jsonb.ApplicationClientConfig;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@Data
+@JsonDeserialize(as = DefaultApplicationClientConfig.class)
+@JsonSuperType(type = ApplicationClientConfig.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@ToString
+@EqualsAndHashCode
+public class DefaultApplicationClientConfig implements ApplicationClientConfig {
+    @Schema(
+        description = "The configuration of the map view.",
+        required = true
+    )
+    private DefaultMapView mapView;
+
+    @Schema(
+        description = "The description of the application."
+    )
+    private String description;
+}

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationLayerConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationLayerConfig.java
@@ -1,3 +1,19 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2022-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.terrestris.shogun.lib.model.jsonb.application;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationLayerConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationLayerConfig.java
@@ -1,0 +1,32 @@
+package de.terrestris.shogun.lib.model.jsonb.application;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import de.terrestris.shogun.lib.annotation.JsonSuperType;
+import de.terrestris.shogun.lib.model.jsonb.LayerConfig;
+import de.terrestris.shogun.lib.model.jsonb.layer.DefaultLayerClientConfig;
+import de.terrestris.shogun.lib.model.jsonb.layer.DefaultLayerSourceConfig;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@Data
+@JsonDeserialize(as = DefaultApplicationLayerConfig.class)
+@JsonSuperType(type = LayerConfig.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@ToString
+@EqualsAndHashCode
+public class DefaultApplicationLayerConfig implements LayerConfig {
+    @Schema(
+        description = "The configuration of the layer which should be used to define client specific aspects of " +
+            "the layer. This may include the name, the visible resolution range, search configurations or similar."
+    )
+    private DefaultLayerClientConfig clientConfig;
+
+    @Schema(
+        description = "The configuration of the datasource of the layer, e.g. the URL of the server, the name or " +
+            "the grid configuration."
+    )
+    private DefaultLayerSourceConfig sourceConfig;
+}

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationToolConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationToolConfig.java
@@ -1,0 +1,32 @@
+package de.terrestris.shogun.lib.model.jsonb.application;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import de.terrestris.shogun.lib.annotation.JsonSuperType;
+import de.terrestris.shogun.lib.model.jsonb.ApplicationToolConfig;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.HashMap;
+
+@Data
+@JsonDeserialize(as = DefaultApplicationToolConfig.class)
+@JsonSuperType(type = ApplicationToolConfig.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@ToString
+@EqualsAndHashCode
+public class DefaultApplicationToolConfig implements ApplicationToolConfig {
+    @Schema(
+        description = "The name of the tool.",
+        example = "map-tool"
+    )
+    private String name;
+
+    @Schema(
+        description = "The configuration object of the tool.",
+        example = "{\"visible\": true}"
+    )
+    private HashMap<String, Object> config;
+}

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationToolConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationToolConfig.java
@@ -1,3 +1,19 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2022-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.terrestris.shogun.lib.model.jsonb.application;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultLayerTree.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultLayerTree.java
@@ -1,3 +1,19 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2022-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.terrestris.shogun.lib.model.jsonb.application;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultLayerTree.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultLayerTree.java
@@ -1,0 +1,45 @@
+package de.terrestris.shogun.lib.model.jsonb.application;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import de.terrestris.shogun.lib.annotation.JsonSuperType;
+import de.terrestris.shogun.lib.model.jsonb.LayerTree;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.ArrayList;
+
+@Data
+@JsonDeserialize(as = DefaultLayerTree.class)
+@JsonSuperType(type = LayerTree.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@ToString
+@EqualsAndHashCode
+public class DefaultLayerTree implements LayerTree {
+    @Schema(
+        description = "The title of the node to show.",
+        example = "Layer A"
+    )
+    private String title;
+
+    @Schema(
+        description = "Whether the node should be checked initially or not.",
+        example = "true"
+    )
+    private Boolean checked;
+
+    @Schema(
+        description = "The ID of the layer to associate to the node.",
+        example = "1909"
+    )
+    private Integer layerId;
+
+    @Schema(
+        description = "The children configuration",
+        example = "[]"
+    )
+    private ArrayList<DefaultLayerTree> children;
+}
+

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultMapView.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultMapView.java
@@ -1,0 +1,44 @@
+package de.terrestris.shogun.lib.model.jsonb.application;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+
+@Data
+@ToString
+@EqualsAndHashCode
+public class DefaultMapView implements Serializable {
+    @Schema(
+        description = "The initial zoom level of the map.",
+        example = "1"
+    )
+    private Integer zoom;
+
+    @Schema(
+        description = "The initial center of the map (in WGS84).",
+        example = "[10.3, 51.08]"
+    )
+    private ArrayList<Double> center;
+
+    @Schema(
+        description = "The maximum extent of the map (in WGS84).",
+        example = "[2.5683045738288137, 45.429089001638076, 19.382621082401887, 57.283993958205926]"
+    )
+    private ArrayList<Double> extent;
+
+    @Schema(
+        description = "The projection of the map.",
+        example = "EPSG:25832"
+    )
+    private String projection;
+
+    @Schema(
+        description = "The list of resolutions/zoom levels of the map.",
+        example = "[2445.9849047851562, 1222.9924523925781, 611.4962261962891, 305.74811309814453, 152.87405654907226, 76.43702827453613, 38.218514137268066, 19.109257068634033, 9.554628534317017, 4.777314267158508, 2.388657133579254, 1.194328566789627, 0.5971642833948135, 0.298582142, 0.149291071, 0.074645535]"
+    )
+    private ArrayList<Double> resolutions;
+}

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultMapView.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultMapView.java
@@ -1,3 +1,19 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2022-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.terrestris.shogun.lib.model.jsonb.application;
 
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerClientConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerClientConfig.java
@@ -1,3 +1,19 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2022-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.terrestris.shogun.lib.model.jsonb.layer;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerClientConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerClientConfig.java
@@ -1,0 +1,62 @@
+package de.terrestris.shogun.lib.model.jsonb.layer;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import de.terrestris.shogun.lib.annotation.JsonSuperType;
+import de.terrestris.shogun.lib.model.jsonb.LayerClientConfig;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+@Data
+@JsonDeserialize(as = DefaultLayerClientConfig.class)
+@JsonSuperType(type = LayerClientConfig.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@ToString
+@EqualsAndHashCode
+public class DefaultLayerClientConfig implements LayerClientConfig {
+    @Schema(
+        description = "The minimum resolution of the layer (at what resolution/zoom level the layer should become visible).",
+        example = "305.74811309814453"
+    )
+    private Double minResolution;
+
+    @Schema(
+        description = "The maximum resolution of the layer (to which resolution/zoom level the layer should be visible).",
+        example = "2500"
+    )
+    private Double maxResolution;
+
+    @Schema(
+        description = "Whether the layer is hoverable or not.",
+        example = "true"
+    )
+    private Boolean hoverable;
+
+    @Schema(
+        description = "Whether the layer is searchable or not.",
+        example = "true"
+    )
+    private Boolean searchable;
+
+    @Schema(
+        description = "The search configuration."
+    )
+    private Map<String, Object> searchConfig;
+
+    @Schema(
+        description = "The property configuration."
+    )
+    private ArrayList<DefaultLayerPropertyConfig> propertyConfig;
+
+    @Schema(
+        description = "The cross Origin mode to use.",
+        example = "anonymous"
+    )
+    private String crossOrigin;
+}
+

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerPropertyConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerPropertyConfig.java
@@ -1,0 +1,36 @@
+package de.terrestris.shogun.lib.model.jsonb.layer;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.io.Serializable;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@ToString
+@EqualsAndHashCode
+public class DefaultLayerPropertyConfig implements Serializable {
+
+    @Schema(
+        description = "The name of the property.",
+        example = "description",
+        required = true
+    )
+    private String propertyName;
+
+    @Schema(
+        description = "The name of the attribute to show.",
+        example = "Description"
+    )
+    private String displayName;
+
+    @Schema(
+        description = "Whether the attribute should be shown or not.",
+        example = "true"
+    )
+    private boolean visible = true;
+}
+

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerPropertyConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerPropertyConfig.java
@@ -1,3 +1,19 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2022-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.terrestris.shogun.lib.model.jsonb.layer;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerSourceConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerSourceConfig.java
@@ -1,3 +1,19 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2022-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.terrestris.shogun.lib.model.jsonb.layer;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerSourceConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerSourceConfig.java
@@ -1,0 +1,63 @@
+package de.terrestris.shogun.lib.model.jsonb.layer;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import de.terrestris.shogun.lib.annotation.JsonSuperType;
+import de.terrestris.shogun.lib.model.jsonb.LayerSourceConfig;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.util.ArrayList;
+
+@Data
+@JsonDeserialize(as = DefaultLayerSourceConfig.class)
+@JsonSuperType(type = LayerSourceConfig.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@ToString
+@EqualsAndHashCode
+public class DefaultLayerSourceConfig implements LayerSourceConfig {
+    @Schema(
+        description = "The base URL of the layer.",
+        example = "https://ows.terrestris.de/ows"
+    )
+    private String url;
+
+    @Schema(
+        description = "A comma separated list of layers to request.",
+        example = "layerA"
+    )
+    private String layerNames;
+
+    @Schema(
+        description = "A custom legend URL.",
+        example = "https://ows.terrestris.de/ows/my-legend.png"
+    )
+    private String legendUrl;
+
+    @Schema(
+        description = "The tile size.",
+        example = "512"
+    )
+    private Double tileSize;
+
+    @Schema(
+        description = "The tile origin.",
+        example = "[239323.44497139292, 4290144.074117256]"
+    )
+    private ArrayList<Double> tileOrigin;
+
+    @Schema(
+        description = "The list of resolutions the layer should be requested on.",
+        example = "[2445.9849047851562, 1222.9924523925781, 611.4962261962891, 305.74811309814453, 152.87405654907226, 76.43702827453613, 38.218514137268066, 19.109257068634033, 9.554628534317017, 4.777314267158508]"
+    )
+    private ArrayList<Double> resolutions;
+
+    @Schema(
+        description = "The attribution to show.",
+        example = "© by terrestris GmbH & Co. KG"
+    )
+    private String attribution;
+}
+

--- a/shogun-lib/src/main/resources/graphql/shogun.graphqls
+++ b/shogun-lib/src/main/resources/graphql/shogun.graphqls
@@ -1398,7 +1398,7 @@ type Layer implements BaseEntity {
     name: String
     """
     The configuration of the layer which should be used to define client specific aspects of the layer. This may include
-    the name, the visible resolution range, search configurations or similiar. For example:
+    the name, the visible resolution range, search configurations or similar. For example:
 
     ```
     {
@@ -1491,7 +1491,7 @@ type Layer implements BaseEntity {
     sourceConfig: JSON
     """
     Custom features for the layers that aren't available in the datasource. This might be used for custom draw layers
-    or similiar. It's advised to store the features using the GeoJSON format. For example:
+    or similar. It's advised to store the features using the GeoJSON format. For example:
 
     ```
     {
@@ -1666,7 +1666,7 @@ type User implements BaseEntity {
     details: JSON
     """
     The configuration of the user which should be used to define client specific aspects of the user. This may include
-    the locale set by the user, the last application visited by the user or similiar. For example:
+    the locale set by the user, the last application visited by the user or similar. For example:
 
     ```
     {


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This introduces model definitions for all JSONB interfaces (e.g. the `ApplicationClientConfig`) to provide some defaults which can be used without any project specific implementations.

**Note:** As there is a single candidate of each super type definition valid, the `JsonSuperType` annotations in existing serializers in project implementations must be updated to have the `override` flag set to true. Example:

```diff
@Data
@JsonDeserialize(as = ProjectApplicationClientConfig.class)
-@JsonSuperType(type = ApplicationClientConfig.class)
+@JsonSuperType(type = ApplicationClientConfig.class, override = true)
@JsonInclude(JsonInclude.Include.NON_NULL)
@ToString
@EqualsAndHashCode
public class ProjectApplicationClientConfig implements ApplicationClientConfig {
```

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [x] I have added a screenshot/screencast to illustrate the visual output of my update.
