### PR TITLE
fix: remove baseURL from request params and scheme from proxy host

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/HttpUtil.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/HttpUtil.java
@@ -2229,7 +2229,7 @@ public class HttpUtil {
 
         if (proxyHost != null && proxyPort > 0) {
             log.debug("Using proxy from system properties: Host=" + proxyHost + ", Port=" + proxyPort);
-            return new HttpHost(scheme, InetAddress.getByName(proxyHost), proxyPort);
+            return new HttpHost(InetAddress.getByName(proxyHost), proxyPort);
         }
 
         log.debug("Attempting to detect system proxy via ProxySelector.");
@@ -2245,7 +2245,6 @@ public class HttpUtil {
                 );
 
                 return new HttpHost(
-                    scheme,
                     InetAddress.getByName(address.getHostName()),
                     address.getPort()
                 );

--- a/shogun-proxy/src/main/java/de/terrestris/shogun/service/HttpProxyService.java
+++ b/shogun-proxy/src/main/java/de/terrestris/shogun/service/HttpProxyService.java
@@ -239,9 +239,15 @@ public class HttpProxyService {
             return url;
         }
         URIBuilder uriBuilder = new URIBuilder(url.toURI());
-        for (Map.Entry<String, String> entry : params.entrySet()) {
-            uriBuilder.addParameter(entry.getKey(), entry.getValue());
-        }
+
+        params.forEach((key, value) -> {
+            if (!StringUtils.equalsIgnoreCase(key, "baseUrl")) {
+                uriBuilder.addParameter(key, value);
+            } else {
+                log.warn("Skipping baseUrl empty parameter: baseUrl ={}", value);
+            }
+        });
+
         return uriBuilder.build().toURL();
     }
 

--- a/shogun-proxy/src/test/resources/application-proxy-test.yml
+++ b/shogun-proxy/src/test/resources/application-proxy-test.yml
@@ -39,3 +39,4 @@ shogun-proxy:
     - localhost
     - localhost:8080
     - terrestris.de
+    - my-test-example.org


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->


This MR introduces two fixes in `ProxyService` / `HttpUtil`:

1. Updated the construction of `HttpHost` to omit the scheme parameter when setting up a proxy via system properties or ProxySelector. This avoids incorrect behavior in tunneling HTTPS connections, e.g. if IPs are given in `https.proxyHost`
2. Skip the `baseUrl` parameter when building the forwarded request. This prevents redundant or malformed nested URLs in proxy requests.

Plz review @terrestris/devs 

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [x] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
