### PR TITLE
fix: prevent exception when keycloak group does not exist

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakGroupProviderService.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/service/security/provider/keycloak/KeycloakGroupProviderService.java
@@ -114,8 +114,9 @@ public class KeycloakGroupProviderService implements GroupProviderService<UserRe
         List<GroupRepresentation> groupRepresentations = keycloakUtil.getKeycloakUserGroups(user.get());
 
         return (List) groupRepresentations.stream().
-            map(groupRepresentation -> repository.findByAuthProviderId(groupRepresentation.getId()).orElseThrow()).
-            collect(Collectors.toList());
+            map(groupRepresentation -> repository.findByAuthProviderId(groupRepresentation.getId()).orElse(null))
+                .filter(group -> group != null)
+                .collect(Collectors.toList());
     }
 
     public void setTransientRepresentations(Group<GroupRepresentation> group) {


### PR DESCRIPTION
## Description

See title.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.

@terrestris/devs Please review.