### PR TITLE
Allow internal keycloak requests again

### DIFF
--- a/shogun-config/src/main/resources/application-base.yml
+++ b/shogun-config/src/main/resources/application-base.yml
@@ -113,7 +113,7 @@ keycloak:
   client-id: shogun-boot
   principal-attribute: preferred_username
   disableHostnameVerification: true
-  internal-server-url: shogun-keycloak
+  internal-server-url: http://shogun-keycloak:8080/auth
   extract-roles-from-resource: true
   extract-roles-from-realm: false
 


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

The keycloak webhook is e.g. used by the [keycloak-event-listener-shogun](https://github.com/terrestris/keycloak-event-listener-shogun). Since the request is not equipped with an authentication we used the `IpAddressMatcher` for detecting if a request was sent from the internal keycloak container to bypass further security checks. Since Spring Security 6.3.1 the [matcher](https://github.com/spring-projects/spring-security/blob/6.3.1/web/src/main/java/org/springframework/security/web/util/matcher/IpAddressMatcher.java) is not accepting a host name anymore (and I'm not quite sure if it was intended to be used before) and any call to the webhook from keycloak was rejected.

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
