### PR TITLE
Revert "build(deps): bump spring-boot.version from 2.6.7 to 2.7.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <jib-maven-plugin.version>3.2.1</jib-maven-plugin.version>
 
     <!-- Spring -->
-    <spring-boot.version>2.7.2</spring-boot.version>
+    <spring-boot.version>2.6.7</spring-boot.version>
     <spring-data.version>2.5.6</spring-data.version>
 
     <jackson-bom.version>2.13.2.20220328</jackson-bom.version>


### PR DESCRIPTION
Reverts terrestris/shogun#546

There is an issue with spring-data 2.7.2 (https://github.com/terrestris/shogun/pull/542)