### PR TITLE
Adds missing layer types for tile layers and mark VECTORTILE as deprecated

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/enumeration/LayerType.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/enumeration/LayerType.java
@@ -18,11 +18,14 @@ package de.terrestris.shogun.lib.enumeration;
 
 public enum LayerType {
     TILEWMS("TileWMS"),
+    @Deprecated
     VECTORTILE("VectorTile"),
     WFS("WFS"),
     WMS("WMS"),
     WMTS("WMTS"),
     WMSTIME("WMSTime"),
+    MAPBOXSTYLE("MapboxStyle"),
+    MVT("MVT"),
     XYZ("XYZ");
 
     private final String type;


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

To keep `LayerType`s synchronous between `shogun` and [`shogun-util`](https://github.com/terrestris/shogun-util) this PR adds missing layer types for tile layers and mark VECTORTILE as deprecated. 

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
