### PR TITLE
Register Jackson JDK8 module

### DIFF
--- a/shogun-config/src/main/resources/application-base.yml
+++ b/shogun-config/src/main/resources/application-base.yml
@@ -71,10 +71,6 @@ spring:
           cache:
             uri: ehcache.xml
             provider: org.ehcache.jsr107.EhcacheCachingProvider
-
-  jackson:
-    serialization:
-      fail-on-empty-beans: false
   flyway:
     enabled: true
     baselineOnMigrate: true

--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/config/JacksonConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/config/JacksonConfig.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import de.terrestris.shogun.lib.annotation.JsonSuperType;
 import io.hypersistence.utils.hibernate.type.util.ObjectMapperSupplier;
@@ -71,13 +72,14 @@ public class JacksonConfig implements ObjectMapperSupplier {
             GeometryFactory geomFactory = new GeometryFactory(new PrecisionModel(coordinatePrecisionScale), srid);
             objectMapper.registerModule(new JtsModule(geomFactory));
 
-            var javaTimeModule = new JavaTimeModule();
-            objectMapper.registerModule(javaTimeModule);
+            objectMapper.registerModule(new JavaTimeModule());
+            objectMapper.registerModule(new Jdk8Module());
             objectMapper.configure(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false);
 
             objectMapper.configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false);
             objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+            objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
 
             for (var entry : findAnnotatedClasses().entrySet()) {
                 objectMapper.addMixIn(entry.getKey(), entry.getValue());


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

Currently serialising particular types with Jackson is failing, e.g. while requesting a revision of an entity via the `/rev` interfaces:

```
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Java 8 optional type `java.util.Optional<java.time.Instant>` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jdk8" to enable handling (through reference chain: org.springframework.data.history.Revisions["latestRevision"]->org.springframework.data.history.Revision["metadata"]->de.terrestris.shogun.lib.envers.ShogunRevisionMetadata["revisionInstant"])
```

In order to fix this issue the [`Jdk8Module`](https://github.com/FasterXML/jackson-modules-java8) of Jackson needs to be registered separately since it's not registered by default since version 2.16.0 anymore.

In addition the `jackson` config entry of the `application.yml` is moved to the `ObjectMapper` instantiation itself since we build it by ourselves and not via Spring Boot.

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
