### PR TITLE
Improve content type detection for file uploads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
 
     <!-- Utils -->
     <commons.io.version>2.13.0</commons.io.version>
-    <tika.core.version>2.9.0</tika.core.version>
+    <tika.version>2.9.0</tika.version>
     <reflections.version>0.10.2</reflections.version>
     <evo-inflector.version>1.3</evo-inflector.version>
 
@@ -511,7 +511,12 @@
       <dependency>
         <groupId>org.apache.tika</groupId>
         <artifactId>tika-core</artifactId>
-        <version>${tika.core.version}</version>
+        <version>${tika.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tika</groupId>
+        <artifactId>tika-parsers-standard-package</artifactId>
+        <version>${tika.version}</version>
       </dependency>
 
       <!-- Jackson -->

--- a/shogun-config/src/main/java/de/terrestris/shogun/config/WebSecurityConfig.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/config/WebSecurityConfig.java
@@ -16,11 +16,8 @@
  */
 package de.terrestris.shogun.config;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.core.Ordered;
-import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.util.matcher.RequestMatcher;

--- a/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/config/InterceptorWebSecurityConfig.java
+++ b/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/config/InterceptorWebSecurityConfig.java
@@ -18,10 +18,8 @@ package de.terrestris.shogun.interceptor.config;
 
 import de.terrestris.shogun.config.DefaultWebSecurityConfig;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 

--- a/shogun-lib/pom.xml
+++ b/shogun-lib/pom.xml
@@ -228,6 +228,11 @@
       <artifactId>tika-core</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.tika</groupId>
+      <artifactId>tika-parsers-standard-package</artifactId>
+    </dependency>
+
     <!-- Testing -->
     <dependency>
       <groupId>org.springframework</groupId>

--- a/shogun-proxy/src/test/java/de/terrestris/shogun/service/HttpProxyServiceTest.java
+++ b/shogun-proxy/src/test/java/de/terrestris/shogun/service/HttpProxyServiceTest.java
@@ -30,7 +30,6 @@ import org.mockito.MockedStatic;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

- adds `tika-parsers` to the classpath, this allows Tika to detect more file types
- uses the *Tika Facade*, simplifying the content type detection
- uses `StringUtils.equalsIgnoreCase` to compare the detected type because of inconsistencies
- some minor fixes

Useful Resources:

- https://tika.apache.org/2.9.0/gettingstarted.html
- https://tika.apache.org/2.9.0/examples.html

@terrestris/devs Please review

## Related issues or pull requests

- https://github.com/terrestris/shogun/pull/312

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
