### PR TITLE
Hide `null` values in serialized JSONB models

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationTheme.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationTheme.java
@@ -16,6 +16,7 @@
  */
 package de.terrestris.shogun.lib.model.jsonb.application;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -24,6 +25,7 @@ import lombok.ToString;
 import java.io.Serializable;
 
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @ToString
 @EqualsAndHashCode
 public class DefaultApplicationTheme implements Serializable {

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultCrsDefinition.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultCrsDefinition.java
@@ -16,6 +16,7 @@
  */
 package de.terrestris.shogun.lib.model.jsonb.application;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -24,6 +25,7 @@ import lombok.ToString;
 import java.io.Serializable;
 
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @ToString
 @EqualsAndHashCode
 public class DefaultCrsDefinition implements Serializable {

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultLegalInformation.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultLegalInformation.java
@@ -16,6 +16,7 @@
  */
 package de.terrestris.shogun.lib.model.jsonb.application;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -24,6 +25,7 @@ import lombok.ToString;
 import java.io.Serializable;
 
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @ToString
 @EqualsAndHashCode
 public class DefaultLegalInformation implements Serializable {

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultMapView.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultMapView.java
@@ -16,6 +16,7 @@
  */
 package de.terrestris.shogun.lib.model.jsonb.application;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -25,6 +26,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 
 @Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @ToString
 @EqualsAndHashCode
 public class DefaultMapView implements Serializable {


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This adds the `@JsonInclude(JsonInclude.Include.NON_NULL)` annotation to all JSONB models to omit fields with `null` values from the serialized responses.

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
