### PR TITLE
create shogun users in `getUserBySession` if needed

### DIFF
--- a/shogun-boot/src/main/java/de/terrestris/shogun/boot/controller/ResourceController.java
+++ b/shogun-boot/src/main/java/de/terrestris/shogun/boot/controller/ResourceController.java
@@ -35,7 +35,7 @@ public class ResourceController {
     @Autowired(required = false)
     BuildProperties buildProperties;
 
-    @RequestMapping("/")
+    @GetMapping("/")
     public ModelAndView home(ModelAndView modelAndView) {
         String buildVersion = "@VERSION@";
         if (buildProperties != null) {

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakUserProviderService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakUserProviderService.java
@@ -131,9 +131,14 @@ public class KeycloakUserProviderService implements UserProviderService<UserRepr
 
         Optional<User<UserRepresentation>> user = (Optional) userRepository.findByAuthProviderId(keycloakUserId);
 
-        user.ifPresent(this::setTransientRepresentations);
-
-        return user;
+        if (user.isPresent()) {
+            this.setTransientRepresentations(user.get());
+            return user;
+        } else {
+            log.warn("There is no shogun entity for user {}. Creating entity now.", keycloakUserId);
+            User<UserRepresentation> createdUser = findOrCreateByProviderId(keycloakUserId);
+            return Optional.of(createdUser);
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

Adds a fallback in `getUserBySession` which creates a shogun user if it does not exist yet.

Usually, the user should have been created from an event fired when the user was created in keycloak. But I think we can't always rely on that event; e.g.:

- user was created via import
- event listener plugin was not active

Also changes the generic `@RequestMapping("/")` to `@GetMapping` in ResourceController . This should be more secure. I don't think we need to allow other request types there.

@terrestris/devs Please review.

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
