### PR TITLE
feat: allow cacheService to evict specific regions

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/CacheController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/CacheController.java
@@ -51,7 +51,7 @@ public class CacheController {
 
         try {
             if (regions == null || regions.isEmpty()) {
-                service.evictAllCacheRegions();
+                service.evictCache();
                 log.info("Successfully evicted all cache regions.");
             } else {
                 service.evictCacheRegions(regions.toArray(new String[]{}));

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/CacheController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/CacheController.java
@@ -61,7 +61,7 @@ public class CacheController {
             return ResponseEntity.ok().build();
         } catch (Exception e) {
             log.error("Could not evict the cache: {}", e.getMessage());
-            log.trace("Full stack trace:", e);
+            log.trace("Full stack trace: ", e);
 
             throw new ResponseStatusException(
                 HttpStatus.INTERNAL_SERVER_ERROR,

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/CacheController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/CacheController.java
@@ -26,8 +26,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
 
 @Log4j2
 @RestController
@@ -42,19 +45,23 @@ public class CacheController {
     protected MessageSource messageSource;
 
     @PostMapping("/evict")
-    public ResponseEntity<?> evictCache() {
+    public ResponseEntity<?> evictCache(@RequestParam(required = false) List<String> regions) {
 
         log.info("Requested to evict the cache.");
 
         try {
-            service.evictCache();
-
-            log.info("Successfully evicted the cache.");
+            if (regions == null || regions.isEmpty()) {
+                service.evictAllCacheRegions();
+                log.info("Successfully evicted all cache regions.");
+            } else {
+                service.evictCacheRegions(regions.toArray(new String[]{}));
+                log.info("Successfully evicted cache regions {}", regions);
+            }
 
             return ResponseEntity.ok().build();
         } catch (Exception e) {
             log.error("Could not evict the cache: {}", e.getMessage());
-            log.trace("Full stack trace: {}", e);
+            log.trace("Full stack trace:", e);
 
             throw new ResponseStatusException(
                 HttpStatus.INTERNAL_SERVER_ERROR,

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/CacheService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/CacheService.java
@@ -54,16 +54,15 @@ public class CacheService {
         }
         if (entityManager == null) {
             throw new Exception("Could not get the entity manager.");
-        } else {
-            EntityManagerFactory entityManagerFactory = entityManager.getEntityManagerFactory();
-            SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
-            Cache cache = sessionFactory.getCache();
-            for (String r : region) {
-                if (StringUtils.isEmpty(r)) {
-                    continue;
-                }
-                cache.evictRegion(r);
+        }
+        EntityManagerFactory entityManagerFactory = entityManager.getEntityManagerFactory();
+        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
+        Cache cache = sessionFactory.getCache();
+        for (String r : region) {
+            if (StringUtils.isEmpty(r)) {
+                continue;
             }
+            cache.evictRegion(r);
         }
     }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/CacheService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/CacheService.java
@@ -33,7 +33,7 @@ public class CacheService {
     @PersistenceContext
     private EntityManager entityManager;
 
-    public void evictAllCacheRegions() throws Exception {
+    public void evictCache() throws Exception {
 
         if (entityManager == null) {
            throw new Exception("Could not get the entity manager.");

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/CacheService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/CacheService.java
@@ -62,7 +62,12 @@ public class CacheService {
             if (StringUtils.isEmpty(r)) {
                 continue;
             }
-            cache.evictRegion(r);
+            try {
+                cache.evictRegion(r);
+            } catch (NullPointerException e) {
+                log.error("Could not find cache region {}. Region was not cleared.", r);
+                log.trace("Full stack trace", e);
+            }
         }
     }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/CacheService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/CacheService.java
@@ -16,20 +16,24 @@
  */
 package de.terrestris.shogun.lib.service;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.PersistenceContext;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Cache;
 import org.hibernate.SessionFactory;
 import org.springframework.stereotype.Service;
 
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceContext;
+
 @Service
+@Log4j2
 public class CacheService {
 
     @PersistenceContext
     private EntityManager entityManager;
 
-    public void evictCache() throws Exception {
+    public void evictAllCacheRegions() throws Exception {
 
         if (entityManager == null) {
            throw new Exception("Could not get the entity manager.");
@@ -42,5 +46,24 @@ public class CacheService {
         Cache cache = sessionFactory.getCache();
 
         cache.evictAllRegions();
+    }
+
+    public void evictCacheRegions(String... region) throws Exception {
+        if (region == null) {
+            return;
+        }
+        if (entityManager == null) {
+            throw new Exception("Could not get the entity manager.");
+        } else {
+            EntityManagerFactory entityManagerFactory = entityManager.getEntityManagerFactory();
+            SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
+            Cache cache = sessionFactory.getCache();
+            for (String r : region) {
+                if (StringUtils.isEmpty(r)) {
+                    continue;
+                }
+                cache.evictRegion(r);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

Allows cacheController / cacheService to evict specific regions. i.e.:

```bash
curl -k -v -X POST 'https://localhost/cache/evict?regions=layers,groups,files'
```

`CacheService::evictCacheRegions` can be called with multiple regions:

```java
@Autowired
CacheService cacheService;

cacheService.evictCacheRegions("layers", "topics", "groups");
```

@terrestris/devs Please review

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
