### PR TITLE
fix: remove @Transactional from interceptGeoServerRequest to prevent DB connection leaks

### DIFF
--- a/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/service/GeoServerInterceptorService.java
+++ b/shogun-gs-interceptor/src/main/java/de/terrestris/shogun/interceptor/service/GeoServerInterceptorService.java
@@ -42,7 +42,6 @@ import org.apache.hc.core5.net.URIBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -302,7 +301,6 @@ public class GeoServerInterceptorService {
      * @throws HttpException
      * @throws IOException
      */
-    @Transactional(readOnly = true)
     public HttpResponse interceptGeoServerRequest(HttpServletRequest request) throws InterceptorException, URISyntaxException, HttpException, IOException {
         return interceptGeoServerRequest(request, Optional.empty());
     }
@@ -316,7 +314,6 @@ public class GeoServerInterceptorService {
      * @throws HttpException
      * @throws IOException
      */
-    @Transactional(readOnly = true)
     public HttpResponse interceptGeoServerRequest(HttpServletRequest request, Optional<String> endpoint) throws InterceptorException, URISyntaxException, HttpException, IOException {
         // wrap the request, we want to manipulate it
         MutableHttpServletRequest mutableRequest =
@@ -327,6 +324,7 @@ public class GeoServerInterceptorService {
         }
 
         // get the OGC message information (service, request, endPoint)
+        // This is the only part that needs a DB transaction (rule lookup).
         OgcMessage message = getOgcMessage(mutableRequest);
 
         // check whether WMS reflector endpoint should be called


### PR DESCRIPTION
The annotation held a HikariCP connection for the entire GeoServer HTTP proxy call, causing "Connection leak detection triggered" warnings under load. The DB transaction is already scoped correctly in `InterceptorRuleService.findAllRulesForServiceAndEvent()`.

## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
