### PR TITLE
Fix constructor annotations in JSONB classes

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationClientConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationClientConfig.java
@@ -21,16 +21,17 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import de.terrestris.shogun.lib.annotation.JsonSuperType;
 import de.terrestris.shogun.lib.model.jsonb.ApplicationClientConfig;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 @Data
 @JsonDeserialize(as = DefaultApplicationClientConfig.class)
 @JsonSuperType(type = ApplicationClientConfig.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@ToString
-@EqualsAndHashCode
+@NoArgsConstructor(force = true)
 @AllArgsConstructor
-@RequiredArgsConstructor
 public class DefaultApplicationClientConfig implements ApplicationClientConfig {
 
     @Schema(

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationLayerConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationLayerConfig.java
@@ -23,16 +23,17 @@ import de.terrestris.shogun.lib.model.jsonb.LayerConfig;
 import de.terrestris.shogun.lib.model.jsonb.layer.DefaultLayerClientConfig;
 import de.terrestris.shogun.lib.model.jsonb.layer.DefaultLayerSourceConfig;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 @Data
 @JsonDeserialize(as = DefaultApplicationLayerConfig.class)
 @JsonSuperType(type = LayerConfig.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@ToString
-@EqualsAndHashCode
+@NoArgsConstructor(force = true)
 @AllArgsConstructor
-@RequiredArgsConstructor
 public class DefaultApplicationLayerConfig implements LayerConfig {
 
     @Schema(

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationTheme.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationTheme.java
@@ -18,14 +18,15 @@ package de.terrestris.shogun.lib.model.jsonb.application;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@ToString
-@EqualsAndHashCode
+@NoArgsConstructor
 @AllArgsConstructor
 public class DefaultApplicationTheme implements Serializable {
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationToolConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationToolConfig.java
@@ -21,7 +21,10 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import de.terrestris.shogun.lib.annotation.JsonSuperType;
 import de.terrestris.shogun.lib.model.jsonb.ApplicationToolConfig;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 import java.util.HashMap;
 
@@ -29,18 +32,16 @@ import java.util.HashMap;
 @JsonDeserialize(as = DefaultApplicationToolConfig.class)
 @JsonSuperType(type = ApplicationToolConfig.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@ToString
-@EqualsAndHashCode
+@NoArgsConstructor(force = true)
 @AllArgsConstructor
-@RequiredArgsConstructor
 public class DefaultApplicationToolConfig implements ApplicationToolConfig {
 
-    @NonNull
     @Schema(
         description = "The name of the tool.",
         example = "map-tool",
         requiredMode = Schema.RequiredMode.REQUIRED
     )
+    @NonNull
     private String name;
 
     @Schema(

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultCrsDefinition.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultCrsDefinition.java
@@ -20,15 +20,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@ToString
-@EqualsAndHashCode
+@NoArgsConstructor
 @AllArgsConstructor
 public class DefaultCrsDefinition implements Serializable {
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultLayerTree.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultLayerTree.java
@@ -23,8 +23,7 @@ import de.terrestris.shogun.lib.model.jsonb.LayerTree;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 
@@ -32,10 +31,10 @@ import java.util.ArrayList;
 @JsonDeserialize(as = DefaultLayerTree.class)
 @JsonSuperType(type = LayerTree.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@ToString
-@EqualsAndHashCode
+@NoArgsConstructor
 @AllArgsConstructor
 public class DefaultLayerTree implements LayerTree {
+
     @Schema(
         description = "The title of the node to show.",
         example = "Layer A"
@@ -60,4 +59,3 @@ public class DefaultLayerTree implements LayerTree {
     )
     private ArrayList<DefaultLayerTree> children;
 }
-

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultLegalInformation.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultLegalInformation.java
@@ -20,15 +20,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@ToString
-@EqualsAndHashCode
+@NoArgsConstructor
 @AllArgsConstructor
 public class DefaultLegalInformation implements Serializable {
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultMapView.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultMapView.java
@@ -20,16 +20,14 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@ToString
-@EqualsAndHashCode
+@NoArgsConstructor
 @AllArgsConstructor
 public class DefaultMapView implements Serializable {
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerClientConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerClientConfig.java
@@ -23,18 +23,15 @@ import de.terrestris.shogun.lib.model.jsonb.LayerClientConfig;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
-import java.util.Map;
 
 @Data
 @JsonDeserialize(as = DefaultLayerClientConfig.class)
 @JsonSuperType(type = LayerClientConfig.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@ToString
-@EqualsAndHashCode
+@NoArgsConstructor
 @AllArgsConstructor
 public class DefaultLayerClientConfig implements LayerClientConfig {
 
@@ -106,4 +103,3 @@ public class DefaultLayerClientConfig implements LayerClientConfig {
     private Boolean editable;
 
 }
-

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerPropertyConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerPropertyConfig.java
@@ -18,16 +18,16 @@ package de.terrestris.shogun.lib.model.jsonb.layer;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@ToString
-@EqualsAndHashCode
+@NoArgsConstructor
 @AllArgsConstructor
-@RequiredArgsConstructor
 public class DefaultLayerPropertyConfig implements Serializable {
 
     @Schema(
@@ -44,4 +44,3 @@ public class DefaultLayerPropertyConfig implements Serializable {
     private String displayName;
 
 }
-

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerSourceConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerSourceConfig.java
@@ -23,8 +23,7 @@ import de.terrestris.shogun.lib.model.jsonb.LayerSourceConfig;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,8 +32,7 @@ import java.util.HashMap;
 @JsonDeserialize(as = DefaultLayerSourceConfig.class)
 @JsonSuperType(type = LayerSourceConfig.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@ToString
-@EqualsAndHashCode
+@NoArgsConstructor
 @AllArgsConstructor
 public class DefaultLayerSourceConfig implements LayerSourceConfig {
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DownloadConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DownloadConfig.java
@@ -18,16 +18,16 @@ package de.terrestris.shogun.lib.model.jsonb.layer;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@ToString
-@EqualsAndHashCode
+@NoArgsConstructor
 @AllArgsConstructor
-@RequiredArgsConstructor
 public class DownloadConfig implements Serializable {
 
     @Schema(
@@ -44,4 +44,3 @@ public class DownloadConfig implements Serializable {
     private String formatName;
 
 }
-

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/PropertyFormItemEditConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/PropertyFormItemEditConfig.java
@@ -19,14 +19,16 @@ package de.terrestris.shogun.lib.model.jsonb.layer;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import de.terrestris.shogun.lib.enumeration.EditFormComponentType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import lombok.NoArgsConstructor;
 
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@ToString
 @EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+@AllArgsConstructor
 public class PropertyFormItemEditConfig extends PropertyFormItemReadConfig {
 
     @Schema(
@@ -49,4 +51,3 @@ public class PropertyFormItemEditConfig extends PropertyFormItemReadConfig {
     private Boolean required;
 
 }
-

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/PropertyFormItemReadConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/PropertyFormItemReadConfig.java
@@ -18,16 +18,18 @@ package de.terrestris.shogun.lib.model.jsonb.layer;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import lombok.NoArgsConstructor;
 
 import java.util.Map;
 
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@ToString
 @EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+@AllArgsConstructor
 public class PropertyFormItemReadConfig extends DefaultLayerPropertyConfig {
 
     @Schema(
@@ -37,4 +39,3 @@ public class PropertyFormItemReadConfig extends DefaultLayerPropertyConfig {
     private Map<String, Object> fieldProps;
 
 }
-

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/PropertyFormTabConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/PropertyFormTabConfig.java
@@ -18,17 +18,17 @@ package de.terrestris.shogun.lib.model.jsonb.layer;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@ToString
-@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
 public class PropertyFormTabConfig<T extends PropertyFormItemReadConfig> implements Serializable {
 
     // TODO i18n?
@@ -45,4 +45,3 @@ public class PropertyFormTabConfig<T extends PropertyFormItemReadConfig> impleme
     private ArrayList<T> children;
 
 }
-

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/SearchConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/SearchConfig.java
@@ -18,17 +18,17 @@ package de.terrestris.shogun.lib.model.jsonb.layer;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
+import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 import java.util.List;
 
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@ToString
-@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
 public class SearchConfig implements Serializable {
 
     @Schema(
@@ -44,4 +44,3 @@ public class SearchConfig implements Serializable {
     private String displayTemplate;
 
 }
-


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

The previous state has broken the serialization via Jackson.

In addition the `@ToString` and `@EqualsAndHashCode` annotations were removed as they are added by `@Data` already.

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
