### PR TITLE
fix: adjust onKeycloakEvent listener condition

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/listener/KeycloakEventListener.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/listener/KeycloakEventListener.java
@@ -35,7 +35,7 @@ public class KeycloakEventListener {
     @EventListener
     public void onKeycloakEvent(KeycloakEvent event) {
         switch (event.getEventType()) {
-            case USER_CREATED, USER_GROUP_MEMBERSHIP_CHANGED -> userService.findOrCreateByKeyCloakId(event.getKeycloakId());
+            case USER_CREATED -> userService.findOrCreateByKeyCloakId(event.getKeycloakId());
             case GROUP_CREATED -> groupService.findOrCreateByKeycloakId(event.getKeycloakId());
         }
     }


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

Removes the `USER_GROUP_MEMBERSHIP_CHANGED` condition. When a user changes group membership that should not require the user to be created in shogun.

Currently this results in conflicts with other event listeners.

@terrestris/devs Please review

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
