### PR TITLE
fix: use correct mail dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <spring-data.version>3.3.1</spring-data.version>
 
     <!-- Mail -->
-    <jakarta-mail.version>2.0.1</jakarta-mail.version>
+    <sun-jakarta-mail.version>2.0.1</sun-jakarta-mail.version>
 
     <!-- Hibernate, Jackson, JAXB etc. -->
     <jaxb-api.version>2.3.1</jaxb-api.version>
@@ -567,9 +567,15 @@
       </dependency>
 
       <dependency>
+        <groupId>jakarta.mail</groupId>
+        <artifactId>jakarta.mail-api</artifactId>
+        <version>${jakarta-mail.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.sun.mail</groupId>
         <artifactId>jakarta.mail</artifactId>
-        <version>${jakarta-mail.version}</version>
+        <version>${sun-jakarta-mail.version}</version>
       </dependency>
 
       <dependency>

--- a/shogun-lib/pom.xml
+++ b/shogun-lib/pom.xml
@@ -209,6 +209,11 @@
     </dependency>
 
     <dependency>
+      <groupId>jakarta.mail</groupId>
+      <artifactId>jakarta.mail-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.sun.mail</groupId>
       <artifactId>jakarta.mail</artifactId>
     </dependency>


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This is a bugfix for the mail dependencies in succession of the spring 6 migration (sun vs jakarta packages).

Explanation:

The used parent pom `spring-boot-dependencies` (via `spring-boot-starter-parent`) declares a property `jakarta-mail.version` for the underlying `jakarta.mail:jakarta.mail-api` dependency. Within this project, this property has been "overwritten" and (mis-)used for the `com.sun.mail:jakarta.mail` dependency instead.

When using the mail functionality based on spring (`JavaMailSender`) this misconfiguration leads to an exception (`could not find class...`). The change of this PR fixes the issue.


## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [x] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [x] I have added a screenshot/screencast to illustrate the visual output of my update.
