### PR TITLE
Add nullchecks before iterating over groups

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupClassPermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupClassPermissionService.java
@@ -110,6 +110,10 @@ public class GroupClassPermissionService extends BaseService<GroupClassPermissio
         // Get all groups of the user from Keycloak
         List<Group> groups = groupProviderService.findByUser(user);
         Optional<GroupClassPermission> gcp = Optional.empty();
+        if (groups == null) {
+            return gcp;
+        }
+
         for (Group g : groups) {
             Optional<GroupClassPermission> permissionsForGroup = repository
                 .findByGroupIdAndClassName(g.getId(), className);

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/permission/GroupInstancePermissionService.java
@@ -113,6 +113,9 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
         // Get all groups of the user from Keycloak
         List<Group> groups = groupProviderService.findByUser(user);
         Optional<GroupInstancePermission> gip = Optional.empty();
+        if (groups == null) {
+            return gip;
+        }
         for (Group g : groups) {
             Optional<GroupInstancePermission> permissionsForGroup = repository
                 .findByGroupIdAndEntityId(g.getId(), entity.getId());
@@ -121,7 +124,6 @@ public class GroupInstancePermissionService extends BaseService<GroupInstancePer
                 break;
             }
         }
-
         return gip;
     }
 


### PR DESCRIPTION
## Description

This adds two nullchecks before iterating over groups.

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
