### PR TITLE
Fix failing `startup` workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
         working-directory: ../
 
       - name: Checkout specific commit to ensure reproducibility
-        run: git checkout d02a88ad9b1583b1f7c05407d944b5ff91585765
+        run: git checkout bd6ce1bc64caaee29fe1fb4afb2785b705d57067
         working-directory: ../shogun-docker
 
       - name: Set environment variables

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
         working-directory: ../shogun-docker
 
       - name: Start containers
-        run: docker-compose up -d
+        run: docker-compose up -d shogun-postgis shogun-boot shogun-gs-interceptor
         working-directory: ../shogun-docker
 
       - name: Inspect network

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
         working-directory: ../shogun-docker
 
       - name: Start containers
-        run: docker-compose -f docker-compose.yml -f docker-compose-dev.yml up -d
+        run: docker-compose up -d
         working-directory: ../shogun-docker
 
       - name: Inspect network
@@ -114,7 +114,7 @@ jobs:
 
       - name: Docker logs
         if: always()
-        run: docker-compose -f docker-compose.yml -f docker-compose-dev.yml logs
+        run: docker-compose logs
         working-directory: ../shogun-docker
 
       - name: Maven output

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
         working-directory: ../shogun-docker
 
       - name: Set environment variables
-        run: ./setEnvironment.sh
+        run: ./setEnvironment.sh create
         working-directory: ../shogun-docker
 
       - name: Show environment variables

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
         working-directory: ../
 
       - name: Checkout specific commit to ensure reproducibility
-        run: git checkout 4fdcbc51fa2d20bcfb0bcafafdfdece83c863819
+        run: git checkout d02a88ad9b1583b1f7c05407d944b5ff91585765
         working-directory: ../shogun-docker
 
       - name: Set environment variables

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
         working-directory: ../shogun-docker
 
       - name: Start containers
-        run: docker-compose up -d shogun-postgis shogun-boot shogun-gs-interceptor
+        run: docker compose up -d shogun-postgis shogun-boot shogun-gs-interceptor
         working-directory: ../shogun-docker
 
       - name: Inspect network
@@ -114,7 +114,7 @@ jobs:
 
       - name: Docker logs
         if: always()
-        run: docker-compose logs
+        run: docker compose logs
         working-directory: ../shogun-docker
 
       - name: Maven output

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
         working-directory: ../shogun-docker
 
       - name: Set environment variables
-        run: ./setEnvironment.sh create
+        run: ./setEnvironment.sh create -y
         working-directory: ../shogun-docker
 
       - name: Show environment variables

--- a/scripts/wait.sh
+++ b/scripts/wait.sh
@@ -14,11 +14,11 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-URL="https://localhost/"
+URL="http://$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' shogun-boot):8080/"
 TIMEOUT=360
 seconds=0
 
-echo 'Waiting up to' $TIMEOUT 'seconds for HTTP 200 from' $URL 
+echo 'Waiting up to' $TIMEOUT 'seconds for HTTP 200 from' $URL
 until [ "$seconds" -gt "$TIMEOUT" ] || $(curl --insecure --location --output /dev/null --silent --max-time $TIMEOUT --head --fail $URL); do
   sleep 5
   seconds=$((seconds+5))


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This fixes the failing `startup` workflow which was pinned to an ancient version of the `shogun-docker` repository.

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
