### PR TITLE
feat: add printApp to DefaultApplicationClientConfig

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationClientConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationClientConfig.java
@@ -62,7 +62,7 @@ public class DefaultApplicationClientConfig implements ApplicationClientConfig {
     private String defaultLanguage;
 
     @Schema(
-        description = "The configuration of the print tool templates"
+        description = "The name of the mapfish printapp to use."
     )
     private String printApp;
 

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationClientConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/application/DefaultApplicationClientConfig.java
@@ -61,4 +61,9 @@ public class DefaultApplicationClientConfig implements ApplicationClientConfig {
     )
     private String defaultLanguage;
 
+    @Schema(
+        description = "The configuration of the print tool templates"
+    )
+    private String printApp;
+
 }


### PR DESCRIPTION
## Description

Adds printApp to default client config to give more possibilities of selecting print templates per app

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [X] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [X] No

## Checklist

- [ ] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [ ] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
