### PR TITLE
fix: repair keycloak event listeners for groups

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/listener/KeycloakEventListener.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/listener/KeycloakEventListener.java
@@ -20,8 +20,8 @@ package de.terrestris.shogun.lib.listener;
 import de.terrestris.shogun.lib.enumeration.PermissionCollectionType;
 import de.terrestris.shogun.lib.event.KeycloakEvent;
 import de.terrestris.shogun.lib.event.OnRegistrationConfirmedEvent;
-import de.terrestris.shogun.lib.service.GroupService;
 import de.terrestris.shogun.lib.service.security.permission.UserInstancePermissionService;
+import de.terrestris.shogun.lib.service.security.provider.GroupProviderService;
 import de.terrestris.shogun.lib.service.security.provider.UserProviderService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
@@ -31,10 +31,10 @@ import org.springframework.stereotype.Component;
 public class KeycloakEventListener {
 
     @Autowired
-    UserProviderService userProviderService;
+    private UserProviderService userProviderService;
 
     @Autowired
-    GroupService groupService;
+    private GroupProviderService groupProviderService;
 
     @Autowired
     protected UserInstancePermissionService userInstancePermissionService;
@@ -43,7 +43,7 @@ public class KeycloakEventListener {
     public void onKeycloakEvent(KeycloakEvent event) {
         switch (event.getEventType()) {
             case USER_CREATED -> userProviderService.findOrCreateByProviderId(event.getKeycloakId());
-            case GROUP_CREATED -> groupService.findOrCreateByKeycloakId(event.getKeycloakId());
+            case GROUP_CREATED -> groupProviderService.findOrCreateByProviderId(event.getKeycloakId());
         }
     }
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/GroupService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/GroupService.java
@@ -84,7 +84,7 @@ public class GroupService extends BaseService<GroupRepository, Group> {
     }
 
     /**
-     * Finds a Group by the passed keycloak ID. If it does not exists in the SHOGun DB it gets created.
+     * Finds a Group by the passed keycloak ID. If it does not exist in the SHOGun DB it gets created.
      *
      * @param keycloakGroupId
      * @return

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakGroupProviderService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakGroupProviderService.java
@@ -134,6 +134,8 @@ public class KeycloakGroupProviderService implements GroupProviderService<UserRe
         }
     }
 
+    // disabled because there is no authentication for events invoked by keycloak via /webhooks
+    // @PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#keycloakGroupId, 'CREATE')")
     @Transactional
     public Group<GroupRepresentation> findOrCreateByProviderId(String keycloakGroupId) {
         Optional<Group<GroupRepresentation>> groupOptional = (Optional) repository.findByAuthProviderId(keycloakGroupId);

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakUserProviderService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakUserProviderService.java
@@ -63,14 +63,15 @@ public class KeycloakUserProviderService implements UserProviderService<UserRepr
     GroupProviderService groupProviderService;
 
     /**
-     * Finds a User by the passed keycloak ID. If it does not exists in the SHOGun DB it gets created.
+     * Finds a User by the passed keycloak ID. If it does not exist in the SHOGun DB it gets created.
      *
      * The groups of the user are also checked and created if needed.
      *
-     * @param keycloakUserId
+     * @param keycloakUserId UUID of keycloak user to find or create.
      * @return
      */
-//    @PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#keycloakUserId, 'CREATE')")
+    // disabled because there is no authentication for events invoked by keycloak via /webhooks
+    // @PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#keycloakUserId, 'CREATE')")
     @Transactional
     public User<UserRepresentation> findOrCreateByProviderId(String keycloakUserId) {
         Optional<User<UserRepresentation>> userOptional = (Optional) userRepository.findByAuthProviderId(keycloakUserId);


### PR DESCRIPTION
## Description

- make use of `GroupProviderService` in KeycloakEventListener
- briefly explains why security check is disabled

@terrestris/devs Please review

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
