### PR TITLE
Use lambda DSL for security filter chain

### DIFF
--- a/shogun-config/src/main/java/de/terrestris/shogun/config/DefaultWebSecurityConfig.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/config/DefaultWebSecurityConfig.java
@@ -28,7 +28,7 @@ public interface DefaultWebSecurityConfig extends WebSecurityConfig {
             .sessionManagement(session -> session
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             )
-            .authorizeHttpRequests()
+            .authorizeHttpRequests(authorize -> authorize
                 .requestMatchers(
                     "/",
                     "/auth/**",
@@ -55,15 +55,16 @@ public interface DefaultWebSecurityConfig extends WebSecurityConfig {
                     .hasRole("ADMIN")
                 .anyRequest()
                     .authenticated()
-            .and()
-                .csrf()
-                    .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                    .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
-                    .ignoringRequestMatchers(csrfRequestMatcher)
-                    .ignoringRequestMatchers("/graphql")
-                    .ignoringRequestMatchers("/actuator/**")
-                    .ignoringRequestMatchers("/sso/**")
-                    .ignoringRequestMatchers("/ws/**");
+            )
+            .csrf(csrf -> csrf
+                .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
+                .ignoringRequestMatchers(csrfRequestMatcher)
+                .ignoringRequestMatchers("/graphql")
+                .ignoringRequestMatchers("/actuator/**")
+                .ignoringRequestMatchers("/sso/**")
+                .ignoringRequestMatchers("/ws/**")
+            );
     }
 
     default void configure(HttpSecurity http) throws Exception {

--- a/shogun-config/src/main/java/de/terrestris/shogun/config/KeycloakWebSecurityConfig.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/config/KeycloakWebSecurityConfig.java
@@ -66,13 +66,12 @@ public class KeycloakWebSecurityConfig implements DefaultWebSecurityConfig {
         );
 
         http
-            .csrf()
+            .csrf(csrf -> csrf
                 .ignoringRequestMatchers("/webhooks/**")
-            .and()
-                .oauth2ResourceServer()
-                    .jwt()
-                    .jwtAuthenticationConverter(authConverter);
-
+            )
+            .oauth2ResourceServer(oauth -> oauth
+                .jwt(jwt -> jwt.jwtAuthenticationConverter(authConverter))
+            );
     }
 
 }

--- a/shogun-config/src/main/java/de/terrestris/shogun/config/WebSecurityConfig.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/config/WebSecurityConfig.java
@@ -16,11 +16,8 @@
  */
 package de.terrestris.shogun.config;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.util.matcher.RequestMatcher;

--- a/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/config/InterceptorWebSecurityConfig.java
+++ b/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/config/InterceptorWebSecurityConfig.java
@@ -18,10 +18,9 @@ package de.terrestris.shogun.interceptor.config;
 
 import de.terrestris.shogun.config.DefaultWebSecurityConfig;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
@@ -36,7 +35,7 @@ public class InterceptorWebSecurityConfig implements DefaultWebSecurityConfig {
     @Override
     public void customHttpConfiguration(HttpSecurity http) throws Exception {
         http
-            .authorizeHttpRequests()
+            .authorizeHttpRequests(authorize -> authorize
                 .requestMatchers(
                     // Allow access to swagger interface
                     "/swagger-ui/index.html",
@@ -50,12 +49,12 @@ public class InterceptorWebSecurityConfig implements DefaultWebSecurityConfig {
                     .hasRole("INTERCEPTOR_ADMIN")
                 .anyRequest()
                     .authenticated()
-                .and()
-                    .httpBasic()
-                .and()
-                    .csrf()
-                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                        .ignoringRequestMatchers(csrfRequestMatcher);
+            )
+            .httpBasic(Customizer.withDefaults())
+            .csrf(csrf -> csrf
+                .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                .ignoringRequestMatchers(csrfRequestMatcher)
+            );
     }
 
 }

--- a/shogun-proxy/src/test/java/de/terrestris/shogun/service/HttpProxyServiceTest.java
+++ b/shogun-proxy/src/test/java/de/terrestris/shogun/service/HttpProxyServiceTest.java
@@ -30,7 +30,6 @@ import org.mockito.MockedStatic;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;


### PR DESCRIPTION
## Description

Replaces the security filter chaining with lamdba expressions, which is required for spring security 7 and should improve readability and avoid confusion from nested objects.

See https://docs.spring.io/spring-security/reference/migration-7/configuration.html

@terrestris/devs Please review

## Related issues or pull requests

https://github.com/terrestris/shogun/pull/664

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
