### PR TITLE
fix(deps): downgrade springdoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <graphql-java-extended-scalars.version>21.0</graphql-java-extended-scalars.version>
 
     <!-- Swagger/REST -->
-    <springdoc-openapi.version>2.6.0</springdoc-openapi.version>
+    <springdoc-openapi.version>2.5.0</springdoc-openapi.version>
 
     <!-- JSON/Dataformats -->
     <geojson-jackson.version>1.14</geojson-jackson.version>


### PR DESCRIPTION
This downgrades springdoc to 2.5.0 as the current shogun-admin is not compatible with 2.6.0.
