### PR TITLE
Introduces searchFeatureConfig for layer config

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerClientConfig.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/model/jsonb/layer/DefaultLayerClientConfig.java
@@ -80,6 +80,11 @@ public class DefaultLayerClientConfig implements LayerClientConfig {
     private ArrayList<PropertyFormTabConfig<PropertyFormItemReadConfig>> featureInfoFormConfig;
 
     @Schema(
+        description = "The configuration for displaying search results in the result drawer."
+    )
+    private PropertyFormTabConfig<PropertyFormItemReadConfig> searchFeatureConfig;
+
+    @Schema(
         description = "The configuration for the feature edit form."
     )
     private ArrayList<PropertyFormTabConfig<PropertyFormItemEditConfig>> editFormConfig;

--- a/shogun-lib/src/main/resources/graphql/shogun.graphqls
+++ b/shogun-lib/src/main/resources/graphql/shogun.graphqls
@@ -1433,6 +1433,7 @@ type Layer implements BaseEntity {
       private Boolean hoverable;
       private Boolean searchable;
       private Map<String, Object> searchConfig;
+      private Map<String, Object> searchFeatureConfig;
     }
     ```
     """


### PR DESCRIPTION
## Description

This PR allows the configuration of a `searchFeatureConfig` on a layer.  

This can be used to define a configuration of how the attributes of a feature found via the WFS or SOLR search should be displayed. The configuration is made via the admin and is processed in the shogun-gis-client.

## Related issues or pull requests

https://github.com/terrestris/shogun-gis-client/pull/1943
https://github.com/terrestris/shogun-util/pull/956


## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
