### PR TITLE
test: deactivate swagger for test profiles

### DIFF
--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootSwaggerConfig.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/config/BootSwaggerConfig.java
@@ -19,6 +19,7 @@ package de.terrestris.shogun.boot.config;
 import de.terrestris.shogun.lib.config.SwaggerConfig;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.service.ApiInfo;
 
@@ -27,6 +28,7 @@ import java.util.function.Predicate;
 
 @Configuration
 @EnableAutoConfiguration
+@Profile(value = {"!test"})
 public class BootSwaggerConfig extends SwaggerConfig {
 
     @Override

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/config/SwaggerConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/config/SwaggerConfig.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.schema.AlternateTypeRules;
@@ -39,6 +40,7 @@ import java.util.function.Predicate;
 
 @Configuration
 @EnableAutoConfiguration
+@Profile(value = {"!test"})
 public abstract class SwaggerConfig {
 
     @Autowired


### PR DESCRIPTION
## Description

deactivate swagger for test profiles

## Related issues or pull requests

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
