### PR TITLE
set query region for findAllById query

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/BaseCrudRepository.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/repository/BaseCrudRepository.java
@@ -115,7 +115,10 @@ public interface BaseCrudRepository<T, ID> extends
     @NonNull
     Page<T> findAll(@NonNull Pageable pageable);
 
-    @QueryHints(@QueryHint(name = AvailableHints.HINT_CACHEABLE, value = "true"))
+    @QueryHints({
+        @QueryHint(name = AvailableHints.HINT_CACHEABLE, value = "true"),
+        @QueryHint(name = AvailableHints.HINT_CACHE_REGION, value = "default-query-results-region")
+    })
     @Override
     @NonNull
     Iterable<T> findAllById(@NonNull Iterable<ID> ids);


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

Explicitly sets the query region to `default-query-results-region` for `findAllById` query. 

## Related issues or pull requests

Follow-up to https://github.com/terrestris/shogun/pull/1031 

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [ ] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [ ] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
