### PR TITLE
allow to clear specific query cache regions

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/CacheController.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/controller/CacheController.java
@@ -19,6 +19,7 @@ package de.terrestris.shogun.lib.controller;
 import de.terrestris.shogun.lib.service.CacheService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -31,8 +32,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
-
-import java.util.List;
 
 @Log4j2
 @RestController
@@ -52,16 +51,19 @@ public class CacheController {
     protected MessageSource messageSource;
 
     @PostMapping("/evict")
-    public ResponseEntity<?> evictCache(@RequestParam(required = false) List<String> regions) {
+    public ResponseEntity<?> evictCache(
+        @RequestParam(required = false) List<String> regions,
+        @RequestParam(required = false) List<String> queryRegions
+    ) {
 
         log.info("Requested to evict the cache.");
 
         try {
-            if (regions == null || regions.isEmpty()) {
+            if (regions == null && queryRegions == null) {
                 service.evictCache();
                 log.info("Successfully evicted all cache regions.");
             } else {
-                service.evictCacheRegions(regions.toArray(new String[]{}));
+                service.evictCacheRegions(regions, queryRegions);
                 log.info("Successfully evicted cache regions {}", regions);
             }
 


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

This allows to evict specific *query* regions as well. Previously, the entire cache had to be cleared for this.

### Examples:

Clear the region `default-query-results-region`

```
POST /cache/evict?queryRegions=default-query-results-region
```

Clear a region for a specific query:

- annotate your query with `@QueryHint(name = AvailableHints.HINT_CACHE_REGION, value = "your-custom-name")`
- register that region in ehcache.xml: `<cache alias="your-custom-name" uses-template="default" />`

```
POST /cache/evict?queryRegions=your-custom-name
```

@terrestris/devs Please review

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
