### PR TITLE
ci: only run sonar cube if release was published

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -41,7 +41,7 @@ jobs:
           ]
 
     - name: Install dependencies
-      run: mvn install --batch-mode -DskipTests
+      run: mvn compile --batch-mode
 
     - name: Save cache
       uses: actions/cache/save@v3
@@ -50,6 +50,7 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
 
     - name: Semantic release
+      id: semantic
       uses: cycjimmy/semantic-release-action@v3
       with:
         extra_plugins: |
@@ -60,9 +61,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
     - name: Scan for unit tests
+      if: steps.semantic.outputs.new_release_published == 'true'
       run: mvn clean verify sonar:sonar --batch-mode -Dsonar.projectKey=SHOGun -Dsonar.login="${{ secrets.SONARQUBE_TOKEN }}" -Preporting
 
     - name: Refresh SonarQube
+      if: steps.semantic.outputs.new_release_published == 'true'
       run: mvn compile sonar:sonar --batch-mode -Dsonar.projectKey=SHOGun -Dsonar.host.url=${{ secrets.SONARQUBE_HOST }} -Dsonar.login="${{ secrets.SONARQUBE_TOKEN }}"
 
     - name: Save cache


### PR DESCRIPTION
## Description

only publish to sonar cube if release was published

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
