### PR TITLE
feat: add wmtsDimensions parameter for layer source

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerSourceConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerSourceConfig.java
@@ -96,4 +96,10 @@ public class DefaultLayerSourceConfig implements LayerSourceConfig {
         example = "false"
     )
     private Boolean useBearerToken;
+
+    @Schema(
+        description = "Dimension parameters to be replaced for WMTS requests",
+        example = "{\"Time\": \"2010\"}"
+    )
+    private HashMap<String, String> wmtsDimensions;
 }


### PR DESCRIPTION
## Description

Adds the wmtsDimensions parameter to the layer source

## Related issues or pull requests

https://github.com/terrestris/shogun-util/pull/750

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
