### PR TITLE
Extend application client config model for legal information link config

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationClientConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationClientConfig.java
@@ -45,6 +45,12 @@ public class DefaultApplicationClientConfig implements ApplicationClientConfig {
     private String description;
 
     @Schema(
+        description = "The links to legal information."
+    )
+    private DefaultLegalInformation legal;
+
+
+    @Schema(
         description = "The configuration of the applications theme."
     )
     private DefaultApplicationTheme theme;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationClientConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationClientConfig.java
@@ -49,7 +49,6 @@ public class DefaultApplicationClientConfig implements ApplicationClientConfig {
     )
     private DefaultLegalInformation legal;
 
-
     @Schema(
         description = "The configuration of the applications theme."
     )

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultLegalInformation.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultLegalInformation.java
@@ -1,0 +1,45 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2023-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.terrestris.shogun.lib.model.jsonb.application;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.io.Serializable;
+
+@Data
+@ToString
+@EqualsAndHashCode
+public class DefaultLegalInformation implements Serializable {
+
+    @Schema(
+        description = "URL to contact."
+    )
+    private String contact;
+
+    @Schema(
+        description = "URL to imprint."
+    )
+    private String imprint;
+
+    @Schema(
+        description = "URL to data privacy."
+    )
+    private String privacy;
+}


### PR DESCRIPTION


## Description

This PR adds the optional configuration entry `legal` to the model of the application. This consists of three optional properties: `contact`, `imprint` and `privacy`. If one of these properties has been defined for an application in the admin client, the corresponding value is used as the link target in the map client. The type is a URL as a `string`.

## Related issues or pull requests
https://github.com/terrestris/shogun-util/pull/254
https://github.com/terrestris/shogun-gis-client/pull/646

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
