### PR TITLE
Introduce crsDefinitions field on mapView config

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultCrsDefinition.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultCrsDefinition.java
@@ -1,0 +1,40 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2023-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.terrestris.shogun.lib.model.jsonb.application;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.io.Serializable;
+
+@Data
+@ToString
+@EqualsAndHashCode
+public class DefaultCrsDefinition implements Serializable {
+
+    @Schema(
+        description = "The EPSG code of CRS."
+    )
+    private String crsCode;
+
+    @Schema(
+        description = "CRS definition in proj4 format. See https://epsg.io/<code>.proj4 for examples."
+    )
+    private String definition;
+}

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultMapView.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultMapView.java
@@ -53,6 +53,12 @@ public class DefaultMapView implements Serializable {
     private String projection;
 
     @Schema(
+        description = "The list of CRS definitions in proj4 format that should be registered in the application additionally.",
+        example = "{\"crsCode\": \"EPSG:25832\", \"definition\": \"+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs\"}"
+    )
+    private ArrayList<DefaultCrsDefinition> crsDefinitions;
+
+    @Schema(
         description = "The list of resolutions/zoom levels of the map.",
         example = "[2445.9849047851562, 1222.9924523925781, 611.4962261962891, 305.74811309814453, 152.87405654907226, 76.43702827453613, 38.218514137268066, 19.109257068634033, 9.554628534317017, 4.777314267158508, 2.388657133579254, 1.194328566789627, 0.5971642833948135, 0.298582142, 0.149291071, 0.074645535]"
     )


### PR DESCRIPTION
## Description

Adds `crsDefinitions` field on `DefaultMapView` model.

This enables to configure additional CRS definitions which will be [registered](https://github.com/terrestris/ol-util/blob/master/src/ProjectionUtil/ProjectionUtil.ts#L69) on GIS client in case if it uses some "unusual" projection.

The configuration looks like follows:

```
mapView: {
  [...]
  crsDefinitions: [{
    crsCode: 'EPSG:3857',
    definition: '+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs +type=crs'
  }]
}
```

Please review @terrestris/devs 


<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [ ] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
