### PR TITLE
ci: sonarqube-scan does not run when merging from dependabot

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -66,7 +66,7 @@ jobs:
       run: mvn clean verify sonar:sonar --batch-mode -Dsonar.projectKey=SHOGun -Dsonar.login="${{ secrets.SONARQUBE_TOKEN }}" -Preporting
 
     - name: Refresh SonarQube
-      if: steps.semantic.outputs.new_release_published == 'true'
+      if: ${{ github.actor != 'dependabot[bot]' && steps.semantic.outputs.new_release_published == 'true'
       run: mvn compile sonar:sonar --batch-mode -Dsonar.projectKey=SHOGun -Dsonar.host.url=${{ secrets.SONARQUBE_HOST }} -Dsonar.login="${{ secrets.SONARQUBE_TOKEN }}"
 
     - name: Save cache

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -66,7 +66,7 @@ jobs:
       run: mvn clean verify sonar:sonar --batch-mode -Dsonar.projectKey=SHOGun -Dsonar.login="${{ secrets.SONARQUBE_TOKEN }}" -Preporting
 
     - name: Refresh SonarQube
-      if: ${{ github.actor != 'dependabot[bot]' && steps.semantic.outputs.new_release_published == 'true'
+      if: ${{ github.actor != 'dependabot[bot]' }} && steps.semantic.outputs.new_release_published == 'true'
       run: mvn compile sonar:sonar --batch-mode -Dsonar.projectKey=SHOGun -Dsonar.host.url=${{ secrets.SONARQUBE_HOST }} -Dsonar.login="${{ secrets.SONARQUBE_TOKEN }}"
 
     - name: Save cache


### PR DESCRIPTION
## Description

This MR ensures that merging from dependabot does not send a report to sonarqube


## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe)

Adjusting github workflows

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [x] I have added a screenshot/screencast to illustrate the visual output of my update.
