### PR TITLE
fix: fix GraphQL tests and GeometryScalar

### DIFF
--- a/shogun-boot/src/test/resources/application-test.yml
+++ b/shogun-boot/src/test/resources/application-test.yml
@@ -30,6 +30,9 @@ spring:
         jwt:
           issuer-uri: https://localhost/auth/realms/SHOGun
           jwk-set-uri: https://localhost/auth/realms/SHOGun/protocol/openid-connect/certs
+  graphql:
+    graphiql:
+      enabled: true
 
 keycloak:
   enabled: true

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/scalar/GeometryScalar.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/scalar/GeometryScalar.java
@@ -18,6 +18,7 @@ package de.terrestris.shogun.lib.graphql.scalar;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import de.terrestris.shogun.lib.config.JacksonConfig;
 import graphql.Internal;
 import graphql.language.StringValue;
 import graphql.schema.*;
@@ -31,7 +32,7 @@ import java.util.HashMap;
 public class GeometryScalar {
     private GeometryScalar() {}
 
-    static ObjectMapper om = new ObjectMapper();
+    static ObjectMapper om = (new JacksonConfig()).objectMapper();
 
     static final Coercing<Object, Object> GEOMETRY_COERCING = new Coercing<>() {
         @Override
@@ -52,10 +53,9 @@ public class GeometryScalar {
 
         @Override
         public Object parseValue(Object input) {
-            if (input instanceof String) {
-                String geometryString = (String)input;
+            if (input instanceof HashMap) {
                 try {
-                    return om.readValue(geometryString, HashMap.class);
+                    return om.readValue(om.writeValueAsString(input), Geometry.class);
                 } catch (JsonProcessingException e) {
                     throw new CoercingParseValueException("Unable to parse variable value " + input + " as a geometry");
                 }
@@ -66,7 +66,7 @@ public class GeometryScalar {
         @Override
         public Object parseLiteral(Object input) {
             if (input instanceof StringValue) {
-                String geometryString = ((StringValue) input).getValue();;
+                String geometryString = ((StringValue) input).getValue();
                 try {
                     return om.readValue(geometryString, HashMap.class);
                 } catch (JsonProcessingException e) {

--- a/shogun-proxy/pom.xml
+++ b/shogun-proxy/pom.xml
@@ -77,6 +77,12 @@
       <groupId>de.terrestris</groupId>
       <artifactId>shogun-lib</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.graphql</groupId>
+          <artifactId>spring-graphql</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <!-- SHOGun Config -->
     <dependency>


### PR DESCRIPTION
## Description

This PR fixes the test by configuring some values. It also fixes the deserialization of `GeometryScalar`s by using the correctly configured `ObjectMapper` from `JacksonConfig`.

The graphql interface seems to work, it writes and reads `Geometry`s and also reads `DateTime`s.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [ ] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
