### PR TITLE
Replace unsupported XML properties with feature-based security settings

### DIFF
--- a/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/util/OgcXmlUtil.java
+++ b/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/util/OgcXmlUtil.java
@@ -85,14 +85,10 @@ public class OgcXmlUtil {
             InputSource source = new InputSource(new StringReader(xml));
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 
-            try {
-                // limit resolution of external entities, see https://rules.sonarsource.com/c/type/Vulnerability/RSPEC-2755
-                factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-                factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-            } catch (IllegalArgumentException e) {
-                log.error("External DTD/Schema access properties not supported:"
-                    + e.getMessage());
-            }
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
 
             DocumentBuilder builder = factory.newDocumentBuilder();
             document = builder.parse(source);


### PR DESCRIPTION
## Description

This PR improves the XML parser security configuration in `OgcXmlUtil` by replacing unsupported properties with feature-based settings. The previous configuration attempted to set `ACCESS_EXTERNAL_DTD` and `ACCESS_EXTERNAL_SCHEMA`, which were not recognized by the current XML parser, causing errors in certain environments.

### Changes
- Removed `ACCESS_EXTERNAL_DTD` and `ACCESS_EXTERNAL_SCHEMA` properties due to compatibility issues.
- Enabled `FEATURE_SECURE_PROCESSING` for safer XML parsing.
- Added feature-based settings to:
  - Disallow DOCTYPE declarations (`disallow-doctype-decl`)
  - Disable external general entities (`external-general-entities`)
  - Disable external parameter entities (`external-parameter-entities`)

@terrestris/devs please review

## Related issues or pull requests

Replaces part of the previous PR #931 to handle unsupported XML property errors more effectively

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
