### PR TITLE
feat: configure access to `/webhooks` from keycloak

### DIFF
--- a/shogun-config/src/main/java/de/terrestris/shogun/config/DefaultWebSecurityConfig.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/config/DefaultWebSecurityConfig.java
@@ -47,6 +47,7 @@ public interface DefaultWebSecurityConfig extends WebSecurityConfig {
                 .antMatchers(
                     "/actuator/**",
                     "/cache/**",
+                    "/webhooks/**",
                     "/ws/**"
                 )
                     .hasRole("ADMIN")

--- a/shogun-config/src/main/java/de/terrestris/shogun/config/DefaultWebSecurityConfig.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/config/DefaultWebSecurityConfig.java
@@ -47,7 +47,6 @@ public interface DefaultWebSecurityConfig extends WebSecurityConfig {
                 .antMatchers(
                     "/actuator/**",
                     "/cache/**",
-                    "/webhooks/**",
                     "/ws/**"
                 )
                     .hasRole("ADMIN")

--- a/shogun-config/src/main/java/de/terrestris/shogun/config/KeycloakWebSecurityConfig.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/config/KeycloakWebSecurityConfig.java
@@ -25,8 +25,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
 import javax.annotation.PostConstruct;
 import javax.net.ssl.HttpsURLConnection;

--- a/shogun-config/src/main/java/de/terrestris/shogun/config/KeycloakWebSecurityConfig.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/config/KeycloakWebSecurityConfig.java
@@ -52,6 +52,7 @@ public class KeycloakWebSecurityConfig extends WebSecurityConfigurerAdapter impl
 
     @Override
     public void configure(HttpSecurity http) throws Exception {
+        // allows access to `/webhooks/keycloak` for request from internal keycloak container
         http
             .authorizeRequests()
                 .antMatchers("/webhooks/keycloak/**")

--- a/shogun-config/src/main/java/de/terrestris/shogun/properties/KeycloakProperties.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/properties/KeycloakProperties.java
@@ -47,4 +47,6 @@ public class KeycloakProperties {
 
     private Boolean disableHostnameVerification;
 
+    private String internalServerUrl;
+
 }

--- a/shogun-config/src/main/resources/application-base.yml
+++ b/shogun-config/src/main/resources/application-base.yml
@@ -102,6 +102,7 @@ keycloak:
   client-id: shogun-boot
   principal-attribute: preferred_username
   disableHostnameVerification: true
+  internal-server-url: shogun-keycloak
 
 controller:
   applications:


### PR DESCRIPTION
## Description

Allows internal access to `/webhooks` from keycloak. The url which keycloak is available from can be configured via `keycloak.internal-server-url`. Default is `shogun-keycloak`.

The access is needed for this event listener: https://github.com/terrestris/keycloak-event-listener-shogun

~~Had to overwrite the entire `http` configuration block. Apparently it's not possible to add `antMatchers` after `anyRequest` is defined.~~ -> Now works without duplicating the entire config.

@terrestris/devs Please review.

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
