### PR TITLE
Append transient fields for User and Group entities

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/security/access/entity/GroupPermissionEvaluator.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/security/access/entity/GroupPermissionEvaluator.java
@@ -1,3 +1,19 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2023-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.terrestris.shogun.lib.security.access.entity;
 
 import de.terrestris.shogun.lib.model.Group;

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/security/access/entity/GroupPermissionEvaluator.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/security/access/entity/GroupPermissionEvaluator.java
@@ -1,0 +1,27 @@
+package de.terrestris.shogun.lib.security.access.entity;
+
+import de.terrestris.shogun.lib.model.Group;
+import de.terrestris.shogun.lib.model.User;
+import de.terrestris.shogun.lib.repository.BaseCrudRepository;
+import de.terrestris.shogun.lib.service.security.provider.GroupProviderService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GroupPermissionEvaluator extends BaseEntityPermissionEvaluator<Group> {
+
+    @Autowired
+    GroupProviderService groupProviderService;
+
+    @Override
+    public Page<Group> findAll(User user, Pageable pageable, BaseCrudRepository<Group, Long> repository,
+        Class<Group> baseEntityClass) {
+        Page<Group> groups = super.findAll(user, pageable, repository, baseEntityClass);
+
+        groups.forEach(u -> groupProviderService.setTransientRepresentations(u));
+
+        return groups;
+    }
+}

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/security/access/entity/UserPermissionEvaluator.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/security/access/entity/UserPermissionEvaluator.java
@@ -1,0 +1,26 @@
+package de.terrestris.shogun.lib.security.access.entity;
+
+import de.terrestris.shogun.lib.model.User;
+import de.terrestris.shogun.lib.repository.BaseCrudRepository;
+import de.terrestris.shogun.lib.service.security.provider.UserProviderService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserPermissionEvaluator extends BaseEntityPermissionEvaluator<User> {
+
+    @Autowired
+    UserProviderService userProviderService;
+
+    @Override
+    public Page<User> findAll(User user, Pageable pageable, BaseCrudRepository<User, Long> repository,
+        Class<User> baseEntityClass) {
+        Page<User> users = super.findAll(user, pageable, repository, baseEntityClass);
+
+        users.forEach(u -> userProviderService.setTransientRepresentations(u));
+
+        return users;
+    }
+}

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/security/access/entity/UserPermissionEvaluator.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/security/access/entity/UserPermissionEvaluator.java
@@ -1,3 +1,19 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2023-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.terrestris.shogun.lib.security.access.entity;
 
 import de.terrestris.shogun.lib.model.User;


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This appends the transient field `providerDetails` to `User` and `Group` entities if requested as `Pageable`.

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
