### PR TITLE
fix(HttpProxy): use override instead of bean creation for HttpSecurity

### DIFF
--- a/shogun-proxy/src/main/java/de/terrestris/shogun/config/HttpProxyWebSecurityConfig.java
+++ b/shogun-proxy/src/main/java/de/terrestris/shogun/config/HttpProxyWebSecurityConfig.java
@@ -16,22 +16,19 @@
  */
 package de.terrestris.shogun.config;
 
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 public class HttpProxyWebSecurityConfig implements DefaultWebSecurityConfig {
 
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    @Override
+    public void customHttpConfiguration(HttpSecurity http) throws Exception {
         http
             .authorizeHttpRequests((auths) -> auths
                 .anyRequest()
                 .authenticated()
             );
-        return http.build();
     }
 
 }


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

In order to make `customHttpConfiguration` overwriteable in subproject (as already used in `InterceptorWebSecurityConfig`), `filterChain` bean creation has to be removed in `shogun-proxy` 

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
