### PR TITLE
Configurable layer parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <log4j2.version>2.17.2</log4j2.version>
 
     <!-- Testing -->
-    <testcontainers.version>1.17.2</testcontainers.version>
+    <testcontainers.version>1.17.3</testcontainers.version>
     <junit.jupiter.version>5.7.1</junit.jupiter.version>
     <mockito.version>4.4.0</mockito.version>
     <maven-dependency-plugin.version>3.3.0</maven-dependency-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <keycloak.version>15.0.2</keycloak.version>
 
     <!-- Database -->
-    <hibernate-extra-types.version>2.16.2</hibernate-extra-types.version>
+    <hibernate-extra-types.version>2.16.3</hibernate-extra-types.version>
 
     <!-- GraphQL -->
     <graphql-spring-boot-starter.version>5.0.2</graphql-spring-boot-starter.version>

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerSourceConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerSourceConfig.java
@@ -75,5 +75,11 @@ public class DefaultLayerSourceConfig implements LayerSourceConfig {
         example = "© by terrestris GmbH & Co. KG"
     )
     private String attribution;
+
+    @Schema(
+        description = "Whether the background of the map should be drawn transparent.",
+        example = "true"
+    )
+    private Boolean transparent;
 }
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerSourceConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerSourceConfig.java
@@ -26,6 +26,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 @Data
 @JsonDeserialize(as = DefaultLayerSourceConfig.class)
@@ -77,9 +78,9 @@ public class DefaultLayerSourceConfig implements LayerSourceConfig {
     private String attribution;
 
     @Schema(
-        description = "Whether the layer should be drawn with transparency.",
-        example = "true"
+        description = "Request parameters to be passed to the service when querying a layer.",
+        example = "requestParams: {transparent: true}"
     )
-    private Boolean transparent;
+    private Map requestParams;
 }
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerSourceConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerSourceConfig.java
@@ -81,6 +81,6 @@ public class DefaultLayerSourceConfig implements LayerSourceConfig {
         description = "Request parameters to be passed to the service when querying a layer.",
         example = "requestParams: {transparent: true}"
     )
-    private Map requestParams;
+    private HashMap<String, Object> requestParams;
 }
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerSourceConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerSourceConfig.java
@@ -26,7 +26,7 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 import java.util.ArrayList;
-import java.util.Map;
+import java.util.HashMap;
 
 @Data
 @JsonDeserialize(as = DefaultLayerSourceConfig.class)
@@ -79,7 +79,7 @@ public class DefaultLayerSourceConfig implements LayerSourceConfig {
 
     @Schema(
         description = "Request parameters to be passed to the service when querying a layer.",
-        example = "requestParams: {transparent: true}"
+        example = "{\"transparent\": true}"
     )
     private HashMap<String, Object> requestParams;
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerSourceConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerSourceConfig.java
@@ -77,7 +77,7 @@ public class DefaultLayerSourceConfig implements LayerSourceConfig {
     private String attribution;
 
     @Schema(
-        description = "Whether the background of the map should be drawn transparent.",
+        description = "Whether the layer should be drawn with transparency.",
         example = "true"
     )
     private Boolean transparent;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerSourceConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerSourceConfig.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import de.terrestris.shogun.lib.annotation.JsonSuperType;
 import de.terrestris.shogun.lib.model.jsonb.LayerSourceConfig;
+import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -77,9 +78,10 @@ public class DefaultLayerSourceConfig implements LayerSourceConfig {
     )
     private String attribution;
 
-    @Schema(
-        description = "Request parameters to be passed to the service when querying a layer.",
-        example = "{\"transparent\": true}"
+    @ApiModelProperty(
+        value = "Request parameters to be passed to the service when querying a layer.",
+        example = "{\"transparent\": true}",
+        dataType = "object"
     )
     private HashMap<String, Object> requestParams;
 }

--- a/shogun-lib/src/main/resources/graphql/shogun.graphqls
+++ b/shogun-lib/src/main/resources/graphql/shogun.graphqls
@@ -1464,7 +1464,8 @@ type Layer implements BaseEntity {
         2.388657133579254,
         1.194328566789627,
         0.5971642833948135
-      ]
+      ],
+        "transparent": true
     }
     ```
 
@@ -1485,6 +1486,7 @@ type Layer implements BaseEntity {
       private Double tileSize;
       private ArrayList<Double> tileOrigin;
       private ArrayList<Double> resolutions;
+      private Boolean transparent;
     }
     ```
     """

--- a/shogun-lib/src/main/resources/graphql/shogun.graphqls
+++ b/shogun-lib/src/main/resources/graphql/shogun.graphqls
@@ -1486,7 +1486,7 @@ type Layer implements BaseEntity {
       private Double tileSize;
       private ArrayList<Double> tileOrigin;
       private ArrayList<Double> resolutions;
-      private Map requestParams;
+      private HashMap<String, Object> requestParams;
     }
     ```
     """

--- a/shogun-lib/src/main/resources/graphql/shogun.graphqls
+++ b/shogun-lib/src/main/resources/graphql/shogun.graphqls
@@ -1465,7 +1465,7 @@ type Layer implements BaseEntity {
         1.194328566789627,
         0.5971642833948135
       ],
-        "transparent": true
+        "requestParams": {}
     }
     ```
 
@@ -1486,7 +1486,7 @@ type Layer implements BaseEntity {
       private Double tileSize;
       private ArrayList<Double> tileOrigin;
       private ArrayList<Double> resolutions;
-      private Boolean transparent;
+      private Map requestParams;
     }
     ```
     """


### PR DESCRIPTION
## Description

This PR allows to control the parameter of a layer with the optional config parameter `requestParams`. This can be done via the admin-client interface in the data source field:

```
requestParams: {
  TRANSPARENT: true,
  FORMAT: 'image/png'
}
```

@terrestris/devs please review

## Related issues or pull requests

It is connected to https://github.com/terrestris/shogun-util/pull/64, which allows to get the `requestParam` values from `sourceConfig` field.

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
