### PR TITLE
Fix displaying of application cards on start page

### DIFF
--- a/shogun-boot/src/main/resources/templates/index.html
+++ b/shogun-boot/src/main/resources/templates/index.html
@@ -213,7 +213,11 @@
           }
         });
         const applications = await response.json();
-        return applications;
+        if (applications && applications.content) {
+          return applications.content;
+        } else {
+          throw new Error('Error while fetching applications');
+        }
       } catch (error) {
         console.error(error);
       }

--- a/shogun-boot/src/main/resources/templates/index.html
+++ b/shogun-boot/src/main/resources/templates/index.html
@@ -75,6 +75,7 @@
           border-radius: 10px;
           background-color: rgba(248, 249, 250, 1);
           height: auto;
+          cursor: pointer;
         }
 
         .app-card:hover {


### PR DESCRIPTION
## Description

Follow up of [!606](https://github.com/terrestris/shogun/pull/606).

Fixes displaying of the application cards on the SHOGun's start page due to changed return value of `findAll()` endpoint.

Also adds a pointer cursor while hovering over the cards now :)

Please review @terrestris/devs 

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [ ] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [ ] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
