### PR TITLE
fix: close http client in HTTPutil after request was executed

### DIFF
--- a/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/HttpUtil.java
+++ b/shogun-lib/src/main/java/de/terrestris/shogun/lib/util/HttpUtil.java
@@ -1997,6 +1997,9 @@ public class HttpUtil {
                 log.error("Error while closing resources: {}", e.getMessage());
                 log.trace("Full stack trace:", e);
             }
+
+            // Close the connection manager to release pooled connections
+            poolingHttpClientConnectionManager.close();
         }
 
         return response;


### PR DESCRIPTION
Closes associated resources (threads, sockets). Without this, each request leaks a `PoolingHttpClientConnectionManager` instance.

## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
