### PR TITLE
Fix(gs-interceptor): extract typename in WFS Transaction insert queries correctly

### DIFF
--- a/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/enumeration/OgcEnum.java
+++ b/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/enumeration/OgcEnum.java
@@ -259,7 +259,7 @@ public class OgcEnum {
     }
 
     /**
-     * A enum type for the allowed endPoint format.
+     * An enum type for the allowed endPoint format.
      */
     public enum EndPoint {
         LAYERS("LAYERS"),

--- a/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/servlet/MutableHttpServletRequest.java
+++ b/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/servlet/MutableHttpServletRequest.java
@@ -166,13 +166,17 @@ public class MutableHttpServletRequest extends HttpServletRequestWrapper {
                     if (StringUtils.isEmpty(value)) {
                         value = OgcXmlUtil.getPathInDocument(document, "//@typeName | //@typeNames");
                     }
+                    if (StringUtils.isEmpty(value)) {
+                        log.debug("Check for first feature type in WFS-T insert request");
+                        value = OgcXmlUtil.getPathInDocument(document, "name(//Transaction/Insert/*[1])");
+                    }
                 }
             } else {
                 log.error("No body found in the request.");
             }
         }
 
-        log.trace("Found the request parameter value: " + value);
+        log.trace("Found the request parameter value: {}", value);
         return value;
     }
 

--- a/shogun-gs-interceptor/src/test/java/de/terrestris/shogun/interceptor/servlet/MutableHttpServletRequestTest.java
+++ b/shogun-gs-interceptor/src/test/java/de/terrestris/shogun/interceptor/servlet/MutableHttpServletRequestTest.java
@@ -1,0 +1,154 @@
+package de.terrestris.shogun.interceptor.servlet;
+
+import de.terrestris.shogun.interceptor.enumeration.OgcEnum;
+import de.terrestris.shogun.interceptor.exception.InterceptorException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+class MutableHttpServletRequestTest {
+
+    private final String featureTypeName = "TEST:MY_FEATURE_TYPE";
+    private final String namespaceUrl = "http://localhost/TEST";
+
+    private HttpServletRequest request;
+
+    @BeforeEach
+    public void setUp() {
+        request = Mockito.mock(HttpServletRequest.class);
+    }
+
+    @Test
+    void extractWfsGetFeatureEndpointCorrectly() throws IOException, InterceptorException {
+        String xmlData = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <GetFeature
+                xmlns="http://www.opengis.net/wfs"
+                service="WFS" version="1.1.0"
+                outputFormat="application/json"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd"
+            >
+                <Query typeName="%s" xmlns:TEST="%s">
+                    <Filter xmlns="http://www.opengis.net/ogc"><PropertyIsEqualTo><PropertyName>NUM</PropertyName><Literal>1909</Literal></PropertyIsEqualTo></Filter>
+                </Query>
+            </GetFeature>
+            """.formatted(featureTypeName, namespaceUrl);
+
+        InputStream xmlInputStream = new ByteArrayInputStream(xmlData.getBytes());
+        when(request.getInputStream()).thenReturn(new MockServletInputStream(xmlInputStream));
+
+        String requestEndPoint = MutableHttpServletRequest.getRequestParameterValue(request, OgcEnum.EndPoint.getAllValues());
+        assertEquals(featureTypeName, requestEndPoint);
+    }
+
+    @Test
+    void extractWfsTransactionUpdateEndpointCorrectly() throws IOException, InterceptorException {
+        String xmlData = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Transaction
+                xmlns="http://www.opengis.net/wfs"
+                service="WFS" version="1.1.0"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd"
+            >
+                <Update typeName="%s" xmlns:TEST="%s">
+                    <Property>
+                        <Name>GEOMETRIE</Name>
+                        <Value>
+                            <MultiPoint xmlns="http://www.opengis.net/gml" srsName="EPSG:25832"><pointMember><Point srsName="EPSG:25832"><pos srsDimension="2">373678.86587162 5606983.66695109</pos></Point></pointMember></MultiPoint>
+                        </Value>
+                    </Property>
+                    <Property>
+                        <Name>ID</Name><Value>1909</Value>
+                    </Property>
+                    <Filter xmlns="http://www.opengis.net/ogc"><FeatureId fid="TEST.19"/></Filter>
+                </Update>
+            </Transaction>
+            """.formatted(featureTypeName, namespaceUrl);
+
+        InputStream xmlInputStream = new ByteArrayInputStream(xmlData.getBytes());
+        when(request.getInputStream()).thenReturn(new MockServletInputStream(xmlInputStream));
+
+        String requestEndPoint = MutableHttpServletRequest.getRequestParameterValue(request, OgcEnum.EndPoint.getAllValues());
+        assertEquals(featureTypeName, requestEndPoint);
+    }
+
+    @Test
+    void extractWfsTransactionInsertEndpointCorrectly() throws IOException, InterceptorException {
+        String xmlData = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <Transaction
+                xmlns="http://www.opengis.net/wfs"
+                service="WFS"
+                version="1.1.0"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+                <Insert>
+                    <%s xmlns:TEST="%s">
+                        <TEST:NUM>1909</TEST:NUM>
+                        <TEST:GEOMETRY>
+                            <MultiPoint xmlns="http://www.opengis.net/gml" srsName="EPSG:25832">
+                                <pointMember>
+                                    <Point srsName="EPSG:25832">
+                                        <pos srsDimension="2">373740.32587162 5606976.66695109</pos>
+                                    </Point>
+                                </pointMember>
+                                <pointMember>
+                                    <Point srsName="EPSG:25832">
+                                        <pos srsDimension="2">373721.70587162 5606971.34695109</pos>
+                                    </Point>
+                                </pointMember>
+                            </MultiPoint>
+                        </TEST:GEOMETRY>
+                    </%s>
+                </Insert>
+            </Transaction>
+            """.formatted(featureTypeName, namespaceUrl, featureTypeName);
+
+        InputStream xmlInputStream = new ByteArrayInputStream(xmlData.getBytes());
+        when(request.getInputStream()).thenReturn(new MockServletInputStream(xmlInputStream));
+
+        String requestEndPoint = MutableHttpServletRequest.getRequestParameterValue(request, OgcEnum.EndPoint.getAllValues());
+        assertEquals(featureTypeName, requestEndPoint);
+    }
+
+    private static class MockServletInputStream extends jakarta.servlet.ServletInputStream {
+        private final InputStream inputStream;
+
+        public MockServletInputStream(InputStream inputStream) {
+            this.inputStream = inputStream;
+        }
+
+        @Override
+        public int read() {
+            try {
+                return inputStream.read();
+            } catch (Exception e) {
+                return -1;
+            }
+        }
+
+        @Override
+        public boolean isFinished() {
+            return false;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(jakarta.servlet.ReadListener readListener) {
+        }
+    }
+}

--- a/shogun-gs-interceptor/src/test/java/de/terrestris/shogun/interceptor/servlet/MutableHttpServletRequestTest.java
+++ b/shogun-gs-interceptor/src/test/java/de/terrestris/shogun/interceptor/servlet/MutableHttpServletRequestTest.java
@@ -1,3 +1,20 @@
+/* SHOGun, https://terrestris.github.io/shogun/
+ *
+ * Copyright © 2020-present terrestris GmbH & Co. KG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package de.terrestris.shogun.interceptor.servlet;
 
 import de.terrestris.shogun.interceptor.enumeration.OgcEnum;


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This PR fixes the determination of the endpoint for WFS-T insert requests where the feature type is given in the element name of the children of `<Insert>`. Actually, only the first feature type will be returned. 

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [x] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
