### PR TITLE
Don't allow requests from internal keycloak anonymously anymore

### DIFF
--- a/shogun-config/src/main/java/de/terrestris/shogun/config/DefaultWebSecurityConfig.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/config/DefaultWebSecurityConfig.java
@@ -85,6 +85,7 @@ public interface DefaultWebSecurityConfig extends WebSecurityConfig {
                 .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
                 .ignoringRequestMatchers(csrfRequestMatcher)
                 .ignoringRequestMatchers("/graphql")
+                .ignoringRequestMatchers("/webhooks/**")
                 .ignoringRequestMatchers("/actuator/**")
                 .ignoringRequestMatchers("/sso/**")
                 .ignoringRequestMatchers("/ws/**")

--- a/shogun-config/src/main/java/de/terrestris/shogun/config/KeycloakWebSecurityConfig.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/config/KeycloakWebSecurityConfig.java
@@ -25,7 +25,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.web.access.expression.WebExpressionAuthorizationManager;
 
 import javax.net.ssl.HttpsURLConnection;
 
@@ -50,14 +49,6 @@ public class KeycloakWebSecurityConfig implements DefaultWebSecurityConfig {
 
     @Override
     public void configure(HttpSecurity http) throws Exception {
-        http
-            .authorizeHttpRequests((auths) -> auths
-                .requestMatchers("/webhooks/keycloak/**")
-                .access(new WebExpressionAuthorizationManager(
-                    "authenticated or hasIpAddress('%s')".formatted(keycloakProperties.getInternalServerUrl())
-                ))
-            );
-
         customHttpConfiguration(http);
 
         KeycloakJwtAuthenticationConverter authConverter = new KeycloakJwtAuthenticationConverter(
@@ -68,9 +59,6 @@ public class KeycloakWebSecurityConfig implements DefaultWebSecurityConfig {
         );
 
         http
-            .csrf(csrf -> csrf
-                .ignoringRequestMatchers("/webhooks/**")
-            )
             .oauth2ResourceServer(oauth -> oauth
                 .jwt(jwt -> jwt.jwtAuthenticationConverter(authConverter))
             );

--- a/shogun-config/src/main/java/de/terrestris/shogun/properties/KeycloakProperties.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/properties/KeycloakProperties.java
@@ -47,8 +47,6 @@ public class KeycloakProperties {
 
     private Boolean disableHostnameVerification;
 
-    private String internalServerUrl;
-
     private Boolean extractRolesFromResource = true;
 
     private Boolean extractRolesFromRealm = false;

--- a/shogun-config/src/main/resources/application-base.yml
+++ b/shogun-config/src/main/resources/application-base.yml
@@ -113,7 +113,6 @@ keycloak:
   client-id: shogun-boot
   principal-attribute: preferred_username
   disableHostnameVerification: true
-  internal-server-url: shogun-keycloak
   extract-roles-from-resource: true
   extract-roles-from-realm: false
 


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This removes the special handling for allowing internal Keycloak requests (as used by the [keycloak-event-listener-shogun](https://github.com/terrestris/keycloak-event-listener-shogun)) anonymously. To restore the functionality, projects should use the latest version of the plugin, specifically [this PR](https://github.com/terrestris/keycloak-event-listener-shogun/pull/11).

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

Replaces #957 and requires [#11](https://github.com/terrestris/keycloak-event-listener-shogun/pull/11).

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
