### PR TITLE
Handle unsupported external DTD and schema properties

### DIFF
--- a/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/util/OgcXmlUtil.java
+++ b/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/util/OgcXmlUtil.java
@@ -85,15 +85,21 @@ public class OgcXmlUtil {
             InputSource source = new InputSource(new StringReader(xml));
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 
-            // limit resolution of external entities, see https://rules.sonarsource.com/c/type/Vulnerability/RSPEC-2755
-            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            try {
+                // limit resolution of external entities, see https://rules.sonarsource.com/c/type/Vulnerability/RSPEC-2755
+                factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            } catch (IllegalArgumentException e) {
+                log.error("External DTD/Schema access properties not supported:"
+                    + e.getMessage());
+            }
 
             DocumentBuilder builder = factory.newDocumentBuilder();
             document = builder.parse(source);
-        } catch (ParserConfigurationException | SAXException | IOException e) {
-            throw new IOException("Could not parse input body " +
-                "as XML: " + e.getMessage());
+        } catch (IllegalArgumentException | ParserConfigurationException
+            | SAXException | IOException e) {
+            throw new IOException("Could not parse input body as XML: "
+                + e.getMessage());
         }
         return document;
     }


### PR DESCRIPTION
## Description

This MR addresses an issue where the `DocumentBuilderFactory` would throw an `IllegalArgumentException` when trying to set `XMLConstants.ACCESS_EXTERNAL_DTD` and `XMLConstants.ACCESS_EXTERNAL_SCHEMA` properties if the underlying XML parser does not support them.

Now, the setting of external DTD and schema access properties is wrapped in a try-catch block to handle unsupported cases gracefully. The current implementation was causing a crash when the parser did not recognize the properties related to external DTD and schema access.

@terrestris/devs please review

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
