### PR TITLE
Remove local override of the `git.commit.id.abbrev` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,6 @@
     <mockito.version>4.4.0</mockito.version>
     <maven-dependency-plugin.version>3.3.0</maven-dependency-plugin.version>
     <maven-project-info-reports-plugin.version>3.2.1</maven-project-info-reports-plugin.version>
-    <git.commit.id.abbrev>unknown</git.commit.id.abbrev>
   </properties>
 
   <build>
@@ -204,6 +203,7 @@
                 <additionalProperties>
                   <encoding.source>${project.encoding}</encoding.source>
                   <encoding.reporting>${project.encoding}</encoding.reporting>
+                  <!--suppress UnresolvedMavenProperty -->
                   <commithash>${git.commit.id.abbrev}</commithash>
                 </additionalProperties>
               </configuration>


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This reverts the local override of the `git.commit.id.abbrev` to fix the commit-based docker images:

![image](https://user-images.githubusercontent.com/1137620/167562966-d99b3112-b443-47ba-b5df-5341a716fa4b.png)

Please note @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [x] I have added a screenshot/screencast to illustrate the visual output of my update.
