### PR TITLE
Include REFERENCE_TABLE and make PropertyFormItemEditConfig abstract

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/PropertyFormItemEditConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/PropertyFormItemEditConfig.java
@@ -17,7 +17,10 @@
 package de.terrestris.shogun.lib.model.jsonb.layer;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import de.terrestris.shogun.lib.enumeration.EditFormComponentType;
+import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -29,7 +32,78 @@ import lombok.NoArgsConstructor;
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
-public class PropertyFormItemEditConfig extends PropertyFormItemReadConfig {
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    property = "component",
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    visible = true,
+    defaultImpl = PropertyFormItemEditDefaultConfig.class
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(
+        value = PropertyFormItemEditReferenceTableConfig.class,
+        name = "REFERENCE_TABLE"
+    ),
+    @JsonSubTypes.Type(
+        value = PropertyFormItemEditDefaultConfig.class,
+        names = {
+            "CHECKBOX",
+            "DATE",
+            "DISPLAY",
+            "INPUT",
+            "NUMBER",
+            "SELECT",
+            "SWITCH",
+            "TEXTAREA",
+            "UPLOAD"
+        }
+    )
+})
+@Schema(
+    discriminatorMapping = {
+        @DiscriminatorMapping(
+            value = "REFERENCE_TABLE",
+            schema = PropertyFormItemEditReferenceTableConfig.class
+        ),
+        @DiscriminatorMapping(
+            value = "CHECKBOX",
+            schema = PropertyFormItemEditDefaultConfig.class
+        ),
+        @DiscriminatorMapping(
+            value = "DATE",
+            schema = PropertyFormItemEditDefaultConfig.class
+        ),
+        @DiscriminatorMapping(
+            value = "DISPLAY",
+            schema = PropertyFormItemEditDefaultConfig.class
+        ),
+        @DiscriminatorMapping(
+            value = "INPUT",
+            schema = PropertyFormItemEditDefaultConfig.class
+        ),
+        @DiscriminatorMapping(
+            value = "NUMBER",
+            schema = PropertyFormItemEditDefaultConfig.class
+        ),
+        @DiscriminatorMapping(
+            value = "SELECT",
+            schema = PropertyFormItemEditDefaultConfig.class
+        ),
+        @DiscriminatorMapping(
+            value = "SWITCH",
+            schema = PropertyFormItemEditDefaultConfig.class
+        ),
+        @DiscriminatorMapping(
+            value = "TEXTAREA",
+            schema = PropertyFormItemEditDefaultConfig.class
+        ),
+        @DiscriminatorMapping(
+            value = "UPLOAD",
+            schema = PropertyFormItemEditDefaultConfig.class
+        )
+    }
+)
+public abstract class PropertyFormItemEditConfig extends PropertyFormItemReadConfig {
 
     @Schema(
         description = "The identifier of the component to render for this property.",

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/PropertyFormItemEditDefaultConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/PropertyFormItemEditDefaultConfig.java
@@ -14,23 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.terrestris.shogun.lib.enumeration;
+package de.terrestris.shogun.lib.model.jsonb.layer;
 
-public enum EditFormComponentType {
-    CHECKBOX("Checkbox"),
-    DATE("Date"),
-    DISPLAY("Display"),
-    INPUT("Input"),
-    NUMBER("Number"),
-    REFERENCE_TABLE("ReferenceTable"),
-    SELECT("Select"),
-    SWITCH("Switch"),
-    TEXTAREA("TextArea"),
-    UPLOAD("Upload");
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
-    private final String type;
-
-    EditFormComponentType(String type) {
-        this.type = type;
-    }
-}
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@ToString
+@EqualsAndHashCode(callSuper = true)
+public class PropertyFormItemEditDefaultConfig extends PropertyFormItemEditConfig { }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/PropertyFormItemEditReferenceTableConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/PropertyFormItemEditReferenceTableConfig.java
@@ -1,0 +1,43 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2023-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.terrestris.shogun.lib.model.jsonb.layer;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@ToString
+@EqualsAndHashCode(callSuper = false)
+public class PropertyFormItemEditReferenceTableConfig extends PropertyFormItemEditConfig {
+
+    @Schema(
+        description = "Set the property of the referenced layer (see layerId) that should be displayed in the " +
+            "table. If not set the 'id' field will be used.",
+        example = "BUILDING_ID"
+    )
+    private String tablePropertyName;
+
+    @Schema(
+        description = "Set the configuration of the referenced schema."
+    )
+    private PropertyFormItemEditConfig[] editFormConfig;
+
+}


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This adds the component type `REFERENCE_TABLE` to the available feature attributes fields. It can be used to configure a 1:n relationship of the given field. Example:

```json
{
  "propertyName": "nutzungen",
  "displayName": "Nutzungen",
  "component": "REFERENCE_TABLE",
  "tablePropertyName": "Beschreibung",
  "editFormConfig": [
    {
      "propertyName": "id",
      "displayName": "ID",
      "component": "NUMBER",
      "readOnly": true
    },
    {
      "propertyName": "Beschreibung",
      "displayName": "Beschreibung",
      "component": "TEXTAREA",
      "required": true
    }
  ]
}
```

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

- https://github.com/terrestris/shogun-admin/pull/165
- https://github.com/terrestris/shogun-util/pull/384
- https://github.com/terrestris/shogun-gis-client/pull/1164

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
