### PR TITLE
Fixes for hibernate/ehcache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -442,6 +442,7 @@
         <groupId>org.ehcache</groupId>
         <artifactId>ehcache</artifactId>
         <version>${ehcache3.version}</version>
+        <classifier>jakarta</classifier>
       </dependency>
 
       <dependency>

--- a/shogun-config/src/main/resources/application-base.yml
+++ b/shogun-config/src/main/resources/application-base.yml
@@ -53,10 +53,6 @@ spring:
       hibernate:
         id:
           db_structure_naming_strategy: single
-        jakarta:
-          cache:
-            provider: org.ehcache.jsr107.EhcacheCachingProvider
-            uri: ehcache.xml
         format_sql: true
         # Generate statistics to check if L2/query cache is actually being used
         generate_statistics: true
@@ -66,11 +62,16 @@ spring:
           # Enable query cache
           use_query_cache: true
           region:
-            factory_class: org.hibernate.cache.jcache.JCacheRegionFactory
+            factory_class: jcache
         integration:
           envers:
             # Set this to false to disable auditing entity changes
             enabled: true
+        javax:
+          cache:
+            uri: ehcache.xml
+            provider: org.ehcache.jsr107.EhcacheCachingProvider
+
   jackson:
     serialization:
       fail-on-empty-beans: false

--- a/shogun-config/src/main/resources/ehcache.xml
+++ b/shogun-config/src/main/resources/ehcache.xml
@@ -82,10 +82,14 @@
   <cache alias="permission" uses-template="default" />
   <cache alias="userclasspermissions" uses-template="default" />
   <cache alias="userinstancepermissions" uses-template="default" />
+  <cache alias="roleinstancepermissions" uses-template="default" />
+  <cache alias="roleclasspermissions" uses-template="default" />
+  <cache alias="publicinstancepermissions" uses-template="default" />
   <cache alias="applications" uses-template="default" />
   <cache alias="files" uses-template="default" />
   <cache alias="groups" uses-template="default" />
   <cache alias="layers" uses-template="default" />
+  <cache alias="roles" uses-template="default" />
   <cache alias="users" uses-template="default" />
 
 </config>

--- a/shogun-config/src/main/resources/log4j2.yml
+++ b/shogun-config/src/main/resources/log4j2.yml
@@ -44,6 +44,8 @@ Configuration:
         level: info
       - name: org.hibernate.type.descriptor.sql
         level: info
+      - name: org.ehcache
+        level: info
       - name: org.springframework.boot
         level: info
       - name: org.springframework

--- a/shogun-lib/pom.xml
+++ b/shogun-lib/pom.xml
@@ -161,6 +161,7 @@
     <dependency>
       <groupId>org.ehcache</groupId>
       <artifactId>ehcache</artifactId>
+      <classifier>jakarta</classifier>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/PublicInstancePermission.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/security/permission/PublicInstancePermission.java
@@ -19,6 +19,8 @@ package de.terrestris.shogun.lib.model.security.permission;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.envers.AuditTable;
@@ -31,6 +33,8 @@ import java.time.OffsetDateTime;
 @Table(schema = "shogun")
 @Audited
 @AuditTable(value = "publicinstancepermissions_rev", schema = "shogun_rev")
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="publicinstancepermissions")
 @Getter
 @Setter
 @AllArgsConstructor

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/BaseCrudRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/BaseCrudRepository.java
@@ -26,6 +26,7 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.history.RevisionRepository;
+import org.springframework.lang.NonNull;
 
 import java.util.List;
 
@@ -36,6 +37,8 @@ public interface BaseCrudRepository<T, ID> extends
     PagingAndSortingRepository<T, ID> {
 
     @QueryHints(@QueryHint(name = AvailableHints.HINT_CACHEABLE, value = "true"))
+    @Override
+    @NonNull
     List<T> findAll();
 
     /**
@@ -63,7 +66,7 @@ public interface BaseCrudRepository<T, ID> extends
             AND rip.permission.name IN ('ADMIN', 'READ', 'CREATE_READ', 'CREATE_READ_UPDATE', 'CREATE_READ_DELETE', 'READ_UPDATE', 'READ_DELETE', 'READ_UPDATE_DELETE')
         )
     """)
-    @QueryHints(@QueryHint(name = org.hibernate.annotations.QueryHints.CACHEABLE, value = "true"))
+    @QueryHints(@QueryHint(name = AvailableHints.HINT_CACHEABLE, value = "true"))
     Page<T> findAll(Pageable pageable, Long userId, List<Long> roleIds);
 
     /**
@@ -97,7 +100,7 @@ public interface BaseCrudRepository<T, ID> extends
             AND rip.permission.name IN ('ADMIN', 'READ', 'CREATE_READ', 'CREATE_READ_UPDATE', 'CREATE_READ_DELETE', 'READ_UPDATE', 'READ_DELETE', 'READ_UPDATE_DELETE')
         )
     """)
-    @QueryHints(@QueryHint(name = org.hibernate.annotations.QueryHints.CACHEABLE, value = "true"))
+    @QueryHints(@QueryHint(name = AvailableHints.HINT_CACHEABLE, value = "true"))
     Page<T> findAll(Pageable pageable, Long userId, List<Long> groupIds, List<Long> roleIds);
 
     /**
@@ -107,7 +110,14 @@ public interface BaseCrudRepository<T, ID> extends
      *                 {@literal null}.
      * @return A page of entities.
      */
-    @QueryHints(@QueryHint(name = org.hibernate.annotations.QueryHints.CACHEABLE, value = "true"))
-    Page<T> findAll(Pageable pageable);
+    @QueryHints(@QueryHint(name = AvailableHints.HINT_CACHEABLE, value = "true"))
+    @Override
+    @NonNull
+    Page<T> findAll(@NonNull Pageable pageable);
+
+    @QueryHints(@QueryHint(name = AvailableHints.HINT_CACHEABLE, value = "true"))
+    @Override
+    @NonNull
+    Iterable<T> findAllById(@NonNull Iterable<ID> ids);
 
 }

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/security/permission/PublicInstancePermissionRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/security/permission/PublicInstancePermissionRepository.java
@@ -17,6 +17,9 @@
 package de.terrestris.shogun.lib.repository.security.permission;
 
 import de.terrestris.shogun.lib.model.security.permission.PublicInstancePermission;
+import jakarta.persistence.QueryHint;
+import org.hibernate.jpa.AvailableHints;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
@@ -26,6 +29,7 @@ import java.util.Optional;
 public interface PublicInstancePermissionRepository extends CrudRepository<PublicInstancePermission, Long> {
     void deleteByEntityId(Long entityId);
 
+    @QueryHints(@QueryHint(name = AvailableHints.HINT_CACHEABLE, value = "true"))
     Optional<PublicInstancePermission> findByEntityId(Long entityId);
 
 }


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This applies several fixes for the hibernate (especially the second-level) cache and the appropriate ehcache configuration:

- add missing cache regions to the `ehcache.xml`
- update the default `application.yml` to actually make use of the `ehcache.xml` (I suppose this change is needed since we updated to Spring Boot 3 and resulted in the logger warnings below)
- make `findAllById` cacheable (this e.g. used while loading the layers in an application in the GIS client)
- make `PublicInstancePermission` entities cacheable (this is potentially used in every permission check)

Before:

```
WARN  org.hibernate.orm.cache.createCache() @108 - HHH90001006: Missing cache[applications] was created on-the-fly. The created cache will use a provider-specific default configuration: make sure you defined one. You can disable this warning by setting 'hibernate.javax.cache.missing_cache_strategy' to 'create'.
INFO  org.ehcache.core.EhcacheManager.createCache() @305 - Cache 'applications' created in EhcacheManager.
```

After:

```
INFO  org.ehcache.shadow.org.terracotta.offheapstore.paging.UpfrontAllocatingPageSource.<init>() @149 - Allocating 10.0MB in chunks
09:39:09.734 INFO  org.ehcache.core.EhcacheManager.createCache() @305 - Cache 'applications' created in EhcacheManager.
(…)
INFO  org.ehcache.jsr107.Eh107CacheManager.registerObject() @393 - Registering Ehcache MBean javax.cache:type=CacheStatistics,CacheManager=jar.file./root/.m2/repository/de/terrestris/shogun-config/21.1.3-SNAPSHOT/shogun-config-21.1.3-SNAPSHOT.jar!/ehcache.xml,Cache=applications
```

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
