### PR TITLE
GraphQL: Re-introduce custom DateTimeScalar

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -28,6 +28,7 @@ header:
     - 'shogun-lib/src/main/java/de/terrestris/shogun/lib/envers/ShogunEnversRevisionRepositoryFactoryBean.java'
     - 'shogun-lib/src/main/java/de/terrestris/shogun/lib/envers/ShogunRevisionMetadata.java'
     - 'shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/impl/ShogunRevisionRepositoryImpl.java'
+    - 'shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/graphql/DateTimeScalar.java'
     - 'shogun-boot/target'
     - 'shogun-config/target'
     - 'shogun-gs-interceptor/target'

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -28,7 +28,7 @@ header:
     - 'shogun-lib/src/main/java/de/terrestris/shogun/lib/envers/ShogunEnversRevisionRepositoryFactoryBean.java'
     - 'shogun-lib/src/main/java/de/terrestris/shogun/lib/envers/ShogunRevisionMetadata.java'
     - 'shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/impl/ShogunRevisionRepositoryImpl.java'
-    - 'shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/graphql/DateTimeScalar.java'
+    - 'shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/scalar/DateTimeScalar.java'
     - 'shogun-boot/target'
     - 'shogun-config/target'
     - 'shogun-gs-interceptor/target'

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <hibernate-extra-types.version>2.21.0</hibernate-extra-types.version>
 
     <!-- GraphQL -->
-    <graphql-java-extended-scalars.version>19.1</graphql-java-extended-scalars.version>
+    <graphql-java-extended-scalars.version>20.0</graphql-java-extended-scalars.version>
 
     <!-- Swagger/REST -->
     <springdoc-openapi.version>1.6.14</springdoc-openapi.version>

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/config/GraphQLConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/config/GraphQLConfig.java
@@ -16,6 +16,7 @@
  */
 package de.terrestris.shogun.lib.config;
 
+import de.terrestris.shogun.lib.graphql.scalar.DateTimeScalar;
 import de.terrestris.shogun.lib.graphql.scalar.GeometryScalar;
 import graphql.scalars.ExtendedScalars;
 import org.springframework.context.annotation.Bean;
@@ -30,7 +31,7 @@ public class GraphQLConfig {
         return wiringBuilder -> {
             wiringBuilder.scalar(ExtendedScalars.Json);
             wiringBuilder.scalar(GeometryScalar.INSTANCE);
-            wiringBuilder.scalar(ExtendedScalars.DateTime);
+            wiringBuilder.scalar(DateTimeScalar.INSTANCE);
             wiringBuilder.scalar(ExtendedScalars.GraphQLLong);
         };
     }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/scalar/DateTimeScalar.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/scalar/DateTimeScalar.java
@@ -1,0 +1,154 @@
+/*
+ * Modified work - Copyright 2018-present the original author or authors.
+ * See https://raw.githubusercontent.com/graphql-java/graphql-java-extended-scalars/master/src/main/java/graphql/scalars/datetime/DateTimeScalar.java
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.terrestris.shogun.lib.graphql.scalar;
+
+import graphql.Internal;
+import graphql.language.StringValue;
+import graphql.language.Value;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+import graphql.schema.GraphQLScalarType;
+
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.util.function.Function;
+
+import static graphql.scalars.util.Kit.typeName;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static java.time.temporal.ChronoField.OFFSET_SECONDS;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+
+/**
+ * Access this via {@link graphql.scalars.ExtendedScalars#DateTime}
+ *
+ * Added parser / serializer for {@link java.time.Instant} based on <a href="https://raw.githubusercontent.com/terrestris/shogun/v15.0.0/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/scalar/DateTimeScalar.java">this implementation</a>
+ *
+ */
+@Internal
+public final class DateTimeScalar {
+
+    public static final GraphQLScalarType INSTANCE;
+
+    private DateTimeScalar() {}
+    private static final DateTimeFormatter customOutputFormatter = getCustomDateTimeFormatter();
+
+    static {
+        Coercing<OffsetDateTime, String> coercing = new Coercing<OffsetDateTime, String>() {
+            @Override
+            public String serialize(Object input) throws CoercingSerializeException {
+                OffsetDateTime offsetDateTime;
+                if (input instanceof OffsetDateTime) {
+                    offsetDateTime = (OffsetDateTime) input;
+                } else if (input instanceof ZonedDateTime) {
+                    offsetDateTime = ((ZonedDateTime) input).toOffsetDateTime();
+                } else if (input instanceof Instant instant) {
+                    offsetDateTime = instant.atOffset(OffsetDateTime.now().getOffset());
+                } else if (input instanceof String) {
+                    offsetDateTime = parseOffsetDateTime(input.toString(), CoercingSerializeException::new);
+                } else {
+                    throw new CoercingSerializeException(
+                        "Expected something we can convert to 'java.time.OffsetDateTime' but was '" + typeName(input) + "'."
+                    );
+                }
+                try {
+                    return customOutputFormatter.format(offsetDateTime);
+                } catch (DateTimeException e) {
+                    throw new CoercingSerializeException(
+                        "Unable to turn TemporalAccessor into OffsetDateTime because of : '" + e.getMessage() + "'."
+                    );
+                }
+            }
+
+            @Override
+            public OffsetDateTime parseValue(Object input) throws CoercingParseValueException {
+                OffsetDateTime offsetDateTime;
+                if (input instanceof OffsetDateTime) {
+                    offsetDateTime = (OffsetDateTime) input;
+                } else if (input instanceof ZonedDateTime) {
+                    offsetDateTime = ((ZonedDateTime) input).toOffsetDateTime();
+                } else if (input instanceof Instant instant) {
+                    offsetDateTime = instant.atOffset(OffsetDateTime.now().getOffset());
+                } else if (input instanceof String) {
+                    offsetDateTime = parseOffsetDateTime(input.toString(), CoercingParseValueException::new);
+                } else {
+                    throw new CoercingParseValueException(
+                        "Expected a 'String' but was '" + typeName(input) + "'."
+                    );
+                }
+                return offsetDateTime;
+            }
+
+            @Override
+            public OffsetDateTime parseLiteral(Object input) throws CoercingParseLiteralException {
+                if (!(input instanceof StringValue)) {
+                    throw new CoercingParseLiteralException(
+                        "Expected AST type 'StringValue' but was '" + typeName(input) + "'."
+                    );
+                }
+                return parseOffsetDateTime(((StringValue) input).getValue(), CoercingParseLiteralException::new);
+            }
+
+            @Override
+            public Value<?> valueToLiteral(Object input) {
+                String s = serialize(input);
+                return StringValue.newStringValue(s).build();
+            }
+
+            private OffsetDateTime parseOffsetDateTime(String s, Function<String, RuntimeException> exceptionMaker) {
+                try {
+                    OffsetDateTime parse = OffsetDateTime.parse(s, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+                    if (parse.get(OFFSET_SECONDS) == 0 && s.endsWith("-00:00")) {
+                        throw exceptionMaker.apply("Invalid value : '" + s + "'. Negative zero offset is not allowed");
+                    }
+                    return parse;
+                } catch (DateTimeParseException e) {
+                    throw exceptionMaker.apply("Invalid RFC3339 value : '" + s + "'. because of : '" + e.getMessage() + "'");
+                }
+            }
+        };
+
+        INSTANCE = GraphQLScalarType.newScalar()
+            .name("DateTime")
+            .description("A slightly refined version of RFC-3339 compliant DateTime Scalar")
+            .specifiedByUrl("https://scalars.graphql.org/andimarek/date-time") // TODO: Change to .specifiedByURL when builder added to graphql-java
+            .coercing(coercing)
+            .build();
+    }
+
+    private static DateTimeFormatter getCustomDateTimeFormatter() {
+        return new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .append(ISO_LOCAL_DATE)
+            .appendLiteral('T')
+            .appendValue(HOUR_OF_DAY, 2)
+            .appendLiteral(':')
+            .appendValue(MINUTE_OF_HOUR, 2)
+            .appendLiteral(':')
+            .appendValue(SECOND_OF_MINUTE, 2)
+            .appendFraction(NANO_OF_SECOND, 3, 3, true)
+            .appendOffset("+HH:MM", "Z")
+            .toFormatter();
+    }
+
+}

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/scalar/DateTimeScalar.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/scalar/DateTimeScalar.java
@@ -42,7 +42,7 @@ import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
 /**
  * Access this via {@link graphql.scalars.ExtendedScalars#DateTime}
  *
- * Added parser / serializer for {@link java.time.Instant} based on <a href="https://raw.githubusercontent.com/terrestris/shogun/v15.0.0/shogun-lib/src/main/java/de/terrestris/shogun/lib/graphql/scalar/DateTimeScalar.java">this implementation</a>
+ * Added parser / serializer for {@link java.time.Instant} based on <a href="https://github.com/graphql-java/graphql-java-extended-scalars/blob/master/src/main/java/graphql/scalars/datetime/DateTimeScalar.java">this implementation</a>
  *
  */
 @Internal


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->
Since `RevisionMetadata` of spring.history  (resp. `ShogunAnnotationRevisionMetadata`) uses `Instant` datatype, we need to include this in GraphQL serialization / parsing. This PR adds such a scalar.

Beside, [graphql-java-extended-scalars](https://github.com/graphql-java/graphql-java-extended-scalars) is updated to version 20.0

Plz review @terrestris/devs 

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [x] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [n] No

## Checklist

- [ ] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [ ] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
