### PR TITLE
Ignore events for realms other then SHOGun

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/WebhookController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/WebhookController.java
@@ -40,6 +40,11 @@ public class WebhookController {
     public void handleKeyCloakEvent(@RequestBody KeycloakEventDto event) {
         log.debug("Keycloak webhook called with event: {}", event);
 
+        if (!event.getRealmId().equalsIgnoreCase("shogun")){
+            log.debug("Ignoring event for realm: {}", event.getRealmId());
+            return;
+        }
+
         String resourceType = event.getResourceType();
         String eventType = event.getType();
 


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This checks for the realm id when handling keycloak events. If realm name does not equal (ignore case) "shogun" the event is not handled.

@dnlkoch Do we want to have this configurable?

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [ ] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
