### PR TITLE
Introduce theming for applications

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationTheme.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationTheme.java
@@ -16,37 +16,36 @@
  */
 package de.terrestris.shogun.lib.model.jsonb.application;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import de.terrestris.shogun.lib.annotation.JsonSuperType;
-import de.terrestris.shogun.lib.model.jsonb.ApplicationClientConfig;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
+import java.io.Serializable;
+
 @Data
-@JsonDeserialize(as = DefaultApplicationClientConfig.class)
-@JsonSuperType(type = ApplicationClientConfig.class)
-@JsonInclude(JsonInclude.Include.NON_NULL)
 @ToString
 @EqualsAndHashCode
-public class DefaultApplicationClientConfig implements ApplicationClientConfig {
+public class DefaultApplicationTheme implements Serializable {
 
     @Schema(
-        description = "The configuration of the map view.",
-        required = true
+        description = "The primary color."
     )
-    private DefaultMapView mapView;
+    private String primaryColor;
 
     @Schema(
-        description = "The description of the application."
+        description = "The secondary color."
     )
-    private String description;
+    private String secondaryColor;
 
     @Schema(
-        description = "The configuration of the applications theme."
+        description = "The complementary color (e.g. text color, icon color on buttons, …)."
     )
-    private DefaultApplicationTheme theme;
+    private String complementaryColor;
+
+    @Schema(
+        description = "The path to the logo."
+    )
+    private String logoPath;
 
 }


### PR DESCRIPTION
## Description

This introduces the possibility to add a theme to the Application.
Therefore the `DefaultApplicationTheme` is introduced. It is used by `DefaultApplicationClientConfig`.

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [x] I have added a screenshot/screencast to illustrate the visual output of my update.
