### PR TITLE
Ensure the latest docker registry

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -99,6 +99,13 @@ jobs:
               { "id": "terrestris-nexus-snapshots", "username": "${{ secrets.nexus_user }}", "password": "${{ secrets.nexus_pass }}" }
             ]
 
+      - name: Ensure latest Docker image registry
+        shell: bash
+        run: |
+          sed -i \
+            's#docker-public\.terrestris\.de/shogun/#hub\.terrestris\.de/shogun/#' \
+            pom.xml
+
       - name: Install dependencies
         run: mvn compile --batch-mode
 


### PR DESCRIPTION
## Description

<!-- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR. -->

Follow up of #1161:

The workflow [Update docker base images](https://github.com/terrestris/shogun/actions/runs/33517185683) is still failing because it tries to push images to the old registry, e.g. for version [21.5.3](https://github.com/terrestris/shogun/blob/v21.5.3/pom.xml#L149). This suggests to ensure the latest registry by overriding it in the `pom.xml`.

Providing the url by a maven argument (`-Dimage='hub.terrestris.de/shogun/${project.artifactId}:latest'`) is not possible since maven doesn't interpolate placeholders (`${project.artifactId}`) in values provided with `-D`.

Please review @terrestris/devs.

## Related issues or pull requests

<!-- Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated. -->

--

## Pull request type

<!-- Please check the type of change your PR introduces: -->

<!-- Put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the 
  [Apache Licence Version 2.0](https://github.com/terrestris/shogun/blob/main/LICENSE).
- [x] I have followed the [guidelines for contributing](https://github.com/terrestris/shogun/blob/main/CONTRIBUTING.md).
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/terrestris/shogun/blob/main/CODE_OF_CONDUCT.md).
- [x] I have added or updated tests and documentation, and the test suite passes (run `mvn test` locally).
- [ ] I have added a screenshot/screencast to illustrate the visual output of my update.
