### PR TITLE
Anonymous access to graphql interface

### DIFF
--- a/shogun-config/src/main/java/de/terrestris/shogun/config/DefaultWebSecurityConfig.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/config/DefaultWebSecurityConfig.java
@@ -47,8 +47,7 @@ public interface DefaultWebSecurityConfig extends WebSecurityConfig {
                     "/graphiql/**"
                 )
                     .permitAll()
-                // Enable anonymous read access to entity endpoints
-                // will be secured via permission evaluators
+                // Enable anonymous read access to entity endpoints (secured via permission evaluators)
                 .requestMatchers(
                     HttpMethod.GET,
                     "/applications",
@@ -59,6 +58,12 @@ public interface DefaultWebSecurityConfig extends WebSecurityConfig {
                     "/files/*",
                     "/imagefiles",
                     "/imagefiles/*"
+                )
+                .permitAll()
+                // Enable anonymous access to graphql (secured via permission evaluators)
+                .requestMatchers(
+                    HttpMethod.POST,
+                    "/graphql"
                 )
                 .permitAll()
                 .requestMatchers(


### PR DESCRIPTION
This adds anonymous acces to the graphql interface.

This is needed as the gisclient gets its layers via the `/graphql` interface. The graphql queries themeselves are still secured via the permission evaluators.


:exclamation: BREAKING CHANGE: anonymous access to graphql interface

## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [x] Yes
- [ ] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
