### PR TITLE
fix: fix sonarqube bugs and adjust lombok annotations

### DIFF
--- a/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/model/InterceptorRule.java
+++ b/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/model/InterceptorRule.java
@@ -21,17 +21,19 @@ import de.terrestris.shogun.interceptor.enumeration.InterceptorEnum;
 import de.terrestris.shogun.interceptor.enumeration.OgcEnum;
 import de.terrestris.shogun.lib.model.BaseEntity;
 import lombok.*;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 import javax.persistence.*;
+import java.util.Objects;
 
 @Entity
-@Data
+@Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
-@EqualsAndHashCode(callSuper = true)
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="interceptorrules")
 public class InterceptorRule extends BaseEntity {
@@ -76,4 +78,17 @@ public class InterceptorRule extends BaseEntity {
      * coverage or namespace), e.g. SHOGUN:SHINJI.
      */
     private String endPoint;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        InterceptorRule that = (InterceptorRule) o;
+        return getId() != null && Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
 }

--- a/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/util/OgcXmlUtil.java
+++ b/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/util/OgcXmlUtil.java
@@ -29,6 +29,7 @@ import org.xml.sax.SAXException;
 
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -83,6 +84,11 @@ public class OgcXmlUtil {
         try {
             InputSource source = new InputSource(new StringReader(xml));
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+
+            // limit resolution of external entities, see https://rules.sonarsource.com/c/type/Vulnerability/RSPEC-2755
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+
             DocumentBuilder builder = factory.newDocumentBuilder();
             document = builder.parse(source);
         } catch (ParserConfigurationException | SAXException | IOException e) {
@@ -186,7 +192,12 @@ public class OgcXmlUtil {
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         ) {
             Result outputTarget = new StreamResult(outputStream);
-            TransformerFactory.newInstance().newTransformer().transform(xmlSource, outputTarget);
+            TransformerFactory transformerFactory = TransformerFactory.newInstance();
+
+            // limit resolution of external entities, see https://rules.sonarsource.com/c/type/Vulnerability/RSPEC-2755
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+            transformerFactory.newTransformer().transform(xmlSource, outputTarget);
 
             try (InputStream is = new ByteArrayInputStream(outputStream.toByteArray())) {
                 request.setInputStream(is);

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/envers/ShogunRevisionMetadata.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/envers/ShogunRevisionMetadata.java
@@ -16,6 +16,7 @@
  */
 package de.terrestris.shogun.lib.envers;
 
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.hibernate.envers.DefaultRevisionEntity;
 import org.springframework.data.history.RevisionMetadata;
 import org.springframework.util.Assert;
@@ -118,5 +119,10 @@ public final class ShogunRevisionMetadata implements RevisionMetadata<Integer> {
     @Override
     public String toString() {
         return "CustomRevisionMetadata{" + "entity=" + entity + ", revisionType=" + revisionType + '}';
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37).append(entity).append(revisionType).append(changedFields).toHashCode();
     }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Application.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Application.java
@@ -22,6 +22,7 @@ import de.terrestris.shogun.lib.model.jsonb.LayerConfig;
 import de.terrestris.shogun.lib.model.jsonb.LayerTree;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Type;
@@ -30,6 +31,7 @@ import org.hibernate.envers.Audited;
 
 import javax.persistence.*;
 import java.util.List;
+import java.util.Objects;
 
 @Entity(name = "applications")
 @Table(schema = "shogun")
@@ -37,11 +39,11 @@ import java.util.List;
 @AuditTable(value = "applications_rev", schema = "shogun_rev")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="applications")
-@Data
+@Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
 public class Application extends BaseEntity {
 
     @Column
@@ -98,4 +100,17 @@ public class Application extends BaseEntity {
             "configurations for any tools in the given application, e.g. the visibility or the layers the tool should work on."
     )
     private List<ApplicationToolConfig> toolConfig;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        Application that = (Application) o;
+        return getId() != null && Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/BaseEntity.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/BaseEntity.java
@@ -17,11 +17,11 @@
 package de.terrestris.shogun.lib.model;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.TypeDefs;
@@ -31,6 +31,7 @@ import org.hibernate.envers.Audited;
 import javax.persistence.*;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 
 @MappedSuperclass
 @Audited
@@ -40,7 +41,6 @@ import java.time.OffsetDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-@EqualsAndHashCode
 @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 public abstract class BaseEntity implements Serializable {
 
@@ -76,4 +76,16 @@ public abstract class BaseEntity implements Serializable {
     )
     private OffsetDateTime modified;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        BaseEntity that = (BaseEntity) o;
+        return id != null && Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/File.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/File.java
@@ -19,11 +19,13 @@ package de.terrestris.shogun.lib.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Type;
 
 import javax.persistence.*;
+import java.util.Objects;
 import java.util.UUID;
 
 @Entity(name = "files")
@@ -33,7 +35,6 @@ import java.util.UUID;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
 public class File extends BaseEntity {
 
@@ -80,4 +81,17 @@ public class File extends BaseEntity {
     @Column
     @Getter @Setter
     private String path;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        File file = (File) o;
+        return getId() != null && Objects.equals(getId(), file.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Group.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Group.java
@@ -18,12 +18,14 @@ package de.terrestris.shogun.lib.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
 
 import javax.persistence.*;
+import java.util.Objects;
 
 @Entity(name = "groups")
 @Table(schema = "shogun")
@@ -31,11 +33,11 @@ import javax.persistence.*;
 @AuditTable(value = "groups_rev", schema = "shogun_rev")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "groups")
-@Data
+@Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
 public class Group<T> extends BaseEntity {
 
     @Column(unique = true, nullable = false)
@@ -52,4 +54,16 @@ public class Group<T> extends BaseEntity {
     )
     private T providerDetails;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        Group<?> group = (Group<?>) o;
+        return getId() != null && Objects.equals(getId(), group.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/ImageFile.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/ImageFile.java
@@ -17,26 +17,24 @@
 package de.terrestris.shogun.lib.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import org.hibernate.Hibernate;
+
 import javax.persistence.Cacheable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
-
-import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import java.util.Objects;
 
 @Entity(name = "imagefiles")
 @Table(schema = "shogun")
 @Cacheable
-@Data
+@Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
 public class ImageFile extends File {
 
     @Column
@@ -57,4 +55,17 @@ public class ImageFile extends File {
     @ToString.Exclude
     @Column(length = Integer.MAX_VALUE)
     private byte[] thumbnail;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        ImageFile imageFile = (ImageFile) o;
+        return getId() != null && Objects.equals(getId(), imageFile.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Layer.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/Layer.java
@@ -22,6 +22,7 @@ import de.terrestris.shogun.lib.model.jsonb.LayerSourceConfig;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import org.geojson.GeoJsonObject;
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Type;
@@ -29,6 +30,7 @@ import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
 
 import javax.persistence.*;
+import java.util.Objects;
 
 @Entity(name = "layers")
 @Table(schema = "shogun")
@@ -36,11 +38,11 @@ import javax.persistence.*;
 @AuditTable(value = "layers_rev", schema = "shogun_rev")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "layers")
-@Data
+@Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
 public class Layer extends BaseEntity {
 
     @Column(nullable = false)
@@ -88,4 +90,17 @@ public class Layer extends BaseEntity {
         required = true
     )
     private LayerType type;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        Layer layer = (Layer) o;
+        return getId() != null && Objects.equals(getId(), layer.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/User.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/User.java
@@ -20,6 +20,7 @@ import de.terrestris.shogun.lib.model.jsonb.UserClientConfig;
 import de.terrestris.shogun.lib.model.jsonb.UserDetails;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Type;
@@ -27,6 +28,7 @@ import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
 
 import javax.persistence.*;
+import java.util.Objects;
 
 @Entity(name = "users")
 @Table(schema = "shogun")
@@ -34,11 +36,11 @@ import javax.persistence.*;
 @AuditTable(value = "users_rev", schema = "shogun_rev")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "users")
-@Data
+@Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
 public class User<T> extends BaseEntity {
 
     @Column(unique = true, nullable = false)
@@ -74,5 +76,17 @@ public class User<T> extends BaseEntity {
     )
     private UserClientConfig clientConfig;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        User<?> user = (User<?>) o;
+        return getId() != null && Objects.equals(getId(), user.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
 }
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/ClassPermission.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/ClassPermission.java
@@ -16,30 +16,29 @@
  */
 package de.terrestris.shogun.lib.model.security.permission;
 
-import static org.hibernate.envers.RelationTargetAuditMode.NOT_AUDITED;
-
-
 import de.terrestris.shogun.lib.model.BaseEntity;
-import javax.persistence.Column;
-import javax.persistence.FetchType;
-import javax.persistence.MappedSuperclass;
-import javax.persistence.OneToOne;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.envers.Audited;
 
+import javax.persistence.Column;
+import javax.persistence.FetchType;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.OneToOne;
+
+import java.util.Objects;
+
+import static org.hibernate.envers.RelationTargetAuditMode.NOT_AUDITED;
+
 @MappedSuperclass
 @Audited
-@Data
+@Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
-@EqualsAndHashCode(callSuper = true)
 public abstract class ClassPermission extends BaseEntity {
 
     @Column
@@ -55,6 +54,19 @@ public abstract class ClassPermission extends BaseEntity {
     )
     @Fetch(FetchMode.JOIN)
     @Audited(targetAuditMode = NOT_AUDITED)
+    @ToString.Exclude
     private PermissionCollection permissions;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        ClassPermission that = (ClassPermission) o;
+        return getId() != null && Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/GroupClassPermission.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/GroupClassPermission.java
@@ -17,19 +17,18 @@
 package de.terrestris.shogun.lib.model.security.permission;
 
 import de.terrestris.shogun.lib.model.Group;
-import javax.persistence.Cacheable;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
+
+import javax.persistence.Cacheable;
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import java.util.Objects;
 
 @Entity(name = "groupclasspermissions")
 @Table(schema = "shogun")
@@ -37,15 +36,27 @@ import org.hibernate.envers.Audited;
 @AuditTable(value = "groupclasspermissions_rev", schema = "shogun_rev")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="groupclasspermissions")
-@Data
+@Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
 public class GroupClassPermission extends ClassPermission {
 
     @ManyToOne(optional = false)
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     private Group group;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        GroupClassPermission that = (GroupClassPermission) o;
+        return getId() != null && Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/GroupInstancePermission.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/GroupInstancePermission.java
@@ -17,19 +17,18 @@
 package de.terrestris.shogun.lib.model.security.permission;
 
 import de.terrestris.shogun.lib.model.Group;
-import javax.persistence.Cacheable;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
+
+import javax.persistence.Cacheable;
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import java.util.Objects;
 
 @Entity(name = "groupinstancepermissions")
 @Table(schema = "shogun")
@@ -37,15 +36,27 @@ import org.hibernate.envers.Audited;
 @AuditTable(value = "groupinstancepermissions_rev", schema = "shogun_rev")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "groupinstancepermissions")
-@Data
+@Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
 public class GroupInstancePermission extends InstancePermission {
 
     @ManyToOne(optional = false)
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     private Group group;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        GroupInstancePermission that = (GroupInstancePermission) o;
+        return getId() != null && Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/InstancePermission.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/InstancePermission.java
@@ -16,30 +16,29 @@
  */
 package de.terrestris.shogun.lib.model.security.permission;
 
-import static org.hibernate.envers.RelationTargetAuditMode.NOT_AUDITED;
-
-
 import de.terrestris.shogun.lib.model.BaseEntity;
-import javax.persistence.Column;
-import javax.persistence.FetchType;
-import javax.persistence.MappedSuperclass;
-import javax.persistence.OneToOne;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.envers.Audited;
 
+import javax.persistence.Column;
+import javax.persistence.FetchType;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.OneToOne;
+
+import java.util.Objects;
+
+import static org.hibernate.envers.RelationTargetAuditMode.NOT_AUDITED;
+
 @MappedSuperclass
 @Audited
-@Data
+@Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
-@EqualsAndHashCode(callSuper = true)
 public abstract class InstancePermission extends BaseEntity {
 
     @Column
@@ -55,6 +54,19 @@ public abstract class InstancePermission extends BaseEntity {
     )
     @Fetch(FetchMode.JOIN)
     @Audited(targetAuditMode = NOT_AUDITED)
+    @ToString.Exclude
     private PermissionCollection permissions;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        InstancePermission that = (InstancePermission) o;
+        return getId() != null && Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/PermissionCollection.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/PermissionCollection.java
@@ -19,33 +19,27 @@ package de.terrestris.shogun.lib.model.security.permission;
 import de.terrestris.shogun.lib.enumeration.PermissionCollectionType;
 import de.terrestris.shogun.lib.enumeration.PermissionType;
 import de.terrestris.shogun.lib.model.BaseEntity;
-import java.util.HashSet;
-import java.util.Set;
-import javax.persistence.Cacheable;
-import javax.persistence.CollectionTable;
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.Table;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
+import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
 @Entity(name = "permissions")
 @Table(schema = "shogun")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "permissions")
-@Data
+@Getter
+@Setter
+@ToString
 @AllArgsConstructor
 @NoArgsConstructor
-@EqualsAndHashCode(callSuper = true)
 public class PermissionCollection extends BaseEntity {
 
     @ElementCollection
@@ -59,4 +53,16 @@ public class PermissionCollection extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private PermissionCollectionType name;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        PermissionCollection that = (PermissionCollection) o;
+        return getId() != null && Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/UserClassPermission.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/UserClassPermission.java
@@ -17,19 +17,18 @@
 package de.terrestris.shogun.lib.model.security.permission;
 
 import de.terrestris.shogun.lib.model.User;
-import javax.persistence.Cacheable;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
+
+import javax.persistence.Cacheable;
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import java.util.Objects;
 
 @Entity(name = "userclasspermissions")
 @Table(schema = "shogun")
@@ -37,15 +36,27 @@ import org.hibernate.envers.Audited;
 @AuditTable(value = "userclasspermissions_rev", schema = "shogun_rev")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "userclasspermissions")
-@Data
+@Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
 public class UserClassPermission extends ClassPermission {
 
     @ManyToOne(optional = false)
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     private User user;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        UserClassPermission that = (UserClassPermission) o;
+        return getId() != null && Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/UserInstancePermission.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/UserInstancePermission.java
@@ -17,19 +17,18 @@
 package de.terrestris.shogun.lib.model.security.permission;
 
 import de.terrestris.shogun.lib.model.User;
-import javax.persistence.Cacheable;
-import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
+import org.hibernate.Hibernate;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
+
+import javax.persistence.Cacheable;
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import java.util.Objects;
 
 @Entity(name = "userinstancepermissions")
 @Table(schema = "shogun")
@@ -37,15 +36,27 @@ import org.hibernate.envers.Audited;
 @AuditTable(value = "userinstancepermissions_rev", schema = "shogun_rev")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "userinstancepermissions")
-@Data
+@Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
 public class UserInstancePermission extends InstancePermission {
 
     @ManyToOne(optional = false)
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     private User user;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        UserInstancePermission that = (UserInstancePermission) o;
+        return getId() != null && Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/impl/ShogunRevisionRepositoryImpl.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/impl/ShogunRevisionRepositoryImpl.java
@@ -63,14 +63,14 @@ public class ShogunRevisionRepositoryImpl<T, ID, N extends Number & Comparable<N
         List<Revision<N, T>> revisionList = new ArrayList<>(resultList.size());
 
         for (Object[] objects : resultList) {
-            revisionList.add(createRevision(new QueryResult<>(objects)));
+            revisionList.add(createShogunRevision(new QueryResult<>(objects)));
         }
 
         return Revisions.of(revisionList);
     }
 
     @SuppressWarnings("unchecked")
-    private Revision<N, T> createRevision(QueryResult<T> queryResult) {
+    private Revision<N, T> createShogunRevision(QueryResult<T> queryResult) {
         return Revision.of((RevisionMetadata<N>) queryResult.createRevisionMetadata(), queryResult.entity);
     }
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/security/access/BasePermissionEvaluator.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/security/access/BasePermissionEvaluator.java
@@ -77,7 +77,7 @@ public class BasePermissionEvaluator implements PermissionEvaluator {
 
         final BaseEntity persistentObject;
         if (targetDomainObject instanceof Optional) {
-            persistentObject = ((Optional<BaseEntity>) targetDomainObject).get();
+            persistentObject = ((Optional<BaseEntity>) targetDomainObject).orElseThrow();
         } else {
             persistentObject = (BaseEntity) targetDomainObject;
         }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/FileService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/FileService.java
@@ -114,7 +114,8 @@ public class FileService extends BaseFileService<FileRepository, File> {
             log.error("Error when saving file {} to disk: " + e.getMessage(), savedFile.getId());
             log.info("Rollback creation of file {}.", savedFile.getId());
             this.repository.delete(savedFile);
-            fileDirectory.delete();
+            var deleted = fileDirectory.delete();
+            log.info("Cleanup successful: {}.", deleted);
             throw e;
         }
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/ImageFileService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/ImageFileService.java
@@ -106,7 +106,8 @@ public class ImageFileService extends BaseFileService<ImageFileRepository, Image
         // Setup path and directory
         String path = fileUuid + "/" + fileName;
         java.io.File fileDirectory = new java.io.File(uploadBasePath + "/" + fileUuid);
-        fileDirectory.mkdirs();
+        boolean createdDirs = fileDirectory.mkdirs();
+        log.debug("Created new directory: {}", createdDirs);
 
         // Write multipart file data to target directory
         java.io.File outFile = new java.io.File(fileDirectory, fileName);
@@ -119,7 +120,8 @@ public class ImageFileService extends BaseFileService<ImageFileRepository, Image
             log.error("Error while saving file {} to disk: {}", e.getMessage(), savedFile.getId());
             log.info("Rollback creation of file {}.", savedFile.getId());
             this.repository.delete(savedFile);
-            fileDirectory.delete();
+            boolean deleted = fileDirectory.delete();
+            log.info("Cleanup successful: {}", deleted);
             throw e;
         }
 


### PR DESCRIPTION
## Description

Fixes some bugs detected by sonarqube (788d544a1b9a7a171172bf41dc0d780a7914d70c):

- use try-with-resources to close connections
- prevent Optional.get() without isPresent check
- prevent some NullPointerExceptions
- disable access to external entities in XML parsing (d59ee987b97760372ded30a06f1da7e4b9ea0e10)

Also replaces `@Data` annotations from JPA entites with `@Getter`, `@Setter` and manual equals- and hashCode methods. This avoids performance and memory issues (5e64a72564f4991e3f86bf42a2b1142cca2fcce3) 

@terrestris/devs Please review.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
