### PR TITLE
Minor updates to the default JSON models

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationLayerConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationLayerConfig.java
@@ -34,6 +34,13 @@ import lombok.ToString;
 @ToString
 @EqualsAndHashCode
 public class DefaultApplicationLayerConfig implements LayerConfig {
+
+    @Schema(
+        description = "The ID of the layer to apply the custom configuration to.",
+        required = true
+    )
+    private Integer layerId;
+
     @Schema(
         description = "The configuration of the layer which should be used to define client specific aspects of " +
             "the layer. This may include the name, the visible resolution range, search configurations or similar."

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationToolConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationToolConfig.java
@@ -36,7 +36,8 @@ import java.util.HashMap;
 public class DefaultApplicationToolConfig implements ApplicationToolConfig {
     @Schema(
         description = "The name of the tool.",
-        example = "map-tool"
+        example = "map-tool",
+        required = true
     )
     private String name;
 


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This makes the tool name of the `DefaultApplicationToolConfig` required and adds the `layerId` field to the `DefaultApplicationLayerConfig` to make it actually assignable to a layer.

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
