### PR TITLE
Make use of client-credentials in the Keycloak admin client

### DIFF
--- a/shogun-boot/src/test/resources/application-test.yml
+++ b/shogun-boot/src/test/resources/application-test.yml
@@ -37,14 +37,13 @@ spring:
 keycloak:
   enabled: true
   server-url: https://localhost/auth
-  username: admin
-  password: shogun
   master-realm: master
   admin-client-id: admin-cli
+  admin-client-secret: supersecret
   realm: SHOGun
   client-id: shogun-boot
   principal-attribute: preferred_username
-  disableHostnameVerification: true
+  disable-hostname-verification: true
 
 upload:
   basePath: /data

--- a/shogun-config/src/main/java/de/terrestris/shogun/config/KeycloakConfig.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/config/KeycloakConfig.java
@@ -28,6 +28,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import static org.keycloak.OAuth2Constants.CLIENT_CREDENTIALS;
+
 /**
  * Credits to https://stackoverflow.com/questions/57787768/issues-running-example-keycloak-spring-boot-app
  */
@@ -47,9 +49,9 @@ public abstract class KeycloakConfig {
         return KeycloakBuilder.builder()
             .serverUrl(keycloakProperties.getServerUrl())
             .realm(keycloakProperties.getMasterRealm())
-            .username(keycloakProperties.getUsername())
-            .password(keycloakProperties.getPassword())
             .clientId(keycloakProperties.getAdminClientId())
+            .clientSecret(keycloakProperties.getAdminClientSecret())
+            .grantType(CLIENT_CREDENTIALS)
             .resteasyClient(restClient)
             .build();
     }

--- a/shogun-config/src/main/java/de/terrestris/shogun/properties/KeycloakProperties.java
+++ b/shogun-config/src/main/java/de/terrestris/shogun/properties/KeycloakProperties.java
@@ -31,13 +31,11 @@ public class KeycloakProperties {
 
     private String serverUrl;
 
-    private String username;
-
-    private String password;
-
     private String masterRealm;
 
     private String adminClientId;
+
+    private String adminClientSecret;
 
     private String realm;
 

--- a/shogun-config/src/main/resources/application-base.yml
+++ b/shogun-config/src/main/resources/application-base.yml
@@ -105,14 +105,13 @@ springdoc:
 keycloak:
   enabled: true
   server-url: https://${KEYCLOAK_HOST:shogun-keycloak}/auth
-  username: admin
-  password: shogun
-  master-realm: master
+  master-realm: SHOGun
   admin-client-id: admin-cli
+  admin-client-secret: ${KEYCLOAK_ADMIN_CLIENT_SECRET}
   realm: SHOGun
   client-id: shogun-boot
   principal-attribute: preferred_username
-  disableHostnameVerification: true
+  disable-hostname-verification: true
   extract-roles-from-resource: true
   extract-roles-from-realm: false
 

--- a/shogun-gs-interceptor/src/main/resources/application-interceptor.yml
+++ b/shogun-gs-interceptor/src/main/resources/application-interceptor.yml
@@ -35,11 +35,10 @@ interceptor:
 keycloak:
   enabled: true
   server-url: https://${KEYCLOAK_HOST:shogun-keycloak}/auth
-  username: admin
-  password: shogun
   master-realm: master
   admin-client-id: admin-cli
+  admin-client-secret: ${KEYCLOAK_ADMIN_CLIENT_SECRET}
   realm: SHOGun
   client-id: shogun-boot
   principal-attribute: preferred_username
-  disableHostnameVerification: true
+  disable-hostname-verification: true

--- a/shogun-proxy/src/main/resources/application-proxy.yml
+++ b/shogun-proxy/src/main/resources/application-proxy.yml
@@ -28,11 +28,10 @@ shogun-proxy:
 keycloak:
   enabled: true
   server-url: https://${KEYCLOAK_HOST:shogun-keycloak}/auth
-  username: admin
-  password: shogun
   master-realm: master
   admin-client-id: admin-cli
+  admin-client-secret: ${KEYCLOAK_ADMIN_CLIENT_SECRET}
   realm: SHOGun
   client-id: shogun-boot
   principal-attribute: preferred_username
-  disableHostnameVerification: true
+  disable-hostname-verification: true

--- a/shogun-proxy/src/test/resources/application-proxy-test.yml
+++ b/shogun-proxy/src/test/resources/application-proxy-test.yml
@@ -16,14 +16,13 @@
 keycloak:
   enabled: false
   server-url: https://localhost/auth
-  username: admin
-  password: shogun
   master-realm: master
   admin-client-id: admin-cli
+  admin-client-secret: supersecret
   realm: SHOGun
   client-id: shogun-boot
   principal-attribute: preferred_username
-  disableHostnameVerification: true
+  disable-hostname-verification: true
 
 spring:
   session:


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This suggests to drop the support for username-password credentials in the Keycloak admin client. There is no real need to change it, but it _might_ be considered a better practice to actually make use of the secret instead since it's the desired form of providing the authentication in a machine-to-machine communication. It would also be easier to adjust the required permissions for the service account in more restricted scenarios. But this is open for discussion.

Please note that this is considered as a **breaking change** and you are most probably encountering the following error during the first startup:

```
Error: clientSecret required with grant_type=client_credentials
```

To update a running project please ensure:

- The `keycloak` block in the `application.yml` is updated:
  - Remove `username` and `password`.
  - Add `admin-client-secret`.
- To obtain the client secret check the `Credentials` tab in your admin client (usually `admin-cli` in the `SHOGun` realm):
  - Ensure the client has `Client authentication` and `Service accounts roles` settings enabled.
  - Set the desired `realm-management` role for the service accounts roles (e.g. `realm-admin`, but this might be adjusted/lowered to project needs).

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [x] Yes
- [ ] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
