### PR TITLE
Rename mod columns in revision tables according the auth provider chainage in V0.11.0

### DIFF
--- a/shogun-boot/src/main/resources/db/migration/V0.11.1__rename_keycloak_id_mod.sql
+++ b/shogun-boot/src/main/resources/db/migration/V0.11.1__rename_keycloak_id_mod.sql
@@ -1,0 +1,2 @@
+alter table if exists shogun_rev.users_rev rename column keycloak_id_mod to auth_provider_id_mod;
+alter table if exists shogun_rev.groups_rev rename column keycloak_id_mod to auth_provider_id_mod;


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->
Since `keycloak_id` columns haven been renamed in `V0.11.0__rename_keycloak_id.sql` for user and group table (and revision table) the corresponding `_mod` column has to be renamed as well.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
