### PR TITLE
feat(WebhookController): add the group as an additional keycloak id to the `USER_GROUP_MEMBERSHIP_CHANGED` event

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/WebhookController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/WebhookController.java
@@ -52,7 +52,8 @@ public class WebhookController {
             case "GROUP_MEMBERSHIP" -> applicationEventPublisher.publishEvent(new KeycloakEvent(
                 this,
                 KeycloakEventType.USER_GROUP_MEMBERSHIP_CHANGED,
-                split[1]
+                split[1],
+                split[3]
             ));
             case "USER" -> {
                 if (StringUtils.equals(eventType, "CREATE")) {

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/event/KeycloakEvent.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/event/KeycloakEvent.java
@@ -26,9 +26,23 @@ public class KeycloakEvent extends ApplicationEvent {
     @Getter
     private final String keycloakId;
 
+    /**
+     * In case of a `USER_GROUP_MEMBERSHIP_CHANGED` event, the additionalKeycloakId will contain the keycloak id of the changed group.
+     */
+    @Getter
+    private final String additionalKeycloakId;
+
     public KeycloakEvent(Object source, KeycloakEventType eventType, String keycloakId) {
         super(source);
         this.eventType = eventType;
         this.keycloakId = keycloakId;
+        this.additionalKeycloakId = null;
+    }
+
+    public KeycloakEvent(Object source, KeycloakEventType eventType, String keycloakId, String additionalKeycloakId) {
+        super(source);
+        this.eventType = eventType;
+        this.keycloakId = keycloakId;
+        this.additionalKeycloakId = additionalKeycloakId;
     }
 }


### PR DESCRIPTION
## Description

This PR adds the keycloak group id of the changed group to the `USER_GROUP_MEMBERSHIP_CHANGED` keycloak event.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
